### PR TITLE
fix: update meta DB state even on factory failure

### DIFF
--- a/api/src/deployment.rs
+++ b/api/src/deployment.rs
@@ -172,8 +172,7 @@ impl Deployment {
                     // phase. Otherwise we end up in a situation where
                     // a DB was provisioned, but the `meta` does not
                     // know about it.
-                    self.meta.write().await.database_deployment =
-                        factory.into_database_info();
+                    self.meta.write().await.database_deployment = factory.into_database_info();
 
                     match load_result {
                         Err(e) => {

--- a/api/src/deployment.rs
+++ b/api/src/deployment.rs
@@ -163,16 +163,25 @@ impl Deployment {
                         meta.project.clone(),
                     );
                     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
-                    match loader.load(&mut factory, addr, run_logs_tx, meta.id).await {
+
+                    let load_result = loader.load(&mut factory, addr, run_logs_tx, meta.id).await;
+
+                    // Even in case `load_result.is_err()`, we want to
+                    // make sure `self.meta` reflects the latest of
+                    // the state that was achieved through the
+                    // phase. Otherwise we end up in a situation where
+                    // a DB was provisioned, but the `meta` does not
+                    // know about it.
+                    self.meta.write().await.database_deployment =
+                        factory.into_database_info();
+
+                    match load_result {
                         Err(e) => {
                             debug!("{}: factory phase FAILED: {:?}", meta.project, e);
                             DeploymentState::Error(e.into())
                         }
                         Ok((handle, so)) => {
                             debug!("{}: factory phase DONE", meta.project);
-                            self.meta.write().await.database_deployment =
-                                factory.into_database_info();
-
                             // Remove stale active deployments
                             if let Some(stale_id) = context.router.promote(meta.host, meta.id).await
                             {


### PR DESCRIPTION
This is a quick workaround for #197.

In a nutshell: secrets are implemented through a separate API endpoint that sets them directly in the DB backend that is attached to a deployment (this is actually pretty unsafe, this should be fixed). However, a DB is attached to a deployment's state only after a successful load and not at all if the factory phase of deployment fails. This leads to a situation where the DB is provisioned but that is not reflected in the deployment's state. And in that case, the secrets endpoints on the API silently fail.

Since a much better approach is on the way in `feat/deployer`, this simple fix will do for now. A client-side update is on the way as well.