### PR TITLE
feat(deployer): implement container memory limits

### DIFF
--- a/examples/warp/hello-world/src/lib.rs
+++ b/examples/warp/hello-world/src/lib.rs
@@ -3,6 +3,6 @@ use warp::Reply;
 
 #[shuttle_service::main]
 async fn warp() -> shuttle_service::ShuttleWarp<(impl Reply,)> {
-    let route = warp::any().map(|| "Hello, World");
+    let route = warp::any().map(|| "Hello, World!");
     Ok(route.boxed())
 }

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -387,7 +387,9 @@ impl ProjectCreating {
                 "Target": "/opt/shuttle",
                 "Source": format!("{prefix}{project_name}_vol"),
                 "Type": "volume"
-            }]
+            }],
+            "Memory": 6442450000i64, // 6 GiB hard limit
+            "MemoryReservation": 4295000000i64, // 4 GiB soft limit, applied if host is low on memory
         });
 
         debug!(


### PR DESCRIPTION
Impose memory limits on deployer containers. The hard limit is set at 6GiB, but if low memory is detected on the host a 4GiB limit will be applied. If a container hits the limit it will be killed (signal: 9, SIGKILL).