### PR TITLE
bug: segmentation fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ RUST_LOG?=debug
 
 DOCKER_COMPOSE_ENV=BACKEND_TAG=$(TAG) PROVISIONER_TAG=$(TAG) POSTGRES_TAG=latest APPS_FQDN=$(APPS_FQDN) DB_FQDN=$(DB_FQDN) POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) RUST_LOG=$(RUST_LOG) CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) MONGO_INITDB_ROOT_USERNAME=$(MONGO_INITDB_ROOT_USERNAME) MONGO_INITDB_ROOT_PASSWORD=$(MONGO_INITDB_ROOT_PASSWORD)
 
-.PHONY: images clean src up down deploy docker-compose.rendered.yml shuttle-% postgres docker-compose.rendered.yml test
+.PHONY: images clean src up down deploy shuttle-% postgres test
 
 clean:
 	rm .shuttle-*

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -32,7 +32,7 @@ sqlx = { version = "0.6.1", optional = true }
 sync_wrapper = { version = "0.1.1", optional = true }
 thiserror = "1.0.32"
 tide = { version = "0.16.0", optional = true }
-tokio = { version = "1.20.1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "=1.20.1", features = ["rt", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 
 # Tide does not have tokio support. So make sure async-std is compatible with tokio

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -369,13 +369,14 @@ pub type StateBuilder<T> =
 /// tokio runtime.
 pub type Binder = for<'a> fn(Box<dyn Service>, SocketAddr, &'a Runtime) -> ServeHandle;
 
+// Make sure every crate used in this struct has its version pinned down to prevent segmentation faults when crossing the FFI.
+// Your future self will thank you!
+// See https://github.com/shuttle-hq/shuttle/pull/348
 #[allow(dead_code)]
 pub struct Bootstrapper {
     service: Option<Box<dyn Service>>,
     builder: Option<StateBuilder<Box<dyn Service>>>,
     binder: Binder,
-    // Do you have time on your hands? If yes, then move this field higher and spend endless hours debugging the segmentation fault
-    // It seems that the [Runtime] changes in size when crossing the FFI which misaligns all fields after it
     runtime: Option<Runtime>,
 }
 


### PR DESCRIPTION
# Postmortem
The segmentation fault would happen as soon as we tried to use the Tokio runtime on the other side of the FFI with [this spawn](https://github.com/shuttle-hq/shuttle/blob/dbfb0eec7fc3d52c84db18e48e30d1ed2e029d69/codegen/src/main/mod.rs#L22). [From past experiences](https://github.com/shuttle-hq/shuttle/blob/dbfb0eec7fc3d52c84db18e48e30d1ed2e029d69/service/src/lib.rs#L377) we also know that causing the Tokio runtime to cross FFI boundaries causes issues. So this was likely to be the source of the problem again... but no order of the `Bootstrapper` fields could get rid of this segmentation fault :angry: .

Yet, clearly, the Tokio runtime was the issue again. This lead to checking if the Tokio version changed which led to the issue.

## The issue
When API compiled `shuttle_service` it used tokio v1.21.1. However, a service, like axum hello_world, would compile with tokio v1.20.1 because it did not support v1.21.1 yet. This meant the Tokio runtime loaded by the FFI (for the service) would be different that the Tokio runtime used by API.

## The fix
Pin down the Tokio version in `shuttle_service` to v1.20.1 to cause API and services to compile with the same version.

We can't pin to v.1.21.1 because axum, rocket, and I think another framework does not support this version yet and will fail to compile.

Fixes ENG-138