### PR TITLE
feat: verify project exists before sending destroy task

### DIFF
--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -366,6 +366,15 @@ pub mod tests {
             .await
             .unwrap();
 
+        // delete returns 404 for project that doesn't exist
+        router
+            .call(delete_project("resurrections").with_header(&authorization))
+            .map_ok(|resp| {
+                assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            })
+            .await
+            .unwrap();
+
         Ok(())
     }
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -893,5 +893,22 @@ pub mod tests {
                 break;
             }
         });
+
+        // Attempting to delete already Destroyed project will return Destroyed
+        api_client
+            .request(
+                Request::delete("/projects/matrix")
+                    .with_header(&authorization)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .map_ok(|resp| {
+                assert_eq!(resp.status(), StatusCode::OK);
+                let resp =
+                    serde_json::from_slice::<project::Response>(resp.body().as_slice()).unwrap();
+                assert_eq!(resp.state, project::State::Destroyed);
+            })
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
This is a quick fix to the issue of `cargo project rm` always returning `destroying`. Draft while I look into improving cli feedback.