### PR TITLE
refactor: change references of `project` to `service`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ graph BT
     classDef binary fill:#f25100,font-weight:bold,stroke-width:0;
     classDef external fill:#343434,font-style:italic,stroke:#f25100;
 
-    api:::binary
+    deployer:::binary
     cargo-shuttle:::binary
     common
     codegen
@@ -116,29 +116,29 @@ graph BT
     provisioner:::binary
     service
     user([user service]):::external
-    api --> proto
-    api -.->|calls| provisioner
+    deployer --> proto
+    deployer -.->|calls| provisioner
     service ---> common
-    api --> common
+    deployer --> common
     cargo-shuttle --->|"features = ['loader']"| service
-    api -->|"features = ['loader', 'secrets']"| service
+    deployer -->|"features = ['loader', 'secrets']"| service
     cargo-shuttle --> common
     service --> codegen
     proto ---> common
     provisioner --> proto
-    e2e -.->|starts up| api
+    e2e -.->|starts up| deployer
     e2e -.->|calls| cargo-shuttle
     user -->|"features = ['codegen']"| service
 ```
 
-First, `provisioner`, `api`, and `cargo-shuttle` are binary crates with `provisioner` and `api` being backend services. The `cargo-shuttle` binary is the `cargo shuttle` command used by users.
+First, `provisioner`, `deployer`, and `cargo-shuttle` are binary crates with `provisioner` and `deployer` being backend services. The `cargo-shuttle` binary is the `cargo shuttle` command used by users.
 
 The rest are the following libraries:
 - `common` contains shared models and functions used by the other libraries and binaries.
 - `codegen` contains our proc-macro code which gets exposed to user services from `service` by the `codegen` feature flag. The redirect through `service` is to make it available under the prettier name of `shuttle_service::main`.
-- `service` is where our special `Service` trait is defined. Anything implementing this `Service` can be loaded by the `api` and the local runner in `cargo-shuttle`.
+- `service` is where our special `Service` trait is defined. Anything implementing this `Service` can be loaded by the `deployer` and the local runner in `cargo-shuttle`.
    The `codegen` automatically implements the `Service` trait for any user service.
-- `proto` contains the gRPC server and client definitions to allow `api` to communicate with `provisioner`.
-- `e2e` just contains tests which starts up the `api` in a container and then deploys services to it using `cargo-shuttle`.
+- `proto` contains the gRPC server and client definitions to allow `deployer` to communicate with `provisioner`.
+- `e2e` just contains tests which starts up the `deployer` in a container and then deploys services to it using `cargo-shuttle`.
 
-Lastly, the `user service` is not a folder in this repository, but is the user service that will be deployed by `api`.
+Lastly, the `user service` is not a folder in this repository, but is the user service that will be deployed by `deployer`.

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shuttle-deployer"
 version = "0.1.0"
 edition = "2021"
-description = "Service with instances created per project for handling the compliation, loading, and execution of Shuttle services"
+description = "Service with instances created per project for handling the compilation, loading, and execution of Shuttle services"
 
 [dependencies]
 anyhow = "1.0.58"

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use portpicker::pick_unused_port;
-use shuttle_common::project::ProjectName;
+use shuttle_common::project::ProjectName as ServiceName;
 use shuttle_service::{
     loader::{LoadedService, Loader},
     Factory,
@@ -51,14 +51,14 @@ pub async fn task(
             }
         };
         let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), port);
-        let project_name = match ProjectName::from_str(&built.service_name) {
+        let service_name = match ServiceName::from_str(&built.service_name) {
             Ok(name) => name,
             Err(err) => {
                 start_crashed_cleanup(&id, err);
                 continue;
             }
         };
-        let mut factory = abstract_factory.get_factory(project_name, built.service_id);
+        let mut factory = abstract_factory.get_factory(service_name, built.service_id);
         let logger = logger_factory.get_logger(id);
         let cleanup = move |result: std::result::Result<
             std::result::Result<(), shuttle_service::Error>,

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -8,7 +8,7 @@ use tracing::trace;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 
-// The `multi_thread` is needed to prevent a deadlock in shutlte_service::loader::build_crate() which spawns two threads
+// The `multi_thread` is needed to prevent a deadlock in shuttle_service::loader::build_crate() which spawns two threads
 // Without this, both threads just don't start up
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -74,7 +74,7 @@ impl Persistence {
             CREATE TABLE IF NOT EXISTS services (
                 id TEXT PRIMARY KEY, -- Identifier of the service.
                 name TEXT UNIQUE,    -- Name of the service.
-                user_id TEXT,        -- Name of the service.
+                user_id TEXT,        -- Identifier of the user the service belongs to.
                 FOREIGN KEY(user_id) REFERENCES users(api_key)
             );
 


### PR DESCRIPTION
Changes references of `project` to `service` to bring the naming up to date with the new architecture in the `feat/deployer` branch.