### PR TITLE
feat(0.6.0): update cargo shuttle init generated code

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -139,7 +139,7 @@ pub struct InitArgs {
     /// Initialize with axum framework
     #[clap(long, conflicts_with_all = &["rocket", "tide", "tower", "poem", "serenity", "salvo"])]
     pub axum: bool,
-    /// Initialize with actix-web framework
+    /// Initialize with rocket framework
     #[clap(long, conflicts_with_all = &["axum", "tide", "tower", "poem", "serenity", "salvo"])]
     pub rocket: bool,
     /// Initialize with tide framework


### PR DESCRIPTION
Update `cargo shuttle init` generated code to match the new features in `0.6.0`.