### PR TITLE
WIP feat: count recent start events before restart

### DIFF
--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -200,7 +200,7 @@ pub fn make_api(service: Arc<GatewayService>, sender: Sender<BoxedTask>) -> Rout
                 })
                 .on_response(
                     |response: &Response<BoxBody>, latency: Duration, span: &Span| {
-                        span.record("http.status_code", &response.status().as_u16());
+                        span.record("http.status_code", response.status().as_u16());
                         debug!(latency = format_args!("{} ns", latency.as_nanos()), "finished processing request");
                     },
                 ),

--- a/gateway/src/custom_domain.rs
+++ b/gateway/src/custom_domain.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CustomDomain {
     // TODO: update custom domain states, these are just placeholders for now

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -711,7 +711,7 @@ where
             .try_collect::<Vec<_>>()
             .await?;
 
-        let start_event_count = start_events.iter().count();
+        let start_event_count = start_events.len();
         debug!(
             "project started {} times in the last 15 minutes",
             start_event_count

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -86,7 +86,7 @@ impl Service<Request<Body>> for ProxyService {
                 let (parts, body) = proxy.into_parts();
                 let body = <Body as HttpBody>::map_err(body, axum::Error::new).boxed_unsync();
 
-                span.record("http.status_code", &parts.status.as_u16());
+                span.record("http.status_code", parts.status.as_u16());
 
                 Ok(Response::from_parts(parts, body))
             }

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -372,8 +372,8 @@ impl GatewayService {
         permissions: &Permissions,
     ) -> Result<(), Error> {
         query("UPDATE accounts SET super_user = ?1, account_tier = ?2 WHERE account_name = ?3")
-            .bind(&permissions.super_user)
-            .bind(&permissions.tier)
+            .bind(permissions.super_user)
+            .bind(permissions.tier)
             .bind(account_name)
             .execute(&self.db)
             .await?;


### PR DESCRIPTION
Count recent start events before restarting a stopped container, to prevent it from looping restarts indefinitely.

I tested that it does indeed not attempt to start if it has started 3 times in the last 15 minutes.