### PR TITLE
bug: `transport error` when trying to connect to provisioner

### DIFF
--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -452,15 +452,17 @@ mod tests {
 
     struct StubAbstractProvisionerFactory;
 
+    #[async_trait::async_trait]
     impl provisioner_factory::AbstractFactory for StubAbstractProvisionerFactory {
         type Output = StubProvisionerFactory;
+        type Error = std::io::Error;
 
-        fn get_factory(
+        async fn get_factory(
             &self,
             _project_name: shuttle_common::project::ProjectName,
             _service_id: Uuid,
-        ) -> Self::Output {
-            StubProvisionerFactory
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(StubProvisionerFactory)
         }
     }
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -62,7 +62,16 @@ pub async fn task(
                 continue;
             }
         };
-        let mut factory = abstract_factory.get_factory(service_name, built.service_id);
+        let mut factory = match abstract_factory
+            .get_factory(service_name, built.service_id)
+            .await
+        {
+            Ok(factory) => factory,
+            Err(err) => {
+                start_crashed_cleanup(&id, err);
+                continue;
+            }
+        };
         let logger = logger_factory.get_logger(id);
 
         let old_deployments_killer = kill_old_deployments(

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -3,7 +3,6 @@ use shuttle_deployer::{
     start, start_proxy, AbstractProvisionerFactory, Args, DeployLayer, Persistence,
     RuntimeLoggerFactory,
 };
-use shuttle_proto::provisioner::provisioner_client::ProvisionerClient;
 use tokio::select;
 use tonic::transport::Endpoint;
 use tracing::trace;
@@ -43,15 +42,8 @@ async fn main() {
     ))
     .expect("provisioner uri is not valid");
 
-    let provisioner_client = ProvisionerClient::connect(provisioner_uri)
-        .await
-        .expect("failed to connect to provisioner");
-
-    let abstract_factory = AbstractProvisionerFactory::new(
-        provisioner_client,
-        persistence.clone(),
-        persistence.clone(),
-    );
+    let abstract_factory =
+        AbstractProvisionerFactory::new(provisioner_uri, persistence.clone(), persistence.clone());
 
     let runtime_logger_factory = RuntimeLoggerFactory::new(persistence.get_log_sender());
 

--- a/provisioner/src/main.rs
+++ b/provisioner/src/main.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use clap::Parser;
 use shuttle_provisioner::{Args, MyProvisioner, ProvisionerServer};
@@ -31,6 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("starting provisioner on {}", addr);
     Server::builder()
+        .http2_keepalive_interval(Some(Duration::from_secs(30))) // Prevent deployer clients from loosing connection #ENG-219
         .add_service(ProvisionerServer::new(provisioner))
         .serve(addr)
         .await?;


### PR DESCRIPTION
This PR ensures the connection to provisioner stays alive, but also ensures the connection is shorter lived by only creating to connection when a deployment needs the factory