### PR TITLE
bug: secret local run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "serde_json",
  "shuttle-common",
  "shuttle-service",
+ "sqlx",
  "tempfile",
  "test-context",
  "tokio",

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -29,6 +29,7 @@ reqwest-retry = "0.1.5"
 semver = "1.0.13"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
+sqlx = { version = "0.6.1", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = "1.20.1"
 toml = "0.5.9"
 toml_edit = "0.14.4"
@@ -43,7 +44,7 @@ path = "../common"
 [dependencies.shuttle-service]
 version = "0.5.0"
 path = "../service"
-features = ["loader"]
+features = ["loader", "secrets"]
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -98,6 +98,17 @@ async fn rocket_postgres() {
         .unwrap();
 
     assert_eq!(request_text, "{\"id\":1,\"note\":\"Deploy to shuttle\"}");
+
+    let request_text = client
+        .get(format!("http://localhost:{port}/secret"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(request_text, "the contents of my API key");
 }
 
 #[tokio::test]


### PR DESCRIPTION
This makes sure secrets are set for local runs. This does, however, assume the use of a shared PG DB and won't work for an RDS PG (see ENG-119)

This closes ENG-120