### PR TITLE
deps(clap): migrate uses of structopt to clap in cargo-shuttle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shuttle"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1043,6 +1043,7 @@ dependencies = [
  "cargo-edit",
  "cargo_metadata",
  "chrono",
+ "clap 3.2.6",
  "colored",
  "crossterm",
  "dirs",
@@ -1058,7 +1059,6 @@ dependencies = [
  "serde_json",
  "shuttle-common",
  "shuttle-service",
- "structopt",
  "test-context",
  "tokio",
  "tokiotest-httpserver",
@@ -4324,34 +4324,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
-name = "shuttle-codegen"
-version = "0.3.1"
-dependencies = [
- "pretty_assertions",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
- "trybuild",
-]
-
-[[package]]
-name = "shuttle-common"
-version = "0.3.1"
-dependencies = [
- "anyhow",
- "chrono",
- "lazy_static",
- "log",
- "rocket",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "shuttle-pod"
-version = "0.1.2"
+name = "shuttle-api"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-mutex",
@@ -4383,8 +4357,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuttle-codegen"
+version = "0.4.0"
+dependencies = [
+ "pretty_assertions",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "trybuild",
+]
+
+[[package]]
+name = "shuttle-common"
+version = "0.4.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "log",
+ "rocket",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "shuttle-proto"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "prost",
  "shuttle-common",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-provisioner"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "aws-config",
  "aws-sdk-rds",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-service"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -14,6 +14,7 @@ cargo = "0.62.0"
 cargo-edit = { version = "0.9.1", features = ["cli"] }
 cargo_metadata = "0.14.2"
 chrono = "0.4.19"
+clap = { version = "3.1.18", features = ["derive", "env"] }
 colored = "2.0.0"
 crossterm = "0.23.2"
 dirs = "4.0.0"
@@ -27,7 +28,6 @@ reqwest-retry = "0.1.5"
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-structopt = "0.3.26"
 tokio = "1.19.2"
 toml = "0.5.9"
 toml_edit = "0.14.4"

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -18,12 +18,9 @@ use shuttle_common::project::ProjectName;
         .hidden(true))
 )]
 pub struct Args {
-    #[clap(
-        long,
-        help = "allows targeting a custom deloyed instance for this command only",
-        env = "SHUTTLE_API"
-    )]
-    /// Run this command against the api at the supplied url
+    /// run this command against the api at the supplied url
+    /// (allows targeting a custom deployed instance for this command only)
+    #[clap(long, env = "SHUTTLE_API")]
     pub api_url: Option<String>,
     #[clap(flatten)]
     pub project_args: ProjectArgs,
@@ -34,69 +31,74 @@ pub struct Args {
 // Common args for subcommands that deal with projects.
 #[derive(Parser, Debug)]
 pub struct ProjectArgs {
+    /// Specify the working directory
     #[clap(
         global = true,
         long,
         parse(try_from_os_str = parse_path),
         default_value = ".",
     )]
-    /// Specify the working directory
     pub working_directory: PathBuf,
-    #[clap(global = true, long)]
     /// Specify the name of the project (overrides crate name)
+    #[clap(global = true, long)]
     pub name: Option<ProjectName>,
 }
 
 #[derive(Parser)]
 pub enum Command {
-    #[clap(help = "deploy a shuttle project")]
+    /// deploy a shuttle project
     Deploy(DeployArgs),
-    #[clap(help = "create a new shuttle project")]
+    /// create a new shuttle project
     Init(InitArgs),
-    #[clap(help = "view the status of a shuttle project")]
+    /// view the status of a shuttle project
     Status,
-    #[clap(help = "view the logs of a shuttle project")]
+    /// view the logs of a shuttle project
     Logs,
-    #[clap(help = "delete the latest deployment for a shuttle project")]
+    /// delete the latest deployment for a shuttle project
     Delete,
-    #[clap(help = "create user credentials for the shuttle platform")]
+    /// create user credentials for the shuttle platform
     Auth(AuthArgs),
-    #[clap(help = "login to the shuttle platform")]
+    /// login to the shuttle platform
     Login(LoginArgs),
-    #[clap(help = "run a shuttle project locally")]
+    /// run a shuttle project locally
     Run(RunArgs),
 }
 
 #[derive(Parser)]
 pub struct LoginArgs {
-    #[clap(long, help = "api key for the shuttle platform")]
+    /// api key for the shuttle platform
+    #[clap(long)]
     pub api_key: Option<String>,
 }
 
 #[derive(Parser)]
 pub struct AuthArgs {
-    #[clap(help = "the desired username for the shuttle platform")]
+    /// the desired username for the shuttle platform
+    #[clap()]
     pub username: String,
 }
 
 #[derive(Parser)]
 pub struct DeployArgs {
-    #[clap(long, help = "allow dirty working directories to be packaged")]
+    /// allow dirty working directories to be packaged
+    #[clap(long)]
     pub allow_dirty: bool,
-    #[clap(long, help = "allows pre-deploy tests to be skipped")]
+    /// allows pre-deploy tests to be skipped
+    #[clap(long)]
     pub no_test: bool,
 }
 
 #[derive(Parser, Debug)]
 pub struct RunArgs {
-    #[clap(long, help = "port to start service on", default_value = "8000")]
+    /// port to start service on
+    #[clap(long, default_value = "8000")]
     pub port: u16,
 }
 
 #[derive(Parser)]
 pub struct InitArgs {
+    /// the path to initialize a new shuttle project
     #[clap(
-        help = "the path to initialize a new shuttle project",
         parse(try_from_os_str = parse_init_path),
         default_value = ".",
     )]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -1,39 +1,40 @@
 use std::{
-    ffi::{OsStr, OsString},
+    ffi::OsStr,
     fs::{canonicalize, create_dir_all},
+    io::{self, ErrorKind},
     path::PathBuf,
 };
 
