### PR TITLE
fix: make profanity filter zealous, add tests to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
   platform_tests:
     strategy:
       matrix:
-        crate: ["shuttle-provisioner", "shuttle-api", "cargo-shuttle"]
+        crate: ["shuttle-provisioner", "shuttle-api", "cargo-shuttle", "shuttle-common"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -59,6 +59,7 @@ impl ProjectName {
 
             let censor = Censor::Standard
                 + Censor::Sex
+                + Censor::Zealous
                 + Censor::Custom(INSTANCE.get().expect("Reserved words not set").clone());
             !censor.check(hostname)
         }

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -60,7 +60,8 @@ impl ProjectName {
             let censor = Censor::Standard
                 + Censor::Sex
                 + Censor::Zealous
-                + Censor::Custom(INSTANCE.get().expect("Reserved words not set").clone());
+                + Censor::Custom(INSTANCE.get().expect("Reserved words not set").clone())
+                - "hell";
             !censor.check(hostname)
         }
 


### PR DESCRIPTION
Fixes the new profanity filter test that failed because it wasn't zealous enough. Alternatively words can be added to or removed from the `censor` crate's word lists easily with the addition/subtraction operators, e.g. `Zealous - "bad word"`. So if you think the `Zealous` list is too strict I can remove words.

I've also included the `shuttle-common` crate in the Github `test` workflow so these new tests run in CI.