### PR TITLE
feat: improve client errors

### DIFF
--- a/api/src/auth.rs
+++ b/api/src/auth.rs
@@ -56,6 +56,7 @@ impl Display for AuthorizationError {
     }
 }
 
+
 impl Error for AuthorizationError {}
 
 #[rocket::async_trait]
@@ -87,6 +88,7 @@ lazy_static! {
     static ref USER_DIRECTORY: UserDirectory = UserDirectory::from_user_file();
 }
 
+#[derive(Debug)]
 struct UserDirectory {
     users: HashMap<String, User>,
 }
@@ -100,10 +102,14 @@ impl UserDirectory {
         let file_path = Self::users_toml_file_path();
         let file_contents: String = std::fs::read_to_string(&file_path)
             .expect(&format!("this should blow up if the users.toml file is not present at {:?}", &file_path));
-        Self {
+        let directory = Self {
             users: toml::from_str(&file_contents)
                 .expect("this should blow up if the users.toml file is unparseable"),
-        }
+        };
+
+        log::debug!("initialising user directory: {:#?}", &directory);
+
+        directory
     }
 
     fn users_toml_file_path() -> PathBuf {

--- a/cargo-unveil/src/client.rs
+++ b/cargo-unveil/src/client.rs
@@ -1,9 +1,10 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use lib::{API_URL, ApiKey, DeploymentMeta, DeploymentStateMeta, UNVEIL_PROJECT_HEADER};
 use lib::project::ProjectConfig;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use std::{fs::File, io::Read, thread::sleep, time::Duration};
+use reqwest::Response;
 
 
 pub(crate) async fn delete(api_key: ApiKey, project: ProjectConfig) -> Result<()> {
@@ -11,15 +12,14 @@ pub(crate) async fn delete(api_key: ApiKey, project: ProjectConfig) -> Result<()
 
     let mut url = API_URL.to_string();
     url.push_str(&format!("/projects/{}", project.name()));
-    let deployment_meta: DeploymentMeta = client
+    let res: Response = client
         .delete(url.clone())
         .basic_auth(api_key, Some(""))
         .send()
         .await
-        .context("failed to delete deployment on the Unveil server")?
-        .json()
-        .await
-        .context("failed to parse Unveil response")?;
+        .context("failed to delete deployment on the Unveil server")?;
+
+    let deployment_meta = to_api_result(res).await?;
 
     println!("{}", deployment_meta);
 
@@ -43,15 +43,15 @@ async fn get_deployment_meta(
 ) -> Result<DeploymentMeta> {
     let mut url = API_URL.to_string();
     url.push_str(&format!("/projects/{}", project.name()));
-    client
+
+    let res: Response = client
         .get(url.clone())
         .basic_auth(api_key.clone(), Some(""))
         .send()
         .await
-        .context("failed to get deployment from the Unveil server")?
-        .json()
-        .await
-        .context("failed to parse Unveil response")
+        .context("failed to get deployment from the Unveil server")?;
+
+    to_api_result(res).await
 }
 
 fn get_retry_client() -> ClientWithMiddleware {
@@ -77,20 +77,16 @@ pub(crate) async fn deploy(
         .read_to_end(&mut package_content)
         .context("failed to convert package content to buf")?;
 
-    // example from Stripe:
-    // curl https://api.stripe.com/v1/charges -u sk_test_BQokikJOvBiI2HlWgH4olfQ2:
-
-    let mut deployment_meta: DeploymentMeta = client
+    let res: Response = client
         .post(url.clone())
         .body(package_content)
         .header(UNVEIL_PROJECT_HEADER, serde_json::to_string(&project)?)
         .basic_auth(api_key.clone(), Some(""))
         .send()
         .await
-        .context("failed to send deployment to the Unveil server")?
-        .json()
-        .await
-        .context("failed to parse Unveil response")?;
+        .context("failed to send deployment to the Unveil server")?;
+
+    let mut deployment_meta = to_api_result(res).await?;
 
     let mut log_pos = 0;
 
@@ -120,5 +116,13 @@ fn print_log(logs: &Option<String>, log_pos: &mut usize) {
             *log_pos = logs.len();
             print!("{}", new);
         }
+    }
+}
+
+async fn to_api_result(res: Response) -> Result<DeploymentMeta> {
+    let text = res.text().await?;
+    match serde_json::from_str::<DeploymentMeta>(&text) {
+        Ok(meta) => Ok(meta),
+        Err(_) => Err(anyhow!("{}", text))
     }
 }

--- a/cargo-unveil/src/main.rs
+++ b/cargo-unveil/src/main.rs
@@ -107,3 +107,4 @@ fn run_cargo_package(working_directory: &Path, allow_dirty: bool) -> Result<File
     let owned = locks.get(0).unwrap().file().try_clone()?;
     Ok(owned)
 }
+

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -136,6 +136,7 @@ impl Display for DeploymentStateMeta {
 
 // TODO: Determine error handling strategy - error types or just use `anyhow`?
 #[derive(Debug, Clone, Serialize, Deserialize, Responder)]
+#[response(content_type = "json")]
 pub enum DeploymentApiError {
     #[response(status = 500)]
     Internal(String),


### PR DESCRIPTION
This took way longer than it should have. The solution I arrived at (basically `to_api_result`) is hacky but it works in showing you the error. I could not find a nice way to have `Result<DeploymentMeta, DeploymentApiResult>` be parsed by the client since various annotations on `DeploymentApiResult` are used for Rocket's control flow as it sends back response codes etc.

So the user will see an unstructured string response for now, until we can figure out something better. 

I'm almost tempted to go back to GRPC a la parallax with something like [tonic](https://github.com/hyperium/tonic) instead of fiddling with server/client Rest APIs.