+use clap::Parser;
 use shuttle_common::project::ProjectName;
-use structopt::StructOpt;
 
-#[derive(StructOpt)]
-#[structopt(
+#[derive(Parser)]
+#[clap(
     // Cargo passes in the subcommand name to the invoked executable. Use a
     // hidden, optional positional argument to deal with it.
-    arg(structopt::clap::Arg::with_name("dummy")
+    arg(clap::Arg::with_name("dummy")
         .possible_value("shuttle")
         .required(false)
         .hidden(true))
 )]
 pub struct Args {
-    #[structopt(
+    #[clap(
         long,
-        about = "allows targeting a custom deloyed instance for this command only",
+        help = "allows targeting a custom deloyed instance for this command only",
         env = "SHUTTLE_API"
     )]
     /// Run this command against the api at the supplied url
     pub api_url: Option<String>,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     pub project_args: ProjectArgs,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
 }
 
 // Common args for subcommands that deal with projects.
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct ProjectArgs {
-    #[structopt(
+    #[clap(
         global = true,
         long,
         parse(try_from_os_str = parse_path),
@@ -41,61 +42,61 @@ pub struct ProjectArgs {
     )]
     /// Specify the working directory
     pub working_directory: PathBuf,
-    #[structopt(global = true, long)]
+    #[clap(global = true, long)]
     /// Specify the name of the project (overrides crate name)
     pub name: Option<ProjectName>,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub enum Command {
-    #[structopt(about = "deploy a shuttle project")]
+    #[clap(help = "deploy a shuttle project")]
     Deploy(DeployArgs),
-    #[structopt(about = "create a new shuttle project")]
+    #[clap(help = "create a new shuttle project")]
     Init(InitArgs),
-    #[structopt(about = "view the status of a shuttle project")]
+    #[clap(help = "view the status of a shuttle project")]
     Status,
-    #[structopt(about = "view the logs of a shuttle project")]
+    #[clap(help = "view the logs of a shuttle project")]
     Logs,
-    #[structopt(about = "delete the latest deployment for a shuttle project")]
+    #[clap(help = "delete the latest deployment for a shuttle project")]
     Delete,
-    #[structopt(about = "create user credentials for the shuttle platform")]
+    #[clap(help = "create user credentials for the shuttle platform")]
     Auth(AuthArgs),
-    #[structopt(about = "login to the shuttle platform")]
+    #[clap(help = "login to the shuttle platform")]
     Login(LoginArgs),
-    #[structopt(about = "run a shuttle project locally")]
+    #[clap(help = "run a shuttle project locally")]
     Run(RunArgs),
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct LoginArgs {
-    #[structopt(long, about = "api key for the shuttle platform")]
+    #[clap(long, help = "api key for the shuttle platform")]
     pub api_key: Option<String>,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct AuthArgs {
-    #[structopt(about = "the desired username for the shuttle platform")]
+    #[clap(help = "the desired username for the shuttle platform")]
     pub username: String,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct DeployArgs {
-    #[structopt(long, about = "allow dirty working directories to be packaged")]
+    #[clap(long, help = "allow dirty working directories to be packaged")]
     pub allow_dirty: bool,
-    #[structopt(long, about = "allows pre-deploy tests to be skipped")]
+    #[clap(long, help = "allows pre-deploy tests to be skipped")]
     pub no_test: bool,
 }
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 pub struct RunArgs {
-    #[structopt(long, about = "port to start service on", default_value = "8000")]
+    #[clap(long, help = "port to start service on", default_value = "8000")]
     pub port: u16,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct InitArgs {
-    #[structopt(
-        about = "the path to initialize a new shuttle project",
+    #[clap(
+        help = "the path to initialize a new shuttle project",
         parse(try_from_os_str = parse_init_path),
         default_value = ".",
     )]
@@ -103,14 +104,19 @@ pub struct InitArgs {
 }
 
 // Helper function to parse and return the absolute path
-fn parse_path(path: &OsStr) -> Result<PathBuf, OsString> {
-    canonicalize(path).map_err(|e| format!("could not turn {path:?} into a real path: {e}").into())
+fn parse_path(path: &OsStr) -> Result<PathBuf, io::Error> {
+    canonicalize(path).map_err(|e| {
+        io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("could not turn {path:?} into a real path: {e}"),
+        )
+    })
 }
 
 // Helper function to parse, create if not exists, and return the absolute path
-fn parse_init_path(path: &OsStr) -> Result<PathBuf, OsString> {
+fn parse_init_path(path: &OsStr) -> Result<PathBuf, io::Error> {
     // Create the directory if does not exist
-    create_dir_all(path).expect("could not find or create a directory with the given path");
+    create_dir_all(path)?;
 
     parse_path(path)
 }

--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
 use cargo_shuttle::{Args, CommandOutcome, Shuttle};
-use structopt::StructOpt;
+use clap::Parser;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
 
-    let result = Shuttle::new().run(Args::from_args()).await;
+    let result = Shuttle::new().run(Args::parse()).await;
 
     if matches!(result, Ok(CommandOutcome::DeploymentFailure)) {
         // Deployment failure results in a shell error exit code being returned (this allows


### PR DESCRIPTION
Part of https://github.com/shuttle-hq/shuttle/issues/248

Migrates the `cargo-shuttle` crate from `structopt` to `clap`.
