### PR TITLE
Feat: #176 test on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ Cargo.lock
 # VS Code
 .vscode/
 
+# OS Specific
+.DS_Store
+
 # Terraform
 **/secret*
 **/.terraform*

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -83,4 +83,6 @@ pub struct AuthArgs {
 pub struct DeployArgs {
     #[structopt(long, about = "allow dirty working directories to be packaged")]
     pub allow_dirty: bool,
+    #[structopt(long, about = "allows pre-deploy tests to be skipped")]
+    pub no_test: bool,
 }

--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -184,22 +184,26 @@ impl Shuttle {
     }
 
     fn run_tests(&self, no_test: bool) -> Result<()> {
+        if no_test {
+            return Ok(());
+        }
+
         let config = cargo::util::config::Config::default()?;
         let working_directory = self.ctx.working_directory();
         let path = working_directory.join("Cargo.toml");
 
         let compile_options = CompileOptions::new(&config, CompileMode::Test).unwrap();
         let ws = Workspace::new(&path, &config)?;
-
         let opts = TestOptions {
             compile_opts: compile_options,
             no_run: false,
             no_fail_fast: false,
         };
+
         let err = cargo::ops::run_tests(&ws, &opts, &[])?;
         match err {
             None => Ok(()),
-            Some(e) => Err(anyhow!(e.to_string())),
+            Some(_) => Err(anyhow!("To ignore all tests, pass the `--no_test` flag")),
         }
     }
 }

--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -203,7 +203,7 @@ impl Shuttle {
         let err = cargo::ops::run_tests(&ws, &opts, &[])?;
         match err {
             None => Ok(()),
-            Some(_) => Err(anyhow!("To ignore all tests, pass the `--no_test` flag")),
+            Some(_) => Err(anyhow!("To ignore all tests, pass the `--no-test` flag")),
         }
     }
 }


### PR DESCRIPTION
Fixes #176 . 

- I couldn't see any tests relating to this area, but feel free to point me in the right direction if these are needed. 
- Currently the tests run by default, personally I think this is the best option but in the original issue it was up for debate. 
- No test_args ([cargo::ops::run_tests](https://docs.rs/cargo/0.62.0/cargo/ops/fn.run_tests.html)) are implemented currently,  I'm unsure if this is required or how that would work if it is. 

New here, to Rust, and to Opensource so feedback or any corrections/suggestion with anything at all is welcomed. The more I can learn the better, so fire away!