### PR TITLE
Docs/local setup relocate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ shuttle-service = { path = "[base]/shuttle/service" }
 Login to shuttle service in a new terminal window from the main shuttle directory:
 
 ```bash
-cargo run --bin cargo-shuttle -- login --api-key "ci-test"
+cargo run --bin cargo-shuttle -- login --api-key "test-key"
 ```
 
 cd into one of the examples:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,16 @@ $ docker compose -f docker-compose.dev.yml up -d
 
 The API is now accessible on `localhost:8000` (for app proxies) and `localhost:8001` (for the control plane). When running `cargo run --bin cargo-shuttle` (in a debug build), the CLI will point itself to `localhost` for its API calls. The deployment parameters can be tweaked by changing values in the [.env](./.env) file.
 
-In order to test local changes to the `shuttle-service` crate, you may want to add the following to a `.cargo/config.toml` file:
-See [Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) for more.
+In order to test local changes to the `shuttle-service` crate, you may want to add the below to a `.cargo/config.toml` file. (See [Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) for more)
 
 ``` toml
 [patch.crates-io]
 shuttle-service = { path = "[base]/shuttle/service" }
 ```
 
-Login to shuttle service in a new terminal window:
+Login to shuttle service in a new terminal window from the main shuttle directory:
 
 ```bash
-cd path/to/shuttle/repo
 cargo run --bin cargo-shuttle -- login --api-key "ci-test"
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Test if the deploy is working:
 
 ```bash
 # (the Host header should match the Host from the deploy output)
-curl --header "Host: hello-world-rocket-app.teste.rs" localhost:8000/hello
+curl --header "Host: {app}.localhost.local" localhost:8000/hello
 ```
 ### Using Podman instead of Docker
 If you are using Podman over Docker, then expose a rootless socket of Podman using the following command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,30 +8,61 @@ Raising [issues](https://github.com/shuttle-hq/shuttle/issues) is encouraged. We
 You can use Docker and docker-compose to test shuttle locally during development. See the [Docker install](https://docs.docker.com/get-docker/)
 and [docker-compose install](https://docs.docker.com/compose/install/) instructions if you do not have them installed already.
 
-You should now be set to run shuttle locally as follow:
+You should now be ready to setup a local environment to test code changes to core `shuttle` packages as follows:
+
+Build the required images with:
 
 ```bash
-# clone the repo
-git clone git@github.com:shuttle-hq/shuttle.git
+$ docker buildx bake -f docker-bake.hcl provisioner backend
+```
 
-# cd into the repo
-cd shuttle
+The images get built with [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) and therefore support incremental builds (most of the time). So they will be much faster to re-build after an incremental change in your code - should you wish to deploy it locally straightaway.
 
-# start the shuttle services
-docker-compose up --build
+Create a docker persistent volume with:
 
-# login to shuttle service in a new terminal window
+```bash
+$ docker volume create shuttle-backend-vol
+```
+
+Finally, you can start a local deployment of the backend with:
+
+```bash
+$ docker compose -f docker-compose.dev.yml up -d
+```
+
+The API is now accessible on `localhost:8000` (for app proxies) and `localhost:8001` (for the control plane). When running `cargo run --bin cargo-shuttle` (in a debug build), the CLI will point itself to `localhost` for its API calls. The deployment parameters can be tweaked by changing values in the [.env](./.env) file.
+
+In order to test local changes to the `shuttle-service` crate, you may want to add the following to a `.cargo/config.toml` file:
+See [Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) for more.
+
+``` toml
+[patch.crates-io]
+shuttle-service = { path = "[base]/shuttle/service" }
+```
+
+Login to shuttle service in a new terminal window:
+
+```bash
 cd path/to/shuttle/repo
 cargo run --bin cargo-shuttle -- login --api-key "ci-test"
+```
 
-# cd into one of the examples
+cd into one of the examples:
+
+```bash
 cd examples/rocket/hello-world/
+```
 
-# deploy the example
+Deploy the example:
+
+```bash
 # the --manifest-path is used to locate the root of the shuttle workspace
 cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- deploy
+```
 
-# test if the deploy is working
+Test if the deploy is working:
+
+```bash
 # (the Host header should match the Host from the deploy output)
 curl --header "Host: hello-world-rocket-app.teste.rs" localhost:8000/hello
 ```

--- a/README.md
+++ b/README.md
@@ -95,40 +95,9 @@ $ cargo shuttle deploy
 
 For the full documentation, visit [docs.rs/shuttle-service](https://docs.rs/shuttle-service)
 
-## Working on shuttle
+## Contributing to shuttle
 
-If you want to setup a local environment to test code changes to core `shuttle` packages, follow these steps.
-
-Build the required images with 
-
-```bash
-$ docker buildx bake -f docker-bake.hcl provisioner backend
-```
-
-The images get build with [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) and therefore support incremental builds (most of the time). So they will be much faster to re-build after an incremental change in your code - should you wish to deploy it locally straightaway.
-
-Create a docker persistent volume with
-
-```bash
-$ docker volume create shuttle-backend-vol
-```
-
-Finally, you can start a local deployment of the backend with
-
-```bash
-$ docker compose -f docker-compose.dev.yml up -d
-```
-
-The API is now accessible on `localhost:8000` (for app proxies) and `localhost:8001` (for the control plane). When running `cargo run --bin cargo-shuttle` (in a debug build), the CLI will point itself to `localhost` for its API calls. The deployment parameters can be tweaked by changing values in the [.env](./.env) file.
-
-In order to test local changes to the `shuttle-service` crate, you may want to add the following to a `.cargo/config.toml` file:
-
-``` toml
-[patch.crates-io]
-shuttle-service = { path = "[base]/shuttle/service" }
-```
-
-See [Overriding Dependencies](https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html) for more.
+If you want to setup a local environment to test code changes to core `shuttle` packages, or want to contribute to the project see [CONTRIBUTING.md](https://github.com/shuttle-hq/shuttle/blob/main/CONTRIBUTING.md)
 
 ## Roadmap
 


### PR DESCRIPTION
Update of the 'old' `docker compose` process, and docs and linking hompage info to the contributions page instead of the home page. This should be subject to there being no further changes needed to fix #233 .