### PR TITLE
feat: add deployment error messages

### DIFF
--- a/cargo-unveil/src/client.rs
+++ b/cargo-unveil/src/client.rs
@@ -92,7 +92,7 @@ pub(crate) async fn deploy(
 
     while !matches!(
         deployment_meta.state,
-        DeploymentStateMeta::Deployed | DeploymentStateMeta::Error
+        DeploymentStateMeta::Deployed | DeploymentStateMeta::Error(_)
     ) {
         print_log(&deployment_meta.build_logs, &mut log_pos);
 

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -112,25 +112,25 @@ impl DatabaseReadyInfo {
 }
 
 /// A label used to represent the deployment state in `DeploymentMeta`
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DeploymentStateMeta {
     Queued,
     Built,
     Loaded,
     Deployed,
-    Error,
+    Error(String),
     Deleted
 }
 
 impl Display for DeploymentStateMeta {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s = match self {
-            DeploymentStateMeta::Queued => "QUEUED",
-            DeploymentStateMeta::Built => "BUILT",
-            DeploymentStateMeta::Loaded => "LOADED",
-            DeploymentStateMeta::Deployed => "DEPLOYED",
-            DeploymentStateMeta::Error => "ERROR",
-            DeploymentStateMeta::Deleted => "DELETED"
+            DeploymentStateMeta::Queued => "QUEUED".to_string(),
+            DeploymentStateMeta::Built => "BUILT".to_string(),
+            DeploymentStateMeta::Loaded => "LOADED".to_string(),
+            DeploymentStateMeta::Deployed => "DEPLOYED".to_string(),
+            DeploymentStateMeta::Error(msg) => format!("ERROR: {}", &msg),
+            DeploymentStateMeta::Deleted => "DELETED".to_string()
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
In the `DeploymentState::Error` mode users get `cargo unveil status` like this:

```
        Project:            hello-world-rocket-app
        Deployment Id:      1af68b67-fb43-4eae-a95f-a284bd850736
        Deployment Status:  ERROR: Error {
    context: "could not compile `hello-world` due to previous error",
    source: ProcessError {
        desc: "process didn't exit successfully: `rustc --crate-name hello_world --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type cdylib --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C metadata=3cbb4a940aa1a044 --out-dir /tmp/unveil/crates/hello-world-rocket-app/target/debug/deps -C incremental=/tmp/unveil/crates/hello-world-rocket-app/target/debug/incremental -L dependency=/tmp/unveil/crates/hello-world-rocket-app/target/debug/deps --extern async_trait=/tmp/unveil/crates/hello-world-rocket-app/target/debug/deps/libasync_trait-25efcc67c068c75d.so --extern rocket=/tmp/unveil/crates/hello-world-rocket-app/target/debug/deps/librocket-541bff7dafe77db4.rlib --extern unveil_service=/tmp/unveil/crates/hello-world-rocket-app/target/debug/deps/libunveil_service-9d27480243c33472.rlib` (exit status: 1)",
        code: Some(
            1,
        ),
        stdout: None,
        stderr: None,
    },
}
        Host:               hello-world-rocket-app.unveil.sh

```

Not perfect but does the job. (In this case the `hello-world` example is using an old version of `service`.)