### PR TITLE
Feat(shuttle-next): stop runtime services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,15 @@ commands:
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             sudo apt update && sudo apt install -y libssl1.1
+  install-protoc:
+    steps:
+      - run:
+          name: Install protoc
+          command: |
+            curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip &&\
+              sudo unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
+              sudo unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
+              rm -f protoc-21.9-linux-x86_64.zip
 
 jobs:
   workspace-fmt:
@@ -104,7 +113,7 @@ jobs:
     steps:
       - checkout
       - restore-cargo-cache
-      - run: sudo apt install -y protobuf-compiler
+      - install-protoc
       - run: cargo fmt --all --check
       - run: cargo install cargo-sort
       - run: cargo sort --check --workspace
@@ -119,7 +128,7 @@ jobs:
     steps:
       - checkout
       - restore-cargo-cache
-      - run: sudo apt install -y protobuf-compiler
+      - install-protoc
       - run: |
           cargo clippy --tests \
                        --all-targets \
@@ -138,7 +147,7 @@ jobs:
     steps:
       - checkout
       - restore-cargo-cache
-      - run: sudo apt install -y protobuf-compiler
+      - install-protoc
       - apply-patches
       - run: cargo fmt --all --check --manifest-path << parameters.path >>/Cargo.toml
       - run: cargo install cargo-sort

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,12 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 FROM rust:1.63.0-buster as shuttle-build
 RUN apt-get update &&\
-    apt-get install -y curl protobuf-compiler
+    apt-get install -y curl
+
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip &&\
+    unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
+    unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
+    rm -f protoc-21.9-linux-x86_64.zip
 RUN cargo install cargo-chef
 WORKDIR /build
 
@@ -36,6 +41,7 @@ shuttle-service = { path = "/usr/src/shuttle/service" } \n\
 shuttle-aws-rds = { path = "/usr/src/shuttle/resources/aws-rds" } \n\
 shuttle-persist = { path = "/usr/src/shuttle/resources/persist" } \n\
 shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" } \n\
+shuttle-proto = { path = "proto" } \n\
 shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }' > $CARGO_HOME/config.toml
 COPY --from=builder /build/target/debug/${crate} /usr/local/bin/service
 ENTRYPOINT ["/usr/local/bin/service"]

--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,7 @@
 FROM rust:1.63.0-buster as shuttle-build
 RUN apt-get update &&\
     apt-get install -y curl
-
+# download protoc binary and unzip it in usr/bin
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip &&\
     unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
     unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
@@ -41,7 +41,6 @@ shuttle-service = { path = "/usr/src/shuttle/service" } \n\
 shuttle-aws-rds = { path = "/usr/src/shuttle/resources/aws-rds" } \n\
 shuttle-persist = { path = "/usr/src/shuttle/resources/persist" } \n\
 shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" } \n\
-shuttle-proto = { path = "proto" } \n\
 shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }' > $CARGO_HOME/config.toml
 COPY --from=builder /build/target/debug/${crate} /usr/local/bin/service
 ENTRYPOINT ["/usr/local/bin/service"]

--- a/common/src/wasm.rs
+++ b/common/src/wasm.rs
@@ -115,7 +115,7 @@ mod test {
             .method(Method::PUT)
             .version(Version::HTTP_11)
             .header("test", HeaderValue::from_static("request"))
-            .uri(format!("https://axum-wasm.example/hello"))
+            .uri("https://axum-wasm.example/hello")
             .body(Body::empty())
             .unwrap();
 

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -380,7 +380,7 @@ ff0e55bda1ff01000000000000000000e0079c01ff12a55500280000",
         )
         .unwrap();
 
-        super::extract_tar_gz_data(test_data.as_slice(), &p).unwrap();
+        super::extract_tar_gz_data(test_data.as_slice(), p).unwrap();
         assert!(fs::read_to_string(p.join("world.txt"))
             .await
             .unwrap()
@@ -391,7 +391,7 @@ ff0e55bda1ff01000000000000000000e0079c01ff12a55500280000",
             .starts_with("def"));
 
         // Can we extract again without error?
