### PR TITLE
bug: deployer freezes

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -266,7 +266,7 @@ impl Shuttle {
         trace!("starting a local run for a service: {run_args:?}");
 
         let (tx, rx): (crossbeam_channel::Sender<Message>, _) = crossbeam_channel::bounded(0);
-        tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
             while let Ok(message) = rx.recv() {
                 match message {
                     Message::TextLine(line) => println!("{line}"),
@@ -332,7 +332,7 @@ impl Shuttle {
 
         handle.await??;
 
-        tokio::spawn(async move {
+        tokio::task::spawn_blocking(move || {
             trace!("closing so file");
             so.close().unwrap();
         });

--- a/deployer/src/persistence/log.rs
+++ b/deployer/src/persistence/log.rs
@@ -107,7 +107,6 @@ fn extract_message(fields: &Value) -> Option<String> {
                         return Some(rendered.as_str()?.to_string());
                     }
                 }
-                Value::String(mes_str) => return Some(mes_str.to_string()),
                 _ => {}
             }
         }


### PR DESCRIPTION
Reduce freezes in deployer by spawning less. This reduces complete lockups by deployer and makes deployer responsive to API calls during build jobs

Closes ENG-274