### PR TITLE
Don't specify tokio version in shuttle_service

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -31,7 +31,7 @@ sync_wrapper = { version = "0.1.1", optional = true }
 thiserror = "1.0.32"
 thruster = { version = "1.2.6", optional = true }
 tide = { version = "0.16.0", optional = true }
-tokio = { version = "=1.20.1", features = ["rt", "rt-multi-thread", "sync"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = "0.1.36"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }


### PR DESCRIPTION
It will prevent other packages depending on a newer version of tokio from building.