### PR TITLE
add support for --working-directory and --name parameters to `cargo shuttle status` and friends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-mutex"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,9 +373,11 @@ name = "cargo-shuttle"
 version = "0.2.6"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "cargo",
  "cargo_metadata",
  "dirs",
+ "predicates",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -736,6 +752,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +791,12 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenv"
@@ -866,6 +894,15 @@ dependencies = [
  "libc",
  "libz-sys",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1717,6 +1754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2028,36 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -2966,6 +3039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3494,15 @@ checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -22,3 +22,7 @@ cargo_metadata = "0.14.2"
 webbrowser = "0.6"
 
 shuttle-common = { version = "0.2.6", path = "../common" }
+
+[dev-dependencies]
+assert_cmd = "2.0.4"
+predicates = "2.1.1"

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -4,6 +4,7 @@ use std::{
     path::PathBuf,
 };
 
+use shuttle_common::project::ProjectName;
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -77,4 +78,6 @@ pub struct ProjectArgs {
         about = "specify the working directory"
     )]
     pub working_directory: PathBuf,
+    #[structopt(long, about = "specify the name of the project (overrides crate name)")]
+    pub name: Option<ProjectName>,
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -41,7 +41,11 @@ pub struct ProjectArgs {
         about = "specify the working directory"
     )]
     pub working_directory: PathBuf,
-    #[structopt(long, about = "specify the name of the project (overrides crate name)")]
+    #[structopt(
+        global = true,
+        long,
+        about = "specify the name of the project (overrides crate name)"
+    )]
     pub name: Option<ProjectName>,
 }
 

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -30,6 +30,26 @@ pub struct Args {
     pub cmd: Command,
 }
 
+// Common args for subcommands that deal with projects.
+#[derive(StructOpt)]
+pub struct ProjectArgs {
+    #[structopt(
+        global = true,
+        long,
+        parse(try_from_os_str = parse_working_directory),
+        default_value = ".",
+        about = "specify the working directory"
+    )]
+    pub working_directory: PathBuf,
+    #[structopt(long, about = "specify the name of the project (overrides crate name)")]
+    pub name: Option<ProjectName>,
+}
+
+fn parse_working_directory(working_directory: &OsStr) -> Result<PathBuf, OsString> {
+    canonicalize(working_directory)
+        .map_err(|e| format!("could not turn {working_directory:?} into a real path: {e}").into())
+}
+
 #[derive(StructOpt)]
 pub enum Command {
     #[structopt(about = "deploy an shuttle project")]
@@ -60,24 +80,4 @@ pub struct AuthArgs {
 pub struct DeployArgs {
     #[structopt(long, about = "allow dirty working directories to be packaged")]
     pub allow_dirty: bool,
-}
-
-fn parse_working_directory(working_directory: &OsStr) -> Result<PathBuf, OsString> {
-    canonicalize(working_directory)
-        .map_err(|e| format!("could not turn {working_directory:?} into a real path: {e}").into())
-}
-
-// Common args for subcommands that deal with projects.
-#[derive(StructOpt)]
-pub struct ProjectArgs {
-    #[structopt(
-        global = true,
-        long,
-        parse(try_from_os_str = parse_working_directory),
-        default_value = ".",
-        about = "specify the working directory"
-    )]
-    pub working_directory: PathBuf,
-    #[structopt(long, about = "specify the name of the project (overrides crate name)")]
-    pub name: Option<ProjectName>,
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -38,14 +38,11 @@ pub struct ProjectArgs {
         long,
         parse(try_from_os_str = parse_working_directory),
         default_value = ".",
-        about = "specify the working directory"
     )]
+    /// Specify the working directory
     pub working_directory: PathBuf,
