### PR TITLE
feat(cargo-shuttle): better error messages

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -396,9 +396,9 @@ impl Shuttle {
     }
 
     async fn project_delete(&self, client: &Client) -> Result<()> {
-        client.delete_project(self.ctx.project_name()).await?;
+        let project = client.delete_project(self.ctx.project_name()).await?;
 
-        println!("Project has been deleted");
+        println!("{project}");
 
         Ok(())
     }

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -1,0 +1,16 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ApiError {
+    pub message: String,
+}
+
+impl Display for ApiError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ApiError {}

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod deployment;
+pub mod error;
 pub mod project;
 pub mod resource;
 pub mod secret;

--- a/deployer/src/handlers/error.rs
+++ b/deployer/src/handlers/error.rs
@@ -5,7 +5,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 
 use serde::{ser::SerializeMap, Serialize};
-use serde_json::json;
+use shuttle_common::models::error::ApiError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -47,7 +47,9 @@ impl IntoResponse for Error {
                 header::CONTENT_TYPE,
                 HeaderValue::from_static("application/json"),
             )],
-            Json(json!({ "message": self })),
+            Json(ApiError {
+                message: self.to_string(),
+            }),
         )
             .into_response()
     }

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -103,10 +103,16 @@ async fn delete_project(
         user: User { name, .. },
     }: ScopedUser,
     Path(project): Path<ProjectName>,
-) -> Result<(), Error> {
+) -> Result<AxumJson<project::Response>, Error> {
     let work = service.destroy_project(project, name).await?;
 
-    sender.send(work).await.map_err(Error::from)
+    let name = work.project_name.to_string();
+    let state = work.work.clone().into();
+
+    sender.send(work).await?;
+
+    let response = project::Response { name, state };
+    Ok(AxumJson(response))
 }
 
 async fn route_project(

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -17,7 +17,7 @@ use futures::prelude::*;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::json;
+use shuttle_common::models::error::ApiError;
 use tokio::sync::mpsc::error::SendError;
 use tracing::error;
 
@@ -141,7 +141,13 @@ impl IntoResponse for Error {
             ErrorKind::Forbidden => (StatusCode::FORBIDDEN, "forbidden"),
             ErrorKind::NotReady => (StatusCode::INTERNAL_SERVER_ERROR, "service not ready"),
         };
-        (status, Json(json!({ "error": error_message }))).into_response()
+        (
+            status,
+            Json(ApiError {
+                message: error_message.to_string(),
+            }),
+        )
+            .into_response()
     }
 }
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -582,8 +582,11 @@ pub mod tests {
 
             let provisioner_host = "provisioner".to_string();
 
+            let docker_host = "/var/run/docker.sock".to_string();
+
             let args = StartArgs {
                 control,
+                docker_host,
                 user,
                 image,
                 prefix,


### PR DESCRIPTION
Return an error message that is more relevant to the user than "failed to parse response to json" on non-200 responses.

Note: this is a simple and quick solution. We may want to refactor the errors sent from deployer/gateway to hold more information about what happened, so we can also suggest a solution when returning the error to the user.