### PR TITLE
fix(cargo-shuttle): prevent crash when config owned by root

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -37,16 +37,10 @@ pub struct Shuttle {
     ctx: RequestContext,
 }
 
-impl Default for Shuttle {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl Shuttle {
-    pub fn new() -> Self {
-        let ctx = RequestContext::load_global().unwrap();
-        Self { ctx }
+    pub fn new() -> Result<Self> {
+        let ctx = RequestContext::load_global()?;
+        Ok(Self { ctx })
     }
 
     pub async fn run(mut self, mut args: Args) -> Result<CommandOutcome> {
@@ -479,7 +473,7 @@ mod tests {
             name: None,
         };
 
-        let mut shuttle = Shuttle::new();
+        let mut shuttle = Shuttle::new().unwrap();
         Shuttle::load_project(&mut shuttle, &mut project_args).unwrap();
 
         assert_eq!(

--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let result = Shuttle::new().run(Args::parse()).await;
+    let result = Shuttle::new()?.run(Args::parse()).await;
 
     if matches!(result, Ok(CommandOutcome::DeploymentFailure)) {
         // Deployment failure results in a shell error exit code being returned (this allows

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -12,6 +12,7 @@ async fn cargo_shuttle_init(path: PathBuf) -> anyhow::Result<CommandOutcome> {
     let working_directory = Path::new(".").to_path_buf();
 
     Shuttle::new()
+        .unwrap()
         .run(Args {
             api_url: Some("http://shuttle.invalid:80".to_string()),
             project_args: ProjectArgs {
@@ -39,6 +40,7 @@ async fn cargo_shuttle_init_framework(path: PathBuf) -> anyhow::Result<CommandOu
     let working_directory = Path::new(".").to_path_buf();
 
     Shuttle::new()
+        .unwrap()
         .run(Args {
             api_url: Some("http://shuttle.invalid:80".to_string()),
             project_args: ProjectArgs {

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -12,6 +12,7 @@ async fn cargo_shuttle_command(
     let working_directory = Path::new(working_directory).to_path_buf();
 
     Shuttle::new()
+        .unwrap()
         .run(Args {
             api_url: Some("http://shuttle.invalid:80".to_string()),
             project_args: ProjectArgs {

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -10,7 +10,7 @@ async fn cargo_shuttle_run(working_directory: &str) -> u16 {
     let port = pick_unused_port().unwrap();
     let run_args = RunArgs { port };
 
-    let runner = Shuttle::new().run(Args {
+    let runner = Shuttle::new().unwrap().run(Args {
         api_url: Some("http://shuttle.invalid:80".to_string()),
         project_args: ProjectArgs {
             working_directory: working_directory.clone(),


### PR DESCRIPTION
Uses `anyhow` contexts to propagate errors. Also removed `Default` implementation as it wasn't used anywhere, and it feels like replacing it with `Self::new().unwrap()` defeats the purpose of propagating the error(s).