### PR TITLE
fix(www): get started button

### DIFF
--- a/www/components/Hero.tsx
+++ b/www/components/Hero.tsx
@@ -57,7 +57,6 @@ export default function Hero() {
               <ExternalLink
                 className="rounded bg-brand-900 py-3 px-8 font-bold text-white transition hover:bg-brand-700"
                 href={SHUTTLE_DOCS_URL}
-                target="_self"
               >
                 Get Started
               </ExternalLink>


### PR DESCRIPTION
This opens the docs in a new tab when clicking `Get Started`. It's a bit jarring, but the krunchdata script seems to block links with `target="_self"`.