### PR TITLE
Fix windows UNC paths and fix gateway complie error.

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -183,6 +183,25 @@ pub struct InitArgs {
 
 // Helper function to parse and return the absolute path
 fn parse_path(path: &OsStr) -> Result<PathBuf, io::Error> {
+    #[cfg(target_os = "windows")]
+    {
+        let p = PathBuf::try_from(path).map_err(|e| {
+            io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("could not turn {path:?} into a real path: {e}"),
+            )
+        })?;
+        
+        std::env::current_dir().map_err(|e| {
+            io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("could not get current working dir: {e}"),
+            )         
+        })?;
+        Ok(p)
+    }
+
+    #[cfg(target_os = "unix")]
     canonicalize(path).map_err(|e| {
         io::Error::new(
             ErrorKind::InvalidInput,

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -192,7 +192,7 @@ impl GatewayService {
     /// * `args` - The [`Args`] with which the service was
     /// started. Will be passed as [`Context`] to workers and state.
     pub async fn init(args: ContextArgs, db: SqlitePool) -> Self {
-        let docker = Docker::connect_with_unix(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
+        let docker = Docker::connect_with_local(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
 
         let container_settings = ContainerSettings::builder(&docker).from_args(&args).await;
 


### PR DESCRIPTION
Two very small fixes which makes life easier:

1. Gateway service compile error: Since Shuttle is Docker and Linux first oriented project, Shuttle gateway service uses Docker linux-first functions which defined through conditional compiling by cfg. This is the issue under windows, since you have to cut out project member from compilation by hand. 
**Replacing Docker::connect_with_unix** with **Docker::connect_with_local** does the same thing as before for unix but allows to be compiled under windows, for cases where if you want to complie Shuttle-CLI or work with other non-server stuff.

2. Fixes (partially) Windows paths for cargo-shuttle deployer. Since Rust tries to support new Windows UNC paths, which are new and compatibility breaking, this support isnt perfect and rust has some bugs with it. As the example - cargo package may break the package on git initialized project and generate instead of working package - package filled with zeros only because of UNC path. 
This simple and small commit should fix at least for now the issue. 