### PR TITLE
feat: support underscore in project name

### DIFF
--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// Project names should conform to valid Host segments (or labels)
 /// as per [IETF RFC 1123](https://datatracker.ietf.org/doc/html/rfc1123).
 /// Initially we'll implement a strict subset of the IETF RFC 1123, concretely:
-/// - It does not start or end with `-`.
-/// - It does not contain any characters outside of the alphanumeric range, except for `-`.
+/// - It does not start or end with `-` or `_`.
+/// - It does not contain any characters outside of the alphanumeric range, except for `-` or '_'.
 /// - It is not empty.
 #[derive(Clone, Serialize, Debug, Eq, PartialEq)]
 pub struct ProjectName(String);
@@ -42,15 +42,21 @@ impl std::fmt::Display for ProjectName {
 impl ProjectName {
     pub fn is_valid(hostname: &str) -> bool {
         fn is_valid_char(byte: u8) -> bool {
-            (b'a'..=b'z').contains(&byte)
-                || (b'A'..=b'Z').contains(&byte)
-                || (b'0'..=b'9').contains(&byte)
-                || byte == b'-'
+            match byte {
+                b'a'..=b'z' 
+                | b'A'..=b'Z' 
+                | b'0'..=b'9' 
+                | b'-' 
+                | b'_' => true,
+                _ => false,
+            }
         }
 
+        let separators = ['-', '_'];
+
         !(hostname.bytes().any(|byte| !is_valid_char(byte))
-            || hostname.ends_with('-')
-            || hostname.starts_with('-')
+            || hostname.ends_with(separators)
+            || hostname.starts_with(separators)
             || hostname.is_empty())
     }
 
@@ -88,8 +94,8 @@ impl Display for ProjectNameError {
                 f,
                 r#"
 `{}` is an invalid project name. project name must
-1. not start or end with `-`.
-2. not contain any characters outside of the alphanumeric range, except for `-`.
+1. start and end with alphanumeric characters.
+2. only contain characters inside of the alphanumeric range, except for `-`, or `_`.
 3. not be empty."#,
                 name
             ),
@@ -107,7 +113,20 @@ pub mod tests {
 
     #[test]
     fn valid_hostnames() {
-        for hostname in ["VaLiD-HoStNaMe", "50-name", "235235", "VaLid", "123"] {
+        for hostname in [
+            "VaLiD-HoStNaMe",
+            "50-name",
+            "235235",
+            "VaLid",
+            "123",
+            "s________e",
+            "snake_case",
+            "kebab-case",
+            "lowercase",
+            "UPPERCASE",
+            "CamelCase",
+            "pascalCase",
+        ] {
             let project_name = ProjectName::from_str(hostname);
             assert!(project_name.is_ok(), "{:?} was err", hostname);
         }
@@ -124,6 +143,9 @@ pub mod tests {
             ".invalid",
             "invalid.name",
             "invalid.name.",
+            "__dunder_like__",
+            "__invalid",
+            "invalid__",
         ] {
             let project_name = ProjectName::from_str(hostname);
             assert!(project_name.is_err(), "{:?} was ok", hostname);

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -42,10 +42,7 @@ impl std::fmt::Display for ProjectName {
 impl ProjectName {
     pub fn is_valid(hostname: &str) -> bool {
         fn is_valid_char(byte: u8) -> bool {
-            match byte {
-                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' => true,
-                _ => false,
-            }
+            matches!(byte, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_')
         }
 
         let separators = ['-', '_'];

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -43,11 +43,7 @@ impl ProjectName {
     pub fn is_valid(hostname: &str) -> bool {
         fn is_valid_char(byte: u8) -> bool {
             match byte {
-                b'a'..=b'z' 
-                | b'A'..=b'Z' 
-                | b'0'..=b'9' 
-                | b'-' 
-                | b'_' => true,
+                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' => true,
                 _ => false,
             }
         }

--- a/examples/rocket/url-shortener/README.md
+++ b/examples/rocket/url-shortener/README.md
@@ -34,10 +34,10 @@ To deploy this app, check out the repository locally
 $ git clone https://github.com/getsynth/shuttle.git
 ```
 
-navigate to `examples/url-shortener`
+navigate to `examples/rocket/url-shortener`
 
 ```bash
-$ cd examples/url-shortener
+$ cd examples/rocket/url-shortener
 ```
 
 install shuttle


### PR DESCRIPTION
## Motivation 

As suggested in #262, naming a project subdomain should allow underscores within the name in the same way it allows hyphens.

In the issue it is stated that the intention is to harmonize with crate naming, but such naming is a still ongoing discussion whether `kebab-case` or `snake_case` should be recommended ([which can be seen here](https://github.com/rust-lang/api-guidelines/discussions/29)). Since one or the other is not standardized, I think shuttle should allow the underscore as well.

## Implementation

Underscores are treated in the same way as hyphens: they can only be within the name of the subdomain, not at the end nor at the start. 
Also, when looking at the code I swapped the implementation of a valid character with a `matches!` macro to use more idiomatic Rust.