### PR TITLE
fix: calling `get_secrets` in setup code fails

### DIFF
--- a/api/src/deployment.rs
+++ b/api/src/deployment.rs
@@ -22,9 +22,6 @@ use shuttle_service::ServeHandle;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{mpsc, RwLock};
 
-use shuttle_service::SecretStore;
-use sqlx::postgres::PgPoolOptions;
-
 use crate::build::Build;
 use crate::router::Router;
 use crate::{database, BuildSystem, ShuttleFactory};

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -114,7 +114,6 @@ async fn create_project(
     initial_secrets: InitialSecrets,
     user: User,
 ) -> ApiResult<DeploymentMeta, DeploymentApiError> {
-    println!("{:?}", initial_secrets.0);
     info!("[CREATE_PROJECT, {}, {}]", &user.name, &project_name);
 
     if !user

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -23,7 +23,7 @@ use deployment::MAX_DEPLOYS;
 use factory::ShuttleFactory;
 use rocket::serde::json::Json;
 use rocket::{tokio, Build, Data, Rocket, State};
-use shuttle_common::project::ProjectName;
+use shuttle_common::project::{ProjectName, InitialSecrets};
 use shuttle_common::{DeploymentApiError, DeploymentMeta, Port};
 use shuttle_service::SecretStore;
 use structopt::StructOpt;
@@ -111,8 +111,10 @@ async fn create_project(
     user_directory: &State<UserDirectory>,
     crate_file: Data<'_>,
     project_name: ProjectName,
+    initial_secrets: InitialSecrets,
     user: User,
 ) -> ApiResult<DeploymentMeta, DeploymentApiError> {
+    println!("{:?}", initial_secrets.0);
     info!("[CREATE_PROJECT, {}, {}]", &user.name, &project_name);
 
     if !user

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -23,7 +23,7 @@ use deployment::MAX_DEPLOYS;
 use factory::ShuttleFactory;
 use rocket::serde::json::Json;
 use rocket::{tokio, Build, Data, Rocket, State};
-use shuttle_common::project::{ProjectName, InitialSecrets};
+use shuttle_common::project::{InitialSecrets, ProjectName};
 use shuttle_common::{DeploymentApiError, DeploymentMeta, Port};
 use shuttle_service::SecretStore;
 use structopt::StructOpt;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -126,7 +126,7 @@ async fn create_project(
     }
     let deployment = state
         .deployment_manager
-        .deploy(crate_file, project_name)
+        .deploy(crate_file, project_name, initial_secrets)
         .await?;
     Ok(Json(deployment))
 }

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -9,7 +9,7 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
 use shuttle_common::project::ProjectName;
-use shuttle_common::{ApiKey, ApiUrl, DeploymentMeta, DeploymentStateMeta, SHUTTLE_PROJECT_HEADER};
+use shuttle_common::{ApiKey, ApiUrl, DeploymentMeta, DeploymentStateMeta, SHUTTLE_PROJECT_HEADER, INITIAL_SECRETS_HEADER};
 use tokio::time::sleep;
 
 use crate::print;
@@ -112,6 +112,7 @@ pub(crate) async fn deploy(
     api_url: ApiUrl,
     api_key: &ApiKey,
     project: &ProjectName,
+    initial_secrets: HashMap<String, String>,
 ) -> Result<()> {
     let mut url = api_url.clone();
     url.push_str(&format!("/projects/{}", project.as_str()));
@@ -128,6 +129,7 @@ pub(crate) async fn deploy(
         .post(url)
         .body(package_content)
         .header(SHUTTLE_PROJECT_HEADER, serde_json::to_string(&project)?)
+        .header(INITIAL_SECRETS_HEADER, serde_json::to_string(&initial_secrets)?)
         .basic_auth(api_key.clone(), Some(""))
         .send()
         .await

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -9,7 +9,10 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
 use shuttle_common::project::ProjectName;
-use shuttle_common::{ApiKey, ApiUrl, DeploymentMeta, DeploymentStateMeta, SHUTTLE_PROJECT_HEADER, INITIAL_SECRETS_HEADER};
+use shuttle_common::{
+    ApiKey, ApiUrl, DeploymentMeta, DeploymentStateMeta, INITIAL_SECRETS_HEADER,
+    SHUTTLE_PROJECT_HEADER,
+};
 use tokio::time::sleep;
 
 use crate::print;
@@ -129,7 +132,10 @@ pub(crate) async fn deploy(
         .post(url)
         .body(package_content)
         .header(SHUTTLE_PROJECT_HEADER, serde_json::to_string(&project)?)
-        .header(INITIAL_SECRETS_HEADER, serde_json::to_string(&initial_secrets)?)
+        .header(
+            INITIAL_SECRETS_HEADER,
+            serde_json::to_string(&initial_secrets)?,
+        )
         .basic_auth(api_key.clone(), Some(""))
         .send()
         .await

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -163,32 +163,6 @@ pub(crate) async fn deploy(
     Ok(())
 }
 
-pub(crate) async fn secrets(
-    api_url: ApiUrl,
-    api_key: &ApiKey,
-    project: &ProjectName,
-    secrets: HashMap<String, String>,
-) -> Result<()> {
-    if secrets.is_empty() {
-        return Ok(());
-    }
-
-    let mut url = api_url.clone();
-    url.push_str(&format!("/projects/{}/secrets/", project.as_str()));
-
-    let client = get_retry_client();
-
-    client
-        .post(url)
-        .body(serde_json::to_string(&secrets)?)
-        .header(SHUTTLE_PROJECT_HEADER, serde_json::to_string(&project)?)
-        .basic_auth(api_key.clone(), Some(""))
-        .send()
-        .await
-        .context("failed to send deployment's secrets to the Shuttle server")
-        .map(|_| ())
-}
-
 fn print_log(logs: &Option<String>, log_pos: &mut usize) {
     if let Some(logs) = logs {
         let new = &logs[*log_pos..];

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -164,7 +164,9 @@ impl Shuttle {
             self.ctx.project_name(),
             addr
         );
-        let (handle, so) = loader.load(&mut factory, addr, tx, deployment_id, Default::default()).await?; // TODO: Secrets.toml
+        let (handle, so) = loader
+            .load(&mut factory, addr, tx, deployment_id, Default::default())
+            .await?; // TODO: Secrets.toml
 
         tokio::spawn(async move {
             while let Some(log) = rx.recv().await {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -194,15 +194,8 @@ impl Shuttle {
             self.ctx.api_url(),
             key,
             self.ctx.project_name(),
+            self.ctx.secrets(),
         )
-        .and_then(|_| {
-            client::secrets(
-                self.ctx.api_url(),
-                key,
-                self.ctx.project_name(),
-                self.ctx.secrets(),
-            )
-        })
         .await
         .context("failed to deploy cargo project")
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -19,7 +19,6 @@ use cargo::ops::{PackageOpts, Packages};
 use colored::Colorize;
 use config::RequestContext;
 use factory::LocalFactory;
-use futures::future::TryFutureExt;
 use shuttle_service::loader::{build_crate, Loader};
 use tokio::sync::mpsc;
 use uuid::Uuid;

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -164,7 +164,7 @@ impl Shuttle {
             self.ctx.project_name(),
             addr
         );
-        let (handle, so) = loader.load(&mut factory, addr, tx, deployment_id).await?;
+        let (handle, so) = loader.load(&mut factory, addr, tx, deployment_id, Default::default()).await?; // TODO: Secrets.toml
 
         tokio::spawn(async move {
             while let Some(log) = rx.recv().await {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -102,7 +102,7 @@ impl ToTokens for Wrapper {
                 #(let #fn_inputs = #factory_ident.get_resource(runtime).await?;)*
 
                 if !initial_secrets.is_empty() {
-                    let db_pool = pool.clone(); // TODO: #factory_ident.get_resource(runtime).await?;
+                    let db_pool = #factory_ident.get_resource(runtime).await?;
 
                     runtime.spawn(async move {
                         for (key, value) in initial_secrets.iter() {

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -265,6 +265,16 @@ mod tests {
                 let pool = factory.get_resource(runtime).await?;
                 let redis = factory.get_resource(runtime).await?;
 
+                if !initial_secrets.is_empty() {
+                    let db_pool = factory.get_resource(runtime).await?;
+
+                    runtime.spawn(async move {
+                        for (key, value) in initial_secrets.iter() {
+                            db_pool.set_secret(key, value).await.unwrap();
+                        }
+                    }).await.unwrap();
+                }
+
                 runtime.spawn(complex(pool, redis)).await.unwrap()
             }
         };

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -118,7 +118,7 @@ impl DatabaseReadyInfo {
             database_name,
         }
     }
-    pub fn connection_string(&self, ip: &str) -> String {
+    pub fn connection_string(&self, ip: impl std::fmt::Display) -> String {
         format!(
             "postgres://{}:{}@{}/{}",
             self.role_name, self.role_password, ip, self.database_name

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::project::ProjectName;
 
 pub const SHUTTLE_PROJECT_HEADER: &str = "Shuttle-Project";
+pub const INITIAL_SECRETS_HEADER: &str = "Initial-Secrets";
 
 #[cfg(debug_assertions)]
 pub const API_URL_DEFAULT: &str = "http://localhost:8001";

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -103,7 +103,7 @@ impl Display for ProjectNameError {
 
 impl Error for ProjectNameError {}
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 #[serde(transparent)]
 pub struct InitialSecrets(pub HashMap<String, String>);
 
@@ -123,6 +123,16 @@ impl<'r> FromRequest<'r> for InitialSecrets {
         else {
             Outcome::Success(InitialSecrets(HashMap::new()))
         }
+    }
+}
+
+impl InitialSecrets {
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item=(&String, &String)> {
+        self.0.iter()
     }
 }
 

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -105,7 +105,7 @@ impl Error for ProjectNameError {}
 
 #[derive(Deserialize, Default)]
 #[serde(transparent)]
-pub struct InitialSecrets(pub HashMap<String, String>);
+pub struct InitialSecrets(HashMap<String, String>);
 
 #[rocket::async_trait]
 impl<'r> FromRequest<'r> for InitialSecrets {

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use std::collections::HashMap;
 
 use rocket::http::Status;
-use rocket::request::{FromParam, FromRequest, Request, Outcome};
+use rocket::request::{FromParam, FromRequest, Outcome, Request};
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -115,12 +115,10 @@ impl<'r> FromRequest<'r> for InitialSecrets {
         if let Some(json) = req.headers().get_one(INITIAL_SECRETS_HEADER) {
             if let Ok(secrets) = serde_json::from_str(json) {
                 Outcome::Success(secrets)
-            }
-            else {
+            } else {
                 Outcome::Failure((Status::BadRequest, ()))
             }
-        }
-        else {
+        } else {
             Outcome::Success(InitialSecrets(HashMap::new()))
         }
     }
@@ -131,7 +129,7 @@ impl InitialSecrets {
         self.0.is_empty()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item=(&String, &String)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &String)> {
         self.0.iter()
     }
 }

--- a/examples/rocket/postgres/src/lib.rs
+++ b/examples/rocket/postgres/src/lib.rs
@@ -46,6 +46,8 @@ struct MyState {
 
 #[shuttle_service::main]
 async fn rocket(pool: PgPool) -> shuttle_service::ShuttleRocket {
+    pool.get_secret("MY_API_KEY").await.unwrap();
+
     pool.execute(include_str!("../schema.sql"))
         .await
         .map_err(CustomError::new)?;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -277,14 +277,14 @@ pub trait Factory: Send + Sync {
 /// should be created on the passed in runtime.
 #[async_trait]
 pub trait GetResource<T> {
-    async fn get_resource(self, runtime: &Runtime) -> Result<T, crate::Error>;
+    async fn get_resource(&mut self, runtime: &Runtime) -> Result<T, crate::Error>;
 }
 
 /// Get an `sqlx::PgPool` from any factory
 #[cfg(feature = "sqlx-postgres")]
 #[async_trait]
-impl GetResource<sqlx::PgPool> for &mut dyn Factory {
-    async fn get_resource(self, runtime: &Runtime) -> Result<sqlx::PgPool, crate::Error> {
+impl GetResource<sqlx::PgPool> for dyn Factory + '_ {
+    async fn get_resource(&mut self, runtime: &Runtime) -> Result<sqlx::PgPool, crate::Error> {
         use error::CustomError;
 
         let connection_string = self.get_sql_connection_string().await?;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -186,8 +186,8 @@ use async_trait::async_trait;
 
 // Pub uses by `codegen`
 pub use log;
-pub use tokio::runtime::Runtime;
 pub use shuttle_common::project::InitialSecrets;
+pub use tokio::runtime::Runtime;
 
 pub mod error;
 pub use error::Error;

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -10,6 +10,7 @@ use cargo::util::homedir;
 use cargo::Config;
 use libloading::{Library, Symbol};
 use shuttle_common::DeploymentId;
+use shuttle_common::project::InitialSecrets;
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -62,11 +63,12 @@ impl Loader {
         addr: SocketAddr,
         tx: UnboundedSender<Log>,
         deployment_id: DeploymentId,
+        initial_secrets: InitialSecrets,
     ) -> Result<(ServeHandle, Library), Error> {
         let mut service = self.service;
         let logger = Box::new(Logger::new(tx, deployment_id));
 
-        service.build(factory, logger).await?;
+        service.build(factory, logger, initial_secrets).await?;
 
         // Start service on this side of the FFI
         let handle = tokio::spawn(async move { service.bind(addr)?.await? });

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -9,8 +9,8 @@ use cargo::ops::{compile, CompileOptions};
 use cargo::util::homedir;
 use cargo::Config;
 use libloading::{Library, Symbol};
-use shuttle_common::DeploymentId;
 use shuttle_common::project::InitialSecrets;
+use shuttle_common::DeploymentId;
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::UnboundedSender;
 

--- a/service/tests/loader.rs
+++ b/service/tests/loader.rs
@@ -76,7 +76,7 @@ async fn sleep_async() {
     let deployment_id = Uuid::new_v4();
     let (tx, _rx) = mpsc::unbounded_channel();
     let (handler, _) = loader
-        .load(&mut factory, addr, tx, deployment_id)
+        .load(&mut factory, addr, tx, deployment_id, Default::default())
         .await
         .unwrap();
 
@@ -111,7 +111,7 @@ async fn sleep() {
     let deployment_id = Uuid::new_v4();
     let (tx, _rx) = mpsc::unbounded_channel();
     let (handler, _) = loader
-        .load(&mut factory, addr, tx, deployment_id)
+        .load(&mut factory, addr, tx, deployment_id, Default::default())
         .await
         .unwrap();
 
@@ -152,7 +152,7 @@ async fn sqlx_pool() {
     let deployment_id = Uuid::new_v4();
     let (tx, mut rx) = mpsc::unbounded_channel();
     let (handler, _) = loader
-        .load(&mut factory, addr, tx, deployment_id)
+        .load(&mut factory, addr, tx, deployment_id, Default::default())
         .await
         .unwrap();
 

--- a/service/tests/resources/sqlx-pool/src/lib.rs
+++ b/service/tests/resources/sqlx-pool/src/lib.rs
@@ -1,5 +1,5 @@
 use shuttle_service::error::CustomError;
-use shuttle_service::{log, GetResource, IntoService, Runtime, ServeHandle, Service};
+use shuttle_service::{log, GetResource, IntoService, Runtime, ServeHandle, Service, InitialSecrets};
 use sqlx::PgPool;
 
 #[macro_use]
@@ -54,6 +54,7 @@ impl Service for PoolService {
         &mut self,
         factory: &mut dyn shuttle_service::Factory,
         logger: Box<dyn log::Log>,
+        _: InitialSecrets,
     ) -> Result<(), shuttle_service::Error> {
         self.runtime
             .spawn_blocking(move || {


### PR DESCRIPTION
https://github.com/shuttle-hq/shuttle/issues/197

**TODO: Handle in `Loader::load` instead of codegen** - need to work out Tokio runtime problems.

* The set of secrets read from `Secrets.toml` are now sent as a HTTP header instead of in a separate request.
* That set of initial secrets is then set immediately before the user's setup function is called.

### Considerations

* Is passing the received set of secrets through the full deployment pipeline all the way to the service build function the best approach? Is there a simpler way to achieve the say outcome?
* Secrets from `Secrets.toml` are now sent as a HTTP header with JSON encoding - this should not result in an invalid HTTP request but may need to test some edge cases (e.g., weird unicode characters). If it is a problem, then a solution could be base64 encoding.