### PR TITLE
feat: improve API key error with command hint

### DIFF
--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -349,7 +349,9 @@ impl RequestContext {
                 "Configuration file: `{}`",
                 self.global.manager.path().display()
             )
-            .context(anyhow!("No valid API key found, try logging in first."))
+            .context(anyhow!(
+                "No valid API key found, try logging in first with:\n\tcargo shuttle login"
+            ))
         })
     }
 


### PR DESCRIPTION
When first trying `cargo shuttle deploy` I got the following output:

```
Error: No valid API key found, try logging in first.

Caused by:
    Configuration file: `/Users/xavientois/Library/Application Support/shuttle/config.toml`
```

The error message was confusing to me, as I was not aware that I needed to login to shuttle or how I would do it. This PR aims to improve this message to be more helpful to beginners who are just starting out with Shuttle:

```
Error: No valid API key found, try logging in first with:
	cargo shuttle login

Caused by:
    Configuration file: `/Users/xavientois/Library/Application Support/shuttle/config.toml`
```