### PR TITLE
fix: helpful error when a secret is not found

### DIFF
--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("Database error: {0}")]
     Database(String),
+    #[error("Secret error: {0}")]
+    Secret(String),
     #[error("Panic occurred in shuttle_service::main`: {0}")]
     BuildPanic(String),
     #[error("Panic occurred in `Service::bind`: {0}")]

--- a/service/src/secrets.rs
+++ b/service/src/secrets.rs
@@ -48,12 +48,19 @@ where
         self.execute(sqlx::query(Self::CREATE_TABLE_QUERY)).await?;
 
         let key = check_and_lower_secret_key(key)?;
-        let query = sqlx::query(Self::GET_QUERY).bind(key);
+        let query = sqlx::query(Self::GET_QUERY).bind(&key);
 
-        self.fetch_one(query)
+        self.fetch_optional(query)
             .await
-            .map(|row| row.get(0))
             .map_err(Error::from)
+            .and_then(|m_one| {
+                m_one.ok_or_else(|| {
+                    Error::Secret(format!(
+                        "Secret `{key}` not found in service environment. If you have made changes to your `Secret.toml` file recently, try deploying again to make sure changes are applied correctly."
+                    ))
+                })
+            })
+            .map(|one| one.get(0))
     }
 
     /// Create (or overwrite if already present) a key/value secret in the database. Will error if

--- a/service/src/secrets.rs
+++ b/service/src/secrets.rs
@@ -56,7 +56,7 @@ where
             .and_then(|m_one| {
                 m_one.ok_or_else(|| {
                     Error::Secret(format!(
-                        "Secret `{key}` not found in service environment. If you have made changes to your `Secret.toml` file recently, try deploying again to make sure changes are applied correctly."
+                        "Secret `{key}` not found in service environment. If you have made changes to your `Secrets.toml` file recently, try deploying again to make sure changes are applied correctly."
                     ))
                 })
             })


### PR DESCRIPTION
Client-side for #332 which is a workaround for #197 while we wait for `feat/deployer` to release.