### PR TITLE
docs: add dependency to make example runnable

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -98,12 +98,13 @@
 //!
 //! ## Using `sqlx`
 //!
-//! Here is a quick example to deploy a service which uses a postgres database and [sqlx](http://docs.rs/sqlx):
+//! Here is a quick example to deploy a service that uses a postgres database and [sqlx](http://docs.rs/sqlx):
 //!
-//! Add the `sqlx-postgres` feature to the `shuttle-service` dependency inside `Cargo.toml`:
+//! Add the `sqlx-postgres` feature to the `shuttle-service` dependency, and add `sqlx` as a dependency with the `runtime-tokio-native-tls` and `postgres` features inside `Cargo.toml`:
 //!
 //! ```toml
 //! shuttle-service = { version = "0.3.3", features = ["web-rocket", "sqlx-postgres"] }
+//! sqlx = { version = "0.5", features = ["runtime-tokio-native-tls", "postgres"] }
 //! ```
 //!
 //! Now update the `#[shuttle_service::main]` function to take in a `PgPool`:


### PR DESCRIPTION
While working through the main documentation examples on the `shuttle_service` crate docs, I reached the point where it gives an example of how to deploy a service that uses a postgres database and sqlx. When I updated my code based on the example, it gave the following error:

```
error[E0432]: unresolved import `sqlx`
 --> src/lib.rs:6:5
  |
6 | use sqlx::PgPool;
  |     ^^^^ use of undeclared crate or module `sqlx`
``` 

While this error was easy enough to fix, it would be a nicer experience if following the example in the docs worked the first time.

This also fixes an incorrect use of "which" rather than "that"