### PR TITLE
fix(service): rocket config

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -432,13 +432,14 @@ impl Service for rocket::Rocket<rocket::Build> {
             ..rocket::config::Shutdown::default()
         };
 
-        let config = rocket::Config {
-            address: addr.ip(),
-            port: addr.port(),
-            log_level: rocket::config::LogLevel::Off,
-            shutdown,
-            ..Default::default()
-        };
+        let config = self
+            .figment()
+            .clone()
+            .merge((rocket::Config::ADDRESS, addr.ip()))
+            .merge((rocket::Config::PORT, addr.port()))
+            .merge((rocket::Config::LOG_LEVEL, rocket::config::LogLevel::Off))
+            .merge((rocket::Config::SHUTDOWN, shutdown));
+
         let _rocket = self
             .configure(config)
             .launch()


### PR DESCRIPTION
Rocket is configured with [`Rocket::configure`](https://api.rocket.rs/master/rocket/struct.Rocket.html#method.configure) that completly overwrite the configurations.

This fix makes that only the required fields of the configuration being patched.

This fixes configuration for fairing like `rocket_dyn_templates` :
```rust
#[shuttle_service::main]
async fn rocket() -> shuttle_service::ShuttleRocket {
    let figment = rocket::Config::figment().merge(("template_dir", "./dist/templates/"));

    let rocket = rocket::custom(figment)
        .attach(Template::fairing());

    Ok(rocket)
}
```