### PR TITLE
feat: support release profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4907,8 +4907,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.0",
- "cargo",
- "cargo-util",
  "chrono",
  "clap",
  "env_logger",
@@ -4961,6 +4959,7 @@ dependencies = [
  "rustrict",
  "semver 1.0.13",
  "serde",
+ "serde_json",
  "uuid 1.1.2",
 ]
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,8 +8,6 @@ publish = false
 anyhow = "1.0.62"
 async-trait = "0.1.57"
 base64 = "0.13.0"
-cargo = "0.64.0"
-cargo-util = "0.2.1"
 chrono = "0.4.22"
 clap = { version = "3.2.17", features = ["derive"] }
 env_logger = "0.9.0"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -24,7 +24,7 @@ use factory::ShuttleFactory;
 use rocket::serde::json::Json;
 use rocket::{tokio, Build, Data, Rocket, State};
 use shuttle_common::project::ProjectName;
-use shuttle_common::{DeploymentApiError, DeploymentMeta, Port};
+use shuttle_common::{BuildConfig, DeploymentApiError, DeploymentMeta, Port};
 use shuttle_service::SecretStore;
 use uuid::Uuid;
 
@@ -118,6 +118,7 @@ async fn create_project(
     crate_file: Data<'_>,
     project_name: ProjectName,
     user: User,
+    build_config: BuildConfig
 ) -> ApiResult<DeploymentMeta, DeploymentApiError> {
     info!("[CREATE_PROJECT, {}, {}]", &user.name, &project_name);
 
@@ -130,7 +131,7 @@ async fn create_project(
     }
     let deployment = state
         .deployment_manager
-        .deploy(crate_file, project_name)
+        .deploy(crate_file, project_name, build_config)
         .await?;
     Ok(Json(deployment))
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -86,6 +86,9 @@ pub struct DeployArgs {
     /// allows pre-deploy tests to be skipped
     #[clap(long)]
     pub no_test: bool,
+    /// builds artifacts in release mode with optimizations
+    #[clap(long)]
+    pub release: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -187,7 +187,7 @@ impl Shuttle {
             working_directory.display()
         );
 
-        let so_path = build_crate(working_directory, buf, BuildProfile::Debug)?;
+        let so_path = build_crate(working_directory, buf, &BuildProfile::Debug)?;
         let loader = Loader::from_so_file(so_path)?;
 
         let mut factory = LocalFactory::new(self.ctx.project_name().clone())?;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -18,4 +18,5 @@ rocket = "0.5.0-rc.2"
 rustrict = "0.5.0"
 semver = "1.0.13"
 serde = "1.0.137"
+serde_json = "1.0.85"
 uuid = { version = "1.1.1", features = ["v4", "serde"] }

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -10,6 +10,7 @@ use cargo::core::{Shell, Verbosity, Workspace};
 use cargo::ops::{compile, CompileOptions};
 use cargo::util::homedir;
 use cargo::Config;
+use cargo::util::interning::InternedString;
 use libloading::{Library, Symbol};
 use log::trace;
 use shuttle_common::{BuildProfile, DeploymentId};
@@ -154,7 +155,19 @@ pub fn build_crate(project_path: &Path, buf: Box<dyn std::io::Write>, build_prof
         }
     }
 
-    let opts = CompileOptions::new(&config, CompileMode::Build)?;
+
+
+    let mut opts = CompileOptions::new(&config, CompileMode::Build)?;
+
+    match build_profile {
+        BuildProfile::Debug => {
+            opts.build_config.requested_profile = InternedString::new("dev");
+        }
+        BuildProfile::Release => {
+            opts.build_config.requested_profile = InternedString::new("release");
+        }
+    }
+
     let compilation = compile(&ws, &opts)?;
 
     Ok(compilation.cdylibs[0].path.clone())

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -12,7 +12,7 @@ use cargo::util::homedir;
 use cargo::Config;
 use libloading::{Library, Symbol};
 use log::trace;
-use shuttle_common::DeploymentId;
+use shuttle_common::{BuildProfile, DeploymentId};
 use thiserror::Error as ThisError;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -101,7 +101,7 @@ impl Loader {
 }
 
 /// Given a project directory path, builds the crate
-pub fn build_crate(project_path: &Path, buf: Box<dyn std::io::Write>) -> anyhow::Result<PathBuf> {
+pub fn build_crate(project_path: &Path, buf: Box<dyn std::io::Write>, build_profile: &BuildProfile) -> anyhow::Result<PathBuf> {
     let mut shell = Shell::from_write(buf);
     shell.set_verbosity(Verbosity::Normal);
 
@@ -114,7 +114,9 @@ pub fn build_crate(project_path: &Path, buf: Box<dyn std::io::Write>) -> anyhow:
         )
     })?;
 
-    let config = Config::new(shell, cwd, homedir);
+    let mut config = Config::new(shell, cwd, homedir);
+
+
     let manifest_path = project_path.join("Cargo.toml");
 
     let mut ws = Workspace::new(&manifest_path, &config)?;


### PR DESCRIPTION
We now support building in release mode:

Defaults to building with the `dev` profile (debug mode):
```bash
cargo shuttle deploy
```

optionally deploy with a release profile:
```bash
cargo shuttle deploy --release
```

`cargo shuttle run` has no option for `--release` currently and only builds with the `dev` profile.

Also introduced a new HTTP header to the API called `BuildConfig` with the idea that it is an extensible DTO for sending build configurations from the client to the server.

Closes #346.