### PR TITLE
feat: poem-web integration

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        features: ["web-axum", "web-rocket", "web-tide", "web-tower"]
+        features: ["web-axum", "web-rocket", "web-tide", "web-tower", web-poem]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ["web-axum", "web-rocket", "web-tide", "web-tower"]
+        features: ["web-axum", "web-rocket", "web-tide", "web-tower", "web-poem"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/api/users.toml
+++ b/api/users.toml
@@ -9,4 +9,5 @@ projects = [
     'hello-world-tide-app',
     'hello-world-tower-app',
     'postgres-tide-app',
+    'hello-world-poem-app'
 ]

--- a/api/users.toml
+++ b/api/users.toml
@@ -9,5 +9,6 @@ projects = [
     'hello-world-tide-app',
     'hello-world-tower-app',
     'postgres-tide-app',
-    'hello-world-poem-app'
+    'hello-world-poem-app',
+    'postgres-poem-app'
 ]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -98,17 +98,20 @@ pub struct RunArgs {
 #[derive(Parser, Debug)]
 pub struct InitArgs {
     /// Initialize with axum framework
-    #[clap(long, conflicts_with_all = &["rocket", "tide", "tower"])]
+    #[clap(long, conflicts_with_all = &["rocket", "tide", "tower", "poem"])]
     pub axum: bool,
     /// Initialize with actix-web framework
-    #[clap(long, conflicts_with_all = &["axum", "tide", "tower"])]
+    #[clap(long, conflicts_with_all = &["axum", "tide", "tower", "poem"])]
     pub rocket: bool,
     /// Initialize with tide framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tower"])]
+    #[clap(long, conflicts_with_all = &["axum", "rocket", "tower", "poem"])]
     pub tide: bool,
     /// Initialize with tower framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide"])]
+    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "poem"])]
     pub tower: bool,
+    /// Initialize with poem framework
+    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "tower"])]
+    pub poem: bool,
     /// Path to initialize a new shuttle project
     #[clap(
         parse(try_from_os_str = parse_init_path),

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -23,6 +23,7 @@ async fn cargo_shuttle_init(path: PathBuf) -> anyhow::Result<CommandOutcome> {
                 rocket: false,
                 tide: false,
                 tower: false,
+                poem: false,
                 path,
             }),
         })
@@ -45,6 +46,7 @@ async fn cargo_shuttle_init_framework(path: PathBuf) -> anyhow::Result<CommandOu
                 rocket: true,
                 tide: false,
                 tower: false,
+                poem: false,
                 path,
             }),
         })

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -197,3 +197,50 @@ async fn tower_hello_world() {
 
     assert_eq!(request_text, "Hello, world!");
 }
