### PR TITLE
feat: store '.so' file names in database instead of using marker files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,3 +5504,7 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[patch.unused]]
+name = "shuttle-service"
+version = "0.3.3"

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -277,6 +277,7 @@ mod tests {
     use tracing_subscriber::prelude::*;
 
     use crate::deployment::{deploy_layer::LogType, Built, DeploymentManager, Queued, State};
+    use crate::persistence::Persistence;
 
     use super::{DeployLayer, Log, LogRecorder};
 
@@ -344,7 +345,7 @@ mod tests {
 
     #[tokio::test]
     async fn deployment_to_be_queued() {
-        let deployment_manager = DeploymentManager::new();
+        let deployment_manager = DeploymentManager::new(Persistence::new_in_memory().await.0);
 
         deployment_manager
             .queue_push(Queued {
@@ -390,7 +391,7 @@ mod tests {
 
     #[tokio::test]
     async fn deployment_from_run() {
-        let deployment_manager = DeploymentManager::new();
+        let deployment_manager = DeploymentManager::new(Persistence::new_in_memory().await.0);
 
         deployment_manager
             .run_push(Built {

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -15,6 +15,8 @@ use tracing::instrument;
 
 use tokio::sync::{broadcast, mpsc};
 
+use crate::persistence::Persistence;
+
 const QUEUE_BUFFER_SIZE: usize = 100;
 const RUN_BUFFER_SIZE: usize = 100;
 const KILL_BUFFER_SIZE: usize = 10;
@@ -28,11 +30,11 @@ pub struct DeploymentManager {
 impl DeploymentManager {
     /// Create a new deployment manager. Manages one or more 'pipelines' for
     /// processing service building, loading, and deployment.
-    pub fn new() -> Self {
+    pub fn new(persistence: Persistence) -> Self {
         let (kill_send, _) = broadcast::channel(KILL_BUFFER_SIZE);
 
         DeploymentManager {
-            pipeline: Pipeline::new(kill_send.clone()),
+            pipeline: Pipeline::new(kill_send.clone(), persistence),
             kill_send,
         }
     }
@@ -79,13 +81,13 @@ impl Pipeline {
     /// executing/deploying built services. Two multi-producer, single consumer
     /// channels are also created which are for moving on-going service
     /// deployments between the aforementioned tasks.
-    fn new(kill_send: KillSender) -> Pipeline {
+    fn new(kill_send: KillSender, persistence: Persistence) -> Pipeline {
         let (queue_send, queue_recv) = mpsc::channel(QUEUE_BUFFER_SIZE);
         let (run_send, run_recv) = mpsc::channel(RUN_BUFFER_SIZE);
 
         let run_send_clone = run_send.clone();
 
-        tokio::spawn(async move { queue::task(queue_recv, run_send_clone).await });
+        tokio::spawn(async move { queue::task(queue_recv, persistence, run_send_clone).await });
         tokio::spawn(async move { run::task(run_recv, kill_send).await });
 
         Pipeline {

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -39,7 +39,7 @@ async fn main() {
         .with(fmt_layer)
         .init();
 
-    let deployment_manager = DeploymentManager::new();
+    let deployment_manager = DeploymentManager::new(persistence.clone());
 
     for existing_deployment in persistence.get_all_runnable_deployments().await.unwrap() {
         let built = Built {

--- a/deployer/src/persistence.rs
+++ b/deployer/src/persistence.rs
@@ -33,7 +33,7 @@ impl Persistence {
     }
 
     #[allow(dead_code)]
-    async fn new_in_memory() -> (Self, JoinHandle<()>) {
+    pub async fn new_in_memory() -> (Self, JoinHandle<()>) {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         Self::from_pool(pool).await
     }


### PR DESCRIPTION
* Compiled '.so' files are still given random names but a service deployment can be mapped to a '.so' file name via a new `libs` database table.
* All '.so' files are moved to a common directory instead of being left in the project directory.