-        super::extract_tar_gz_data(test_data.as_slice(), &p).unwrap();
+        super::extract_tar_gz_data(test_data.as_slice(), p).unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -63,7 +63,7 @@ pub fn make_router(
                 })
                 .on_response(
                     |response: &Response<BoxBody>, latency: Duration, span: &Span| {
-                        span.record("http.status_code", &response.status().as_u16());
+                        span.record("http.status_code", response.status().as_u16());
                         debug!(latency = format_args!("{} ns", latency.as_nanos()), "finished processing request");
                     },
                 ),

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -46,7 +46,7 @@ async fn main() {
     let runtime_dir = workspace_root.join("target/debug");
 
     let mut runtime = tokio::process::Command::new(runtime_dir.join("shuttle-runtime"))
-        .args(&[
+        .args([
             "--legacy",
             "--provisioner-address",
             "https://localhost:5000",

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -352,7 +352,7 @@ impl ResourceRecorder for Persistence {
 
     async fn insert_resource(&self, resource: &Resource) -> Result<()> {
         sqlx::query("INSERT OR REPLACE INTO resources (service_id, type, data) VALUES (?, ?, ?)")
-            .bind(&resource.service_id)
+            .bind(resource.service_id)
             .bind(resource.r#type)
             .bind(&resource.data)
             .execute(&self.pool)
@@ -965,19 +965,19 @@ mod tests {
         )
         // This running item should match
         .bind(Uuid::new_v4())
-        .bind(&service_id)
+        .bind(service_id)
         .bind(State::Running)
         .bind(Utc::now())
         .bind("10.0.0.5:12356")
         // A stopped item should not match
         .bind(Uuid::new_v4())
-        .bind(&service_id)
+        .bind(service_id)
         .bind(State::Stopped)
         .bind(Utc::now())
         .bind("10.0.0.5:9876")
         // Another service should not match
         .bind(Uuid::new_v4())
-        .bind(&service_other_id)
+        .bind(service_other_id)
         .bind(State::Running)
         .bind(Utc::now())
         .bind("10.0.0.5:5678")
@@ -1053,8 +1053,8 @@ mod tests {
         sqlx::query(
             "INSERT INTO deployments (id, service_id, state, last_update) VALUES (?, ?, ?, ?)",
         )
-        .bind(&deployment_id)
-        .bind(&service_id)
+        .bind(deployment_id)
+        .bind(service_id)
         .bind(State::Running)
         .bind(Utc::now())
         .execute(pool)
@@ -1071,7 +1071,7 @@ mod tests {
         let service_id = Uuid::new_v4();
 
         sqlx::query("INSERT INTO services (id, name) VALUES (?, ?)")
-            .bind(&service_id)
+            .bind(service_id)
             .bind(name)
             .execute(pool)
             .await?;

--- a/deployer/src/proxy.rs
+++ b/deployer/src/proxy.rs
@@ -48,7 +48,7 @@ pub async fn handle(
     };
 
     // Record current service for tracing purposes
-    Span::current().record("service", &service);
+    Span::current().record("service", service);
 
     let proxy_address = match address_getter.get_address_for_service(service).await {
         Ok(Some(address)) => address,
@@ -73,7 +73,7 @@ pub async fn handle(
 
     match reverse_proxy(remote_address.ip(), &proxy_address.to_string(), req).await {
         Ok(response) => {
-            Span::current().record("http.status_code", &response.status().as_u16());
+            Span::current().record("http.status_code", response.status().as_u16());
             Ok(response)
         }
         Err(error) => {

--- a/examples/rocket/hello-world/Cargo.toml
+++ b/examples/rocket/hello-world/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
+crate-type = ["cdylib"]
 
 [dependencies]
 rocket = "0.5.0-rc.2"

--- a/examples/rocket/hello-world/Cargo.toml
+++ b/examples/rocket/hello-world/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
 
 [dependencies]
 rocket = "0.5.0-rc.2"

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -162,7 +162,7 @@ pub fn make_api(service: Arc<GatewayService>, sender: Sender<Work>) -> Router<Bo
                 })
                 .on_response(
                     |response: &Response<BoxBody>, latency: Duration, span: &Span| {
-                        span.record("http.status_code", &response.status().as_u16());
+                        span.record("http.status_code", response.status().as_u16());
                         debug!(latency = format_args!("{} ns", latency.as_nanos()), "finished processing request");
                     },
                 ),

--- a/proto/runtime.proto
+++ b/proto/runtime.proto
@@ -10,7 +10,7 @@ service Runtime {
   // Start a loaded service file
   rpc Start(StartRequest) returns (StartResponse);
   
-  // Stop a started service file
+  // Stop a started service
   rpc Stop(StopRequest) returns (StopResponse);
 
   rpc SubscribeLogs(SubscribeLogsRequest) returns (stream LogItem);
@@ -49,7 +49,7 @@ message StartResponse {
 message StopRequest {
   // Id to associate with the deployment being stopped
   bytes deployment_id = 1;
-  // Name of service to start
+  // Name of service to stop
   string service_name = 2;
 }
 

--- a/proto/runtime.proto
+++ b/proto/runtime.proto
@@ -9,6 +9,9 @@ service Runtime {
 
   // Start a loaded service file
   rpc Start(StartRequest) returns (StartResponse);
+  
+  // Stop a started service file
+  rpc Stop(StopRequest) returns (StopResponse);
 
   rpc SubscribeLogs(SubscribeLogsRequest) returns (stream LogItem);
 }
@@ -41,6 +44,18 @@ message StartResponse {
   // Optional port the service was started on
   // This is likely to be None for bots
   uint32 port = 2;
+}
+
+message StopRequest {
+  // Id to associate with the deployment being stopped
+  bytes deployment_id = 1;
+  // Name of service to start
+  string service_name = 2;
+}
+
+message StopResponse {
+  // Was the stop successful
+  bool success = 1;
 }
 
 message SubscribeLogsRequest {}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -27,6 +27,7 @@ wasmtime-wasi = "2.0.0"
 [dependencies.shuttle-common]
 version = "0.7.0"
 path = "../common"
+features = ["axum-wasm"]
 
 [dependencies.shuttle-proto]
 version = "0.7.0"
@@ -37,7 +38,3 @@ version = "0.7.0"
 default-features = false
 features = ["loader"]
 path = "../service"
-
-[features]
-shuttle-axum = ["shuttle-common/axum-wasm"]
-

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,17 +1,17 @@
-.PHONY: wasm next
+.PHONY: axum serenity
 
-all: wasm next
-
-wasm:
-	cd ../tmp/wasm; cargo build --target wasm32-wasi
-	cp ../tmp/wasm/target/wasm32-wasi/debug/shuttle_serenity.wasm bot.wasm
+all: axum serenity
 
 axum:
 	cd ../tmp/axum-wasm; cargo build --target wasm32-wasi
 	cp ../tmp/axum-wasm/target/wasm32-wasi/debug/shuttle_axum.wasm axum.wasm
 
-test: wasm
-	cargo test -- --nocapture
+serenity:
+	cd ../tmp/wasm; cargo build --target wasm32-wasi
+	cp ../tmp/wasm/target/wasm32-wasi/debug/shuttle_serenity.wasm serenity.wasm
+
+test: serenity axum
+	cargo test --all-features -- --nocapture
 
 runtime:
 	cargo build

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -79,9 +79,17 @@ Pass the path to `deployer::start`
 Then in another shell, load a `.so` file and start it up:
 
 ``` bash
+# load
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "examples/rocket/hello-world/target/debug/libhello_world.so"}' localhost:6001 runtime.Runtime/Load
+
+# run
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Start
+
+# subscribe to logs
 grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs
+
+# stop
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Stop
 ```
 
 ## Running the tests

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -15,7 +15,7 @@ make serenity
 Run the test:
 
 ```bash
-cargo test serenity --features shuttle-axum -- --nocapture
+cargo test serenity -- --nocapture
 
 # or, run tests for both axum and serenity:
 make test
@@ -54,7 +54,7 @@ make axum
 Run the test:
 
 ```bash
-cargo test axum --features shuttle-axum -- --nocapture
+cargo test axum -- --nocapture
 
 # or, run tests for both axum and serenity:
 make test
@@ -63,7 +63,7 @@ make test
 Load and run:
 
 ```bash
-cargo run --features shuttle-axum -- --axum --provisioner-address http://localhost:5000
+cargo run -- --axum --provisioner-address http://localhost:5000
 ```
 
 In another terminal:

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -13,9 +13,17 @@ $ DISCORD_TOKEN=xxx cargo run
 In another terminal:
 
 ``` bash
+# load wasm module
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "runtime/bot.wasm"}' localhost:6001 runtime.Runtime/Load
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Start
+
+# start bot (the deployment ID is needed in the StartRequest, but it isn't used by the serenity bot currently)
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Start
+
+# subscribe to logs (unimplemented)
 grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs
+
+# stop (the deployment ID is needed in the StopRequest, but it isn't used by the serenity bot currently)
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Stop
 ```
 
 ## axum-wasm
@@ -41,12 +49,14 @@ cargo run --features shuttle-axum -- --axum --provisioner-address http://localho
 In another terminal:
 
 ``` bash
-# a full, absolute path from home was needed for me in the load request
+# load (a full, absolute path from home was needed for me in the load request)
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "runtime/axum.wasm"}' localhost:6001 runtime.Runtime/Load
 
+# start
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Start
 
-# grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs
+# subscribe to logs (unimplemented)
+grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs
 ```
 
 Curl the service:

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,5 +1,9 @@
 # How to run
 
+## serenity-wasm
+
+Build and run:
+
 ## shuttle-next
 ```bash
 $ make wasm
@@ -51,6 +55,7 @@ curl  localhost:7002/hello
 
 curl  localhost:7002/goodbye
 ```
+
 ## shuttle-legacy
 
 Load and run an .so library that implements `shuttle_service::Service`. 
@@ -64,7 +69,7 @@ docker-compose -f docker-compose.rendered.yml up provisioner
 Then in another shell, start the runtime using the clap CLI:
 
 ```bash
-cargo run -- --legacy --provisioner-address http://localhost:8000
+cargo run -- --legacy --provisioner-address http://localhost:5000
 ```
 
 Or directly (this is the path hardcoded in `deployer::start`):
@@ -72,7 +77,7 @@ Or directly (this is the path hardcoded in `deployer::start`):
 # first, make sure the shuttle-runtime binary is built
 cargo build
 # then
-/home/<path to shuttle repo>/target/debug/shuttle-runtime --legacy --provisioner-address http://localhost:6001
+/home/<path to shuttle repo>/target/debug/shuttle-runtime --legacy --provisioner-address http://localhost:5000
 ```
 
 Pass the path to `deployer::start`
@@ -83,13 +88,12 @@ Then in another shell, load a `.so` file and start it up:
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "examples/rocket/hello-world/target/debug/libhello_world.so"}' localhost:6001 runtime.Runtime/Load
 
 # run (this deployment id is default uuid encoded as base64)
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runti
-me.Runtime/Start
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Start
 
 # subscribe to logs
 grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs
 
-# stop
+# stop (the service started in the legacy runtime can't currently be stopped)
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Stop
 ```
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -5,16 +5,33 @@
 Build and run:
 
 ## shuttle-next
+
+Compile the shuttle-next serenity runtime:
+
 ```bash
-$ make wasm
-$ DISCORD_TOKEN=xxx cargo run
+make serenity
+```
+
+Run the test:
+
+```bash
+cargo test serenity --features shuttle-axum -- --nocapture
+
+# or, run tests for both axum and serenity:
+make test
+```
+
+Start the shuttle-next runtime:
+
+```bash
+DISCORD_TOKEN=xxx cargo run
 ```
 
 In another terminal:
 
 ``` bash
 # load wasm module
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "runtime/bot.wasm"}' localhost:6001 runtime.Runtime/Load
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "/home/<path to shuttle>/runtime/serenity.wasm"}' localhost:6001 runtime.Runtime/Load
 
 # start bot (the deployment ID is needed in the StartRequest, but it isn't used by the serenity bot currently)
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Start
@@ -38,25 +55,31 @@ Run the test:
 
 ```bash
 cargo test axum --features shuttle-axum -- --nocapture
+
+# or, run tests for both axum and serenity:
+make test
 ```
 
 Load and run:
 
 ```bash
-cargo run --features shuttle-axum -- --axum --provisioner-address http://localhost:8000
+cargo run --features shuttle-axum -- --axum --provisioner-address http://localhost:5000
 ```
 
 In another terminal:
 
 ``` bash
-# load (a full, absolute path from home was needed for me in the load request)
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "runtime/axum.wasm"}' localhost:6001 runtime.Runtime/Load
+# load
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "/home/<path to shuttle>/runtime/axum.wasm"}' localhost:6001 runtime.Runtime/Load
 
 # start
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Start
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Start
 
 # subscribe to logs (unimplemented)
 grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs
+
+# stop
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Stop
 ```
 
 Curl the service:
@@ -95,7 +118,7 @@ Then in another shell, load a `.so` file and start it up:
 
 ``` bash
 # load
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "examples/rocket/hello-world/target/debug/libhello_world.so"}' localhost:6001 runtime.Runtime/Load
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "/home/<path to shuttle>/examples/rocket/hello-world/target/debug/libhello_world.so"}' localhost:6001 runtime.Runtime/Load
 
 # run (this deployment id is default uuid encoded as base64)
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runtime.Runtime/Start

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -82,8 +82,9 @@ Then in another shell, load a `.so` file and start it up:
 # load
 grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "path": "examples/rocket/hello-world/target/debug/libhello_world.so"}' localhost:6001 runtime.Runtime/Load
 
-# run
-grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic"}' localhost:6001 runtime.Runtime/Start
+# run (this deployment id is default uuid encoded as base64)
+grpcurl -plaintext -import-path ../proto -proto runtime.proto -d '{"service_name": "Tonic", "deployment_id": "MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw"}' localhost:6001 runti
+me.Runtime/Start
 
 # subscribe to logs
 grpcurl -plaintext -import-path ../proto -proto runtime.proto localhost:6001 runtime.Runtime/SubscribeLogs

--- a/runtime/src/axum/mod.rs
+++ b/runtime/src/axum/mod.rs
@@ -46,6 +46,12 @@ impl AxumWasm {
     }
 }
 
+impl Default for AxumWasm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl Runtime for AxumWasm {
     async fn load(

--- a/runtime/src/axum/mod.rs
+++ b/runtime/src/axum/mod.rs
@@ -122,6 +122,7 @@ impl Runtime for AxumWasm {
                 .is_err()
             {
                 error!("the receiver dropped");
+                return Err(Status::internal("failed to stop deployment"));
             }
 
             Ok(tonic::Response::new(StopResponse { success: true }))

--- a/runtime/src/axum/mod.rs
+++ b/runtime/src/axum/mod.rs
@@ -327,7 +327,7 @@ pub mod tests {
         let request: Request<Body> = Request::builder()
             .method(Method::GET)
             .version(Version::HTTP_11)
-            .uri(format!("https://axum-wasm.example/hello"))
+            .uri("https://axum-wasm.example/hello")
             .body(Body::empty())
             .unwrap();
 
@@ -350,7 +350,7 @@ pub mod tests {
             .method(Method::GET)
             .version(Version::HTTP_11)
             .header("test", HeaderValue::from_static("goodbye"))
-            .uri(format!("https://axum-wasm.example/goodbye"))
+            .uri("https://axum-wasm.example/goodbye")
             .body(Body::from("Goodbye world body"))
             .unwrap();
 
@@ -373,7 +373,7 @@ pub mod tests {
             .method(Method::GET)
             .version(Version::HTTP_11)
             .header("test", HeaderValue::from_static("invalid"))
-            .uri(format!("https://axum-wasm.example/invalid"))
+            .uri("https://axum-wasm.example/invalid")
             .body(Body::empty())
             .unwrap();
 

--- a/runtime/src/legacy/mod.rs
+++ b/runtime/src/legacy/mod.rs
@@ -168,6 +168,7 @@ impl Runtime for Legacy {
                 .is_err()
             {
                 error!("the receiver dropped");
+                return Err(Status::internal("failed to stop deployment"));
             }
 
             Ok(Response::new(StopResponse { success: true }))

--- a/runtime/src/legacy/mod.rs
+++ b/runtime/src/legacy/mod.rs
@@ -152,6 +152,8 @@ impl Runtime for Legacy {
         }
     }
 
+    // todo: this doesn't currently stop the service, since we can't stop the tokio runtime it
+    // is started on.
     async fn stop(&self, request: Request<StopRequest>) -> Result<Response<StopResponse>, Status> {
         let request = request.into_inner();
 

--- a/runtime/src/legacy/mod.rs
+++ b/runtime/src/legacy/mod.rs
@@ -89,7 +89,10 @@ impl Runtime for Legacy {
         let mut factory = abstract_factory.get_factory(service_name);
 
         let logs_tx = self.logs_tx.lock().unwrap().clone();
-        let deployment_id = Uuid::from_slice(&request.deployment_id).unwrap();
+
+        let deployment_id =
+            Uuid::from_str(std::str::from_utf8(&request.deployment_id).unwrap()).unwrap();
+
         let logger = Logger::new(logs_tx, deployment_id);
 
         let so_path = self

--- a/runtime/src/legacy/mod.rs
+++ b/runtime/src/legacy/mod.rs
@@ -171,7 +171,7 @@ impl Runtime for Legacy {
     }
 }
 
-/// Run the service and run until a stop signal is received
+/// Run the service until a stop signal is received
 #[instrument(skip(service))]
 async fn run_until_stopped(
     service: LoadedService,

--- a/runtime/src/legacy/mod.rs
+++ b/runtime/src/legacy/mod.rs
@@ -77,10 +77,6 @@ impl Runtime for Legacy {
 
         let request = request.into_inner();
 
-        println!(
-            "provisioner address: {:?}",
-            self.provisioner_address.clone().uri()
-        );
         let provisioner_client = ProvisionerClient::connect(self.provisioner_address.clone())
             .await
             .expect("failed to connect to provisioner");
@@ -181,15 +177,15 @@ async fn run(
 ) {
     let (handle, library) = service;
 
-    info!("starting deployment on {}", &addr);
+    trace!("starting deployment on {}", &addr);
     tokio::select! {
         _ = handle => {
-            println!("deployment stopped on {}", &addr);
+            trace!("deployment stopped on {}", &addr);
         },
         message = kill_rx => {
             match message {
-                Ok(msg) => println!("{msg}"),
-                Err(_) => println!("the sender dropped")
+                Ok(msg) => trace!("{msg}"),
+                Err(_) => trace!("the sender dropped")
             }
         }
     }

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -37,11 +37,11 @@ async fn main() {
         let svc = RuntimeServer::new(legacy);
         server_builder.add_service(svc)
     } else if args.axum {
-        let axum = AxumWasm::new();
+        let axum = AxumWasm::default();
         let svc = RuntimeServer::new(axum);
         server_builder.add_service(svc)
     } else {
-        let next = Next::new();
+        let next = Next::default();
         let svc = RuntimeServer::new(next);
         server_builder.add_service(svc)
     };

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -39,6 +39,12 @@ impl Next {
     }
 }
 
+impl Default for Next {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl Runtime for Next {
     async fn load(&self, request: Request<LoadRequest>) -> Result<Response<LoadResponse>, Status> {

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -199,7 +199,7 @@ impl BotInner {
             .insert_file(3, Box::new(client), FileCaps::all());
 
         host.write_all(new_message.as_bytes()).unwrap();
-        host.write(&[0]).unwrap();
+        host.write_all(&[0]).unwrap();
 
         println!("calling inner EventHandler message");
         self.linker
@@ -238,7 +238,7 @@ impl Bot {
     }
 
     pub async fn into_client(self, token: &str, intents: GatewayIntents) -> Client {
-        Client::builder(&token, intents)
+        Client::builder(token, intents)
             .event_handler(self)
             .await
             .unwrap()

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -112,6 +112,7 @@ impl Runtime for Next {
                 .is_err()
             {
                 error!("the receiver dropped");
+                return Err(Status::internal("failed to stop deployment"));
             }
 
             Ok(Response::new(StopResponse { success: true }))

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -10,7 +10,8 @@ use cap_std::os::unix::net::UnixStream;
 use serenity::{model::prelude::*, prelude::*};
 use shuttle_proto::runtime::runtime_server::Runtime;
 use shuttle_proto::runtime::{
-    self, LoadRequest, LoadResponse, StartRequest, StartResponse, SubscribeLogsRequest,
+    self, LoadRequest, LoadResponse, StartRequest, StartResponse, StopRequest, StopResponse,
+    SubscribeLogsRequest,
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
@@ -79,6 +80,10 @@ impl Runtime for Next {
         &self,
         _request: Request<SubscribeLogsRequest>,
     ) -> Result<Response<Self::SubscribeLogsStream>, Status> {
+        todo!()
+    }
+
+    async fn stop(&self, _request: Request<StopRequest>) -> Result<Response<StopResponse>, Status> {
         todo!()
     }
 }

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -114,7 +114,7 @@ impl Runtime for Next {
     }
 }
 
-/// Run the bot and run until a stop signal is received
+/// Run the bot until a stop signal is received
 async fn run_until_stopped(mut client: Client, kill_rx: tokio::sync::oneshot::Receiver<String>) {
     tokio::select! {
         _ = client.start() => {

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -260,8 +260,8 @@ pub mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn bot() {
-        let bot = Bot::new("bot.wasm");
+    async fn serenity() {
+        let bot = Bot::new("serenity.wasm");
         let mut inner = bot.inner.lock().await;
         assert_eq!(inner.message("not !hello").await, None);
         assert_eq!(inner.message("!hello").await, Some("world!".to_string()));

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -19,7 +19,7 @@ use shuttle_service::ServiceName;
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::trace;
+use tracing::{error, trace};
 use wasi_common::file::FileCaps;
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::sync::net::UnixStream as WasiUnixStream;
@@ -107,11 +107,12 @@ impl Runtime for Next {
         let kill_tx = self.kill_tx.lock().unwrap().deref_mut().take();
 
         if let Some(kill_tx) = kill_tx {
-            tokio::spawn(async move {
-                kill_tx
-                    .send(format!("stopping deployment: {}", &service_name))
-                    .unwrap();
-            });
+            if kill_tx
+                .send(format!("stopping deployment: {}", &service_name))
+                .is_err()
+            {
+                error!("the receiver dropped");
+            }
 
             Ok(Response::new(StopResponse { success: true }))
         } else {


### PR DESCRIPTION
Add a stop method to `runtime.proto`. We can't currently stop services on the legacy runtime, since we can't actually drop the legacy runtime. I implemented a stop method for it before discovering it was not possible, I left it there but with a comment. I'm happy to replace it with a `todo!()` if that's more tidy for now. 

I implemented stop for wasm serenity and axum, which is tested (manually) and works. We may want to setup integration tests for these runtimes with some helpers for the grpc requests, but maybe in a separate PR?

I opted for `oneshot` channels that are set on each `start`, but on second thought it may have been a mistake. I suppose the runtime should be able to load -> start several services, keeping them all alive until their ID/name receives a stop request. Meaning `broadcast` channels may be the correct choice here.

Note: This PR also changes the Dockerfile to install a newer protoc binary directly, rather than with `apt`, to allow us to use explicit optional fields in the protobufs. This is also done for the CI.

