### PR TITLE
Fix webpage link for the url-shortener example

### DIFF
--- a/www/components/Examples.tsx
+++ b/www/components/Examples.tsx
@@ -19,7 +19,7 @@ const cards: Card[] = [
     title: "Url Shortener",
     description:
       "A URL shortener that you can use from your terminal - built with shuttle, rocket and postgres/sqlx.",
-    link: "https://github.com/getsynth/shuttle/tree/main/examples/url-shortener",
+    link: "https://github.com/getsynth/shuttle/tree/main/examples/rocket/url-shortener",
     icon: "/images/icon2.svg",
   },
   {


### PR DESCRIPTION
The webpage link to the url-shortener example is outdated - this updates it, similar to the other 2 examples, using the `rocket` example.