-    #[structopt(
-        global = true,
-        long,
-        about = "specify the name of the project (overrides crate name)"
-    )]
+    #[structopt(global = true, long)]
+    /// Specify the name of the project (overrides crate name)
     pub name: Option<ProjectName>,
 }
 

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -265,6 +265,16 @@ impl RequestContext {
     /// file does not exist, or it has not set the `name` key then the `ProjectConfig` instance
     /// has `ProjectConfig.name = Some("crate-name")`.
     pub fn load_local(&mut self, project_args: &ProjectArgs) -> Result<()> {
+        let project = Self::get_local_config(project_args)?;
+
+        self.project = Some(project);
+
+        Ok(())
+    }
+
+    pub fn get_local_config(
+        project_args: &ProjectArgs,
+    ) -> Result<Config<LocalConfigManager, ProjectConfig>> {
         let local_manager = LocalConfigManager::new(&project_args.working_directory);
         let mut project = Config::new(local_manager);
         if !project.exists() {
@@ -282,10 +292,7 @@ impl RequestContext {
             // If name key is not in project config, then we infer from crate name
             (None, None) => config.name = Some(find_crate_name(&project_args.working_directory)?),
         };
-
-        self.project = Some(project);
-
-        Ok(())
+        Ok(project)
     }
 
     pub fn set_api_url(&mut self, api_url: Option<String>) {
@@ -346,5 +353,83 @@ impl RequestContext {
             .name
             .as_ref()
             .unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::PathBuf, str::FromStr};
+
+    use shuttle_common::project::ProjectName;
+
+    use crate::{args::ProjectArgs, config::RequestContext};
+
+    fn path_from_workspace_root(path: &str) -> PathBuf {
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("..")
+            .join(path)
+    }
+
+    #[test]
+    fn get_local_config_finds_name_in_shuttle_toml() {
+        let project_args = ProjectArgs {
+            working_directory: path_from_workspace_root("examples/axum/hello-world/"),
+            name: None,
+        };
+
+        let local_config = RequestContext::get_local_config(&project_args).unwrap();
+
+        // FIXME: make a helper for this?
+        let name = local_config
+            .as_ref()
+            .unwrap()
+            .name
+            .as_ref()
+            .unwrap()
+            .to_string();
+        assert_eq!(name, "hello-world-axum-app");
+    }
+
+    #[test]
+    fn fixme_running_in_src_subdir_finds_crate_but_fails_to_find_config() {
+        let project_args = ProjectArgs {
+            working_directory: path_from_workspace_root("examples/axum/hello-world/src"),
+            name: None,
+        };
+
+        let local_config = RequestContext::get_local_config(&project_args).unwrap();
+
+        // FIXME: make a helper for this?
+        let name = local_config
+            .as_ref()
+            .unwrap()
+            .name
+            .as_ref()
+            .unwrap()
+            .to_string();
+
+        // FIXME: this is not the intended behaviour. We should fix this.
+        // This should really be "hello-world-axum-app", as above.
+        assert_eq!(name, "hello-world");
+    }
+
+    #[test]
+    fn setting_name_overrides_name_in_config() {
+        let project_args = ProjectArgs {
+            working_directory: path_from_workspace_root("examples/axum/hello-world/"),
+            name: Some(ProjectName::from_str("my-fancy-project-name").unwrap()),
+        };
+
+        let local_config = RequestContext::get_local_config(&project_args).unwrap();
+
+        // FIXME: make a helper for this?
+        let name = local_config
+            .as_ref()
+            .unwrap()
+            .name
+            .as_ref()
+            .unwrap()
+            .to_string();
+        assert_eq!(name, "my-fancy-project-name");
     }
 }

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -364,10 +364,16 @@ mod tests {
 
     use crate::{args::ProjectArgs, config::RequestContext};
 
+    use super::{Config, LocalConfigManager, ProjectConfig};
+
     fn path_from_workspace_root(path: &str) -> PathBuf {
         PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
             .join("..")
             .join(path)
+    }
+
+    fn unwrap_project_name(config: &Config<LocalConfigManager, ProjectConfig>) -> String {
+        config.as_ref().unwrap().name.as_ref().unwrap().to_string()
     }
 
     #[test]
@@ -379,15 +385,7 @@ mod tests {
 
         let local_config = RequestContext::get_local_config(&project_args).unwrap();
 
-        // FIXME: make a helper for this?
-        let name = local_config
-            .as_ref()
-            .unwrap()
-            .name
-            .as_ref()
-            .unwrap()
-            .to_string();
-        assert_eq!(name, "hello-world-axum-app");
+        assert_eq!(unwrap_project_name(&local_config), "hello-world-axum-app");
     }
 
     #[test]
@@ -399,18 +397,9 @@ mod tests {
 
         let local_config = RequestContext::get_local_config(&project_args).unwrap();
 
-        // FIXME: make a helper for this?
-        let name = local_config
-            .as_ref()
-            .unwrap()
-            .name
-            .as_ref()
-            .unwrap()
-            .to_string();
-
         // FIXME: this is not the intended behaviour. We should fix this.
         // This should really be "hello-world-axum-app", as above.
-        assert_eq!(name, "hello-world");
+        assert_eq!(unwrap_project_name(&local_config), "hello-world");
     }
 
     #[test]
@@ -422,14 +411,6 @@ mod tests {
 
         let local_config = RequestContext::get_local_config(&project_args).unwrap();
 
-        // FIXME: make a helper for this?
-        let name = local_config
-            .as_ref()
-            .unwrap()
-            .name
-            .as_ref()
-            .unwrap()
-            .to_string();
-        assert_eq!(name, "my-fancy-project-name");
+        assert_eq!(unwrap_project_name(&local_config), "my-fancy-project-name");
     }
 }

--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -5,15 +5,15 @@ mod config;
 use crate::args::{Args, AuthArgs, Command, DeployArgs};
 use crate::config::RequestContext;
 use anyhow::{Context, Result};
-use args::LoginArgs;
+use args::{LoginArgs, ProjectArgs};
 use cargo::core::resolver::CliFeatures;
 use cargo::core::Workspace;
 use cargo::ops::{PackageOpts, Packages};
 
 use std::fs::File;
+use std::io;
 use std::io::Write;
 use std::rc::Rc;
-use std::{env, io};
 use structopt::StructOpt;
 
 #[tokio::main]
@@ -42,7 +42,7 @@ impl Shuttle {
             args.cmd,
             Command::Deploy(..) | Command::Delete | Command::Status
         ) {
-            self.load_project()?;
+            self.load_project(&args.project_args)?;
         }
 
         self.ctx.set_api_url(args.api_url);
@@ -56,9 +56,8 @@ impl Shuttle {
         }
     }
 
-    pub fn load_project(&mut self) -> Result<()> {
-        let working_directory = env::current_dir()?;
-        self.ctx.load_local(working_directory)
+    pub fn load_project(&mut self, project_args: &ProjectArgs) -> Result<()> {
+        self.ctx.load_local(project_args)
     }
 
     async fn login(&mut self, login_args: LoginArgs) -> Result<()> {

--- a/cargo-shuttle/tests/integration/README.md
+++ b/cargo-shuttle/tests/integration/README.md
@@ -1,0 +1,5 @@
+# Integration Tests for `cargo-shuttle`
+
+Integration tests are organised following [matklad's recommedations](https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html).
+
+Initially, everything is tested via [assert_cmd](https://docs.rs/assert_cmd/latest/assert_cmd/cmd/struct.Command.html), but it might make sense to split `cargo-shuttle` into a bin+lib crate, to test the internals more easily.

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -1,0 +1,56 @@
+use assert_cmd::Command;
+
+/// creates a `cargo-shuttle` Command instance with some reasonable defaults set.
+fn cargo_shuttle_command() -> Command {
+    let mut cmd = Command::cargo_bin("cargo-shuttle").unwrap();
+    cmd.env(
+        "SHUTTLE_API",
+        "network support is intentionally broken in tests",
+    );
+    cmd
+}
+
+#[test]
+fn default_prints_usage_to_stderr() {
+    let mut cmd = cargo_shuttle_command();
+    cmd.assert()
+        .stderr(predicates::str::is_match("^cargo-shuttle.*\n\nUSAGE:").unwrap());
+}
+
+#[test]
+fn help_prints_usage_to_stdout() {
+    let mut cmd = cargo_shuttle_command();
+    cmd.arg("--help")
+        .assert()
+        .stdout(predicates::str::is_match("^cargo-shuttle.*\n\nUSAGE:").unwrap());
+}
+
+#[test]
+fn network_support_is_intentionally_broken_in_tests() {
+    let mut cmd = cargo_shuttle_command();
+    cmd.arg("status").assert().stderr(predicates::str::contains(
+        "builder error: relative URL without a base",
+    ));
+}
+
+#[test]
+fn fails_if_working_directory_does_not_exist() {
+    let mut cmd = cargo_shuttle_command();
+    cmd.arg("status")
+        .arg("--working-directory=/path_that_does_not_exist")
+        .assert()
+        .stderr(
+            predicates::str::contains(r#"error: Invalid value for '--working-directory <working-directory>': could not turn "/path_that_does_not_exist" into a real path: No such file or directory (os error 2)"#),
+        );
+}
+
+#[test]
+fn fails_if_working_directory_not_part_of_cargo_workspace() {
+    let mut cmd = cargo_shuttle_command();
+    cmd.arg("status")
+        .arg("--working-directory=/")
+        .assert()
+        .stderr(predicates::str::contains(
+            r#"error: could not find `Cargo.toml` in `/` or any parent directory"#,
+        ));
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,9 +16,9 @@ navigate to an example root folder
 $ cd examples/rocket/hello-world
 ```
 
-open up the `Shuttle.toml` file and change the project name to something 
-unique - in shuttle, projects are globally unique. Then run
+Pick a project name that is something unique - in shuttle,
+projects are globally unique. Then run
 
 ```bash
-$ cargo shuttle deploy
+$ cargo shuttle deploy --name=$PROJECT_NAME
 ```

--- a/examples/url-shortener/README.md
+++ b/examples/url-shortener/README.md
@@ -52,9 +52,9 @@ login to shuttle
 $ cargo shuttle login
 ```
 
-open up the `Shuttle.toml` file and change the project name to something 
-unique - in shuttle, projects are globally unique. Then run
+Pick a project name that is something unique - in shuttle,
+projects are globally unique. Then run
 
 ```bash
-$ cargo shuttle deploy
+$ cargo shuttle deploy --name=$PROJECT_NAME
 ```

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -138,6 +138,12 @@
 //!
 //! If the `name` key is not specified, the service's name will be the same as the crate's name.
 //!
+//! Alternatively, you can override the project name on the command-line, by passing the --name argument:
+//!
+//! ```bash
+//! cargo shuttle deploy --name=$PROJECT_NAME
+//! ```
+//!
 //! ## We're in alpha 🤗
 //!
 //! Thanks for using shuttle! We're very happy to have you with us!


### PR DESCRIPTION
Hi all. I added a --name argument to `cargo shuttle status`, so that I could check whether my project was up without `cd`ing into my project dir. I also added a --working-directory arg, while I was at it.

## Open questions:

- [x] Are these good names for command-line flags?

for `--working-directory`, I did a quick:
```bash
 for f in  /Users/alsuren/.cargo/bin/cargo* ; do 
    echo $f
    $f --help | grep dir
done
```
and the only thing that supports any kind of dir arg is:
```
/Users/alsuren/.cargo/bin/cargo-watch
    -C, --workdir <workdir>        Change working directory before running command [default: crate root]
```
cargo subcommands tend to accept a --manifest-path flag, instead
```
        --manifest-path <manifest-path>      Specify path to Cargo.toml
```
(I only implemented `--working-directory` flag because it felt like a pure refactor, and I like to front-load my PRs with refactors if I can. I can kill it off if you want)

- [x] Should I also update the documentation? 

`--name` would allow the "Change the name of your service" section of the docs (https://docs.rs/shuttle-service/latest/shuttle_service/#change-the-name-of-your-service) to be run without making any changes to the git repo (I feel like there was some feedback about needing the `--allow-dirty` flag to deploy the examples, but I can't find the issue now). 

- [x] Should I add some tests?

I feel like it should be pretty easy to write some assert_cmd tests for the failing structopt cases (https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them), to make sure the error messages for `--working-directory=something/that/doesnt/exist` makes sense, and same for names that are not valid project names. I can also add some tests for the `name` fallback code.