### PR TITLE
misc: add more helpful flags to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ deploy: docker-compose.yml
 test:
 	cd e2e; POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) APPS_FQDN=$(APPS_FQDN) cargo test $(CARGO_TEST_FLAGS) -- --nocapture
 
-up: docker-compose.rendered.yml images
-	CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) $(DOCKER_COMPOSE) -f $< -p $(STACK) up -d
+up: docker-compose.rendered.yml
+	CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) $(DOCKER_COMPOSE) -f $< -p $(STACK) up -d $(DOCKER_COMPOSE_FLAGS)
 
 down: docker-compose.rendered.yml
-	CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) $(DOCKER_COMPOSE) -f $< -p $(STACK) down
+	CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) $(DOCKER_COMPOSE) -f $< -p $(STACK) down $(DOCKER_COMPOSE_FLAGS)
 
 shuttle-%: ${SRC} Cargo.lock
 	docker buildx build \


### PR DESCRIPTION
And do not run "images" target when targeting "up". 

On my end, this still triggers a build of the images initially, unless when `DOCKER_COMPOSE_FLAGS=--no-build` is set, which matches the [documented behavior](https://docs.docker.com/engine/reference/commandline/compose_up/#description). Contributing guidelines also make it clear you want to run `make images` first in order to sync up images with their most recent versions, and the CircleCI workflows that do `make up` and `make test` also run `make images` prior. So this should not require changing anything else.