### PR TITLE
docs(examples): update url-shortener example README

### DIFF
--- a/examples/rocket/url-shortener/README.md
+++ b/examples/rocket/url-shortener/README.md
@@ -34,10 +34,10 @@ To deploy this app, check out the repository locally
 $ git clone https://github.com/getsynth/shuttle.git
 ```
 
-navigate to `examples/url-shortener`
+navigate to `examples/rocket/url-shortener`
 
 ```bash
-$ cd examples/url-shortener
+$ cd examples/rocket/url-shortener
 ```
 
 install shuttle


### PR DESCRIPTION
Found out that the README of the url-shortener example had an outdated command, which I updated in this quick PR.