+
+#[tokio::test]
+async fn poem_hello_world() {
+    let port = cargo_shuttle_run("../examples/poem/hello-world").await;
+
+    let request_text = reqwest::Client::new()
+        .get(format!("http://localhost:{port}/hello"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(request_text, "Hello, world!");
+}
+
+// This example uses a shared Postgres. Thus local runs should create a docker container for it.
+#[tokio::test]
+async fn poem_postgres() {
+    let port = cargo_shuttle_run("../examples/poem/postgres").await;
+    let client = reqwest::Client::new();
+
+    let post_text = client
+        .post(format!("http://localhost:{port}/todo"))
+        .body("{\"note\": \"Deploy to shuttle\"}")
+        .header("content-type", "application/json")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(post_text, "{\"id\":1,\"note\":\"Deploy to shuttle\"}");
+
+    let request_text = client
+        .get(format!("http://localhost:{port}/todo/1"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(request_text, "{\"id\":1,\"note\":\"Deploy to shuttle\"}");
+}

--- a/e2e/tests/integration/main.rs
+++ b/e2e/tests/integration/main.rs
@@ -1,6 +1,7 @@
 pub mod helpers;
 
 pub mod axum;
+pub mod poem;
 pub mod rocket;
 pub mod tide;
 pub mod tower;

--- a/e2e/tests/integration/poem.rs
+++ b/e2e/tests/integration/poem.rs
@@ -1,0 +1,19 @@
+use colored::Color;
+
+use crate::helpers;
+
+#[test]
+fn hello_world_poem() {
+    let client = helpers::Services::new_docker("hello-world (poem)", Color::Cyan);
+    client.deploy("poem/hello-world");
+
+    let request_text = client
+        .get("hello")
+        .header("Host", "hello-world-poem-app.localhost.local")
+        .send()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    assert_eq!(request_text, "Hello, world!");
+}

--- a/e2e/tests/integration/poem.rs
+++ b/e2e/tests/integration/poem.rs
@@ -17,3 +17,41 @@ fn hello_world_poem() {
 
     assert_eq!(request_text, "Hello, world!");
 }
+
+#[test]
+fn postgres_poem() {
+    let client = helpers::Services::new_docker("postgres", Color::Blue);
+    client.deploy("poem/postgres");
+
+    let add_response = client
+        .post("todo")
+        .body("{\"note\": \"To the stars\"}")
+        .header("Host", "postgres-poem-app.localhost.local")
+        .header("content-type", "application/json")
+        .send()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    assert_eq!(add_response, "{\"id\":1,\"note\":\"To the stars\"}");
+
+    let fetch_response: String = client
+        .get("todo/1")
+        .header("Host", "postgres-poem-app.localhost.local")
+        .send()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    assert_eq!(fetch_response, "{\"id\":1,\"note\":\"To the stars\"}");
+
+    let secret_response: String = client
+        .get("secret")
+        .header("Host", "postgres-poem-app.localhost.local")
+        .send()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    assert_eq!(secret_response, "the contents of my API key");
+}

--- a/examples/poem/hello-world/Cargo.toml
+++ b/examples/poem/hello-world/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hello-world"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+
+[dependencies]
+poem = "1.3.35"
+shuttle-service = { version = "0.4.0", features = ["web-poem"] }

--- a/examples/poem/hello-world/Shuttle.toml
+++ b/examples/poem/hello-world/Shuttle.toml
@@ -1,0 +1,1 @@
+name = "hello-world-poem-app"

--- a/examples/poem/hello-world/src/lib.rs
+++ b/examples/poem/hello-world/src/lib.rs
@@ -1,0 +1,13 @@
+use poem::{get, handler, Route};
+
+#[handler]
+fn hello_world() -> &'static str {
+    "Hello, world!"
+}
+
+#[shuttle_service::main]
+async fn main() -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+    let app = Route::new().at("/hello", get(hello_world));
+
+    Ok(app)
+}

--- a/examples/poem/postgres/Cargo.toml
+++ b/examples/poem/postgres/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "postgres"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+
+[dependencies]
+poem = "1.3.35"
+serde = "1.0"
+sqlx = { version = "0.5", features = ["runtime-tokio-native-tls", "postgres"] }
+shuttle-service = { version = "0.4.0", features = ["sqlx-postgres", "secrets", "web-poem"] }

--- a/examples/poem/postgres/Secrets.toml
+++ b/examples/poem/postgres/Secrets.toml
@@ -1,0 +1,1 @@
+MY_API_KEY = 'the contents of my API key'

--- a/examples/poem/postgres/Shuttle.toml
+++ b/examples/poem/postgres/Shuttle.toml
@@ -1,0 +1,1 @@
+name = "postgres-poem-app"

--- a/examples/poem/postgres/schema.sql
+++ b/examples/poem/postgres/schema.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS todos;
+
+CREATE TABLE todos (
+  id serial PRIMARY KEY,
+  note TEXT NOT NULL
+);

--- a/examples/poem/postgres/src/lib.rs
+++ b/examples/poem/postgres/src/lib.rs
@@ -1,0 +1,68 @@
+use poem::{
+    error::BadRequest,
+    get, handler,
+    middleware::AddData,
+    post,
+    web::{Data, Json, Path},
+    EndpointExt, Result, Route,
+};
+use serde::{Deserialize, Serialize};
+use shuttle_service::error::CustomError;
+use shuttle_service::SecretStore;
+use sqlx::{Executor, FromRow, PgPool};
+
+#[handler]
+async fn retrieve(Path(id): Path<i32>, state: Data<&PgPool>) -> Result<Json<Todo>> {
+    let todo = sqlx::query_as("SELECT * FROM todos WHERE id = $1")
+        .bind(id)
+        .fetch_one(state.0)
+        .await
+        .map_err(BadRequest)?;
+
+    Ok(Json(todo))
+}
+
+#[handler]
+async fn add(data: Json<TodoNew>, state: Data<&PgPool>) -> Result<Json<Todo>> {
+    let todo = sqlx::query_as("INSERT INTO todos(note) VALUES ($1) RETURNING id, note")
+        .bind(&data.note)
+        .fetch_one(state.0)
+        .await
+        .map_err(BadRequest)?;
+
+    Ok(Json(todo))
+}
+
+#[handler]
+async fn secret(state: Data<&PgPool>) -> Result<String> {
+    // get secret defined in `Secrets.toml` file.
+    state.0.get_secret("MY_API_KEY").await.map_err(BadRequest)
+}
+
+#[shuttle_service::main]
+async fn main(
+    #[shared::Postgres] pool: PgPool,
+) -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+    pool.execute(include_str!("../schema.sql"))
+        .await
+        .map_err(CustomError::new)?;
+
+    let app = Route::new()
+        .at("/secret", get(secret))
+        .at("/todo", post(add))
+        .at("/todo/:id", get(retrieve))
+        .with(AddData::new(pool));
+
+    Ok(app)
+}
+
+#[derive(Deserialize)]
+struct TodoNew {
+    pub note: String,
+}
+
+#[derive(Serialize, FromRow)]
+struct Todo {
+    pub id: i32,
+    pub note: String,
+}

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0.31"
 tide = { version = "0.16.0", optional = true }
 tokio = { version = "1.19.2", features = ["rt", "rt-multi-thread"] }
 tower = { version = "0.4.12", features = ["make"], optional = true }
+poem = { version = "1.3.35", optional = true }
 
 # Tide does not have tokio support. So make sure async-std is compatible with tokio
 # https://github.com/http-rs/tide/issues/791
@@ -65,3 +66,4 @@ web-axum = ["axum", "sync_wrapper"]
 web-rocket = ["rocket"]
 web-tide = ["tide"]
 web-tower = ["tower", "hyper"]
+web-poem = ["poem"]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4.0"
 libloading = { version = "0.7.3", optional = true }
 log = "0.4.17"
 paste = "1.0.7"
+poem = { version = "1.3.35", optional = true }
 regex = "1.5.6"
 rocket = { version = "0.5.0-rc.2", optional = true }
 sqlx = { version = "0.5.13", optional = true }
@@ -28,7 +29,6 @@ thiserror = "1.0.31"
 tide = { version = "0.16.0", optional = true }
 tokio = { version = "1.19.2", features = ["rt", "rt-multi-thread"] }
 tower = { version = "0.4.12", features = ["make"], optional = true }
-poem = { version = "1.3.35", optional = true }
 
 # Tide does not have tokio support. So make sure async-std is compatible with tokio
 # https://github.com/http-rs/tide/issues/791

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -263,6 +263,7 @@ extern crate shuttle_codegen;
 /// | `ShuttleRocket`                       | web-rocket   | [rocket](https://docs.rs/rocket/0.5.0-rc.2) | 0.5.0-rc.2 | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/rocket/hello-world) |
 /// | `ShuttleAxum`                         | web-axum     | [axum](https://docs.rs/axum/0.5)            | 0.5        | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/axum/hello-world)   |
 /// | `ShuttleTide`                         | web-tide     | [tide](https://docs.rs/tide/0.16.0)         | 0.16.0     | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/tide/hello-world)   |
+/// | `ShuttlePoem`                         | web-poem     | [poem](https://docs.rs/poem/1.3.34)         | 1.3.35     | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/poem/hello-world)   |
 /// | `Result<T, shuttle_service::Error>`   | web-tower    | [tower](https://docs.rs/tower/0.4.12)       | 0.14.12    | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/tower/hello-world)  |
 ///
 /// # Getting shuttle managed services
@@ -436,6 +437,25 @@ impl Service for rocket::Rocket<rocket::Build> {
 
 #[cfg(feature = "web-rocket")]
 pub type ShuttleRocket = Result<rocket::Rocket<rocket::Build>, Error>;
+
+#[cfg(feature = "web-poem")]
+#[async_trait]
+impl<T> Service for T
+where
+    T: poem::IntoEndpoint + poem::Endpoint + Sync + Send + 'static,
+{
+    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+        poem::Server::new(poem::listener::TcpListener::bind(addr))
+            .run(self)
+            .await
+            .map_err(error::CustomError::new)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "web-poem")]
+pub type ShuttlePoem<T> = Result<T, Error>;
 
 #[cfg(feature = "web-axum")]
 #[async_trait]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -263,7 +263,7 @@ extern crate shuttle_codegen;
 /// | `ShuttleRocket`                       | web-rocket   | [rocket](https://docs.rs/rocket/0.5.0-rc.2) | 0.5.0-rc.2 | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/rocket/hello-world) |
 /// | `ShuttleAxum`                         | web-axum     | [axum](https://docs.rs/axum/0.5)            | 0.5        | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/axum/hello-world)   |
 /// | `ShuttleTide`                         | web-tide     | [tide](https://docs.rs/tide/0.16.0)         | 0.16.0     | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/tide/hello-world)   |
-/// | `ShuttlePoem`                         | web-poem     | [poem](https://docs.rs/poem/1.3.34)         | 1.3.35     | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/poem/hello-world)   |
+/// | `ShuttlePoem`                         | web-poem     | [poem](https://docs.rs/poem/1.3.35)         | 1.3.35     | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/poem/hello-world)   |
 /// | `Result<T, shuttle_service::Error>`   | web-tower    | [tower](https://docs.rs/tower/0.4.12)       | 0.14.12    | [GitHub](https://github.com/getsynth/shuttle/tree/main/examples/tower/hello-world)  |
 ///
 /// # Getting shuttle managed services
@@ -442,7 +442,7 @@ pub type ShuttleRocket = Result<rocket::Rocket<rocket::Build>, Error>;
 #[async_trait]
 impl<T> Service for T
 where
-    T: poem::IntoEndpoint + poem::Endpoint + Sync + Send + 'static,
+    T: poem::Endpoint + Sync + Send + 'static,
 {
     async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
         poem::Server::new(poem::listener::TcpListener::bind(addr))


### PR DESCRIPTION
### Changes

- [x] Implement `Service` for Poem Web apps.
- [x] Support `cargo shuttle init --poem`.
- [x] Add `hello-world` example.
- [x] Add `postgres` example.
- [x] Add tests for the new examples.
- [x] Update CI. 

### How I tested my changes

I added e2e integration tests for the new examples.
I added integration tests in `cargo-shuttle` for the new examples.
I added a `cargo shuttle init` unit test and updated the `cargo shuttle init` integration test.
I deployed with `cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- deploy` and verified with `curl` that it worked correctly.

### Relevant Issues

Fixes issue #269.
Partially fixes issue #263.