### PR TITLE
Feature/support actix web

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ workflows:
             - workspace-fmt
           matrix:
             parameters:
-              framework: ["web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity"]
+              framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity"]
       - check-standalone:
           matrix:
             parameters:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "examples"]
 	path = examples
-	url = git@github.com:shuttle-hq/examples.git
+	url = git@github.com:biryukovmaxim/shuttle-examples.git
+	branch = feature/actix-web-example

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "examples"]
 	path = examples
-	url = git@github.com:biryukovmaxim/shuttle-examples.git
-	branch = feature/actix-web-example
+	url = git@github.com:shuttle-hq/examples.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7817,9 +7817,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.3+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,185 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+dependencies = [
+ "bitflags",
+ "bytes 1.3.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "memchr",
+ "pin-project-lite 0.2.9",
+ "tokio",
+ "tokio-util 0.7.3",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "ahash",
+ "base64 0.13.0",
+ "bitflags",
+ "brotli",
+ "bytes 1.3.0",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2",
+ "http 0.2.8",
+ "httparse",
+ "httpdate",
+ "itoa 1.0.2",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite 0.2.9",
+ "rand 0.8.5",
+ "sha1 0.10.4",
+ "smallvec",
+ "tracing",
+ "zstd",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+dependencies = [
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+dependencies = [
+ "bytestring",
+ "http 0.2.8",
+ "regex",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "num_cpus",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite 0.2.9",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite 0.2.9",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash",
+ "bytes 1.3.0",
+ "bytestring",
+ "cfg-if 1.0.0",
+ "cookie 0.16.0",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http 0.2.8",
+ "itoa 1.0.2",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite 0.2.9",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time 0.3.11",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+dependencies = [
+ "actix-router",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,7 +699,7 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "hex 0.4.3",
  "http 0.2.8",
  "hyper",
@@ -554,7 +733,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "http-body",
  "lazy_static",
@@ -580,7 +759,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "tokio-stream",
  "tower",
@@ -602,7 +781,7 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-types",
  "aws-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "tokio-stream",
  "tower",
@@ -625,7 +804,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "tower",
 ]
@@ -683,7 +862,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-smithy-http-tower",
  "aws-smithy-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "fastrand",
  "http 0.2.8",
  "http-body",
@@ -703,7 +882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc1af50eac644ab6f58e5bae29328ba3092851fc2ce648ad139134699b2b66f"
 dependencies = [
  "aws-smithy-types",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "bytes-utils",
  "futures-core",
  "http 0.2.8",
@@ -724,7 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1bf4c4664dff2febf91f8796505c5bc8f38a0bff0d1397d1d3fdda17bd5c5d1"
 dependencies = [
  "aws-smithy-http",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "http-body",
  "pin-project-lite 0.2.9",
@@ -798,7 +977,7 @@ dependencies = [
  "axum-core",
  "base64 0.13.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-util",
  "headers",
  "http 0.2.8",
@@ -830,7 +1009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-util",
  "http 0.2.8",
  "http-body",
@@ -844,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8456dab8f11484979a86651da8e619b355ede5d61a160755155f6c344bd18c47"
 dependencies = [
  "arc-swap",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-util",
  "http 0.2.8",
  "http-body",
@@ -966,7 +1145,7 @@ checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
 dependencies = [
  "base64 0.13.0",
  "bollard-stubs",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "futures-util",
  "hex 0.4.3",
@@ -1087,9 +1266,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bytes-utils"
@@ -1097,7 +1276,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1934a3ef9cac8efde4966a92781e77713e1ba329f1d42e446c7d7eba340d8ef1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "either",
 ]
 
@@ -1106,6 +1285,15 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
+name = "bytestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f83e57d9154148e355404702e2694463241880b939570d7c97c014da7a69a1"
+dependencies = [
+ "bytes 1.3.0",
+]
 
 [[package]]
 name = "cache-padded"
@@ -1483,7 +1671,7 @@ version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "memchr",
 ]
 
@@ -1554,6 +1742,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "cookie"
@@ -1980,6 +2174,19 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "rustc_version 0.4.0",
  "syn 1.0.99",
 ]
 
@@ -2578,7 +2785,7 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2635,7 +2842,7 @@ checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "headers-core",
  "http 0.2.8",
  "httpdate",
@@ -2770,7 +2977,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "fnv",
  "itoa 1.0.2",
 ]
@@ -2781,7 +2988,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "pin-project-lite 0.2.9",
 ]
@@ -2850,7 +3057,7 @@ version = "0.14.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2939,7 +3146,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "hyper",
  "native-tls",
  "tokio",
@@ -3179,6 +3386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3272,6 +3485,24 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "local-channel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -3473,7 +3704,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f8f35e687561d5c1667590911e6698a8cb714a134a7505718a182e7bc9d3836"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "encoding_rs",
  "futures-util",
  "http 0.2.8",
@@ -3773,7 +4004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc79add46364183ece1a4542592ca593e6421c60807232f5b8f7a31703825d"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "opentelemetry_api",
  "reqwest",
@@ -4044,7 +4275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d0fec4acc8779b696e3ff25527884fb17cda6cf59a249c57aa1af1e2f65b36"
 dependencies = [
  "async-trait",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-util",
  "headers",
  "http 0.2.8",
@@ -4230,7 +4461,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "prost-derive",
 ]
 
@@ -4240,7 +4471,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "heck",
  "itertools",
  "lazy_static",
@@ -4273,7 +4504,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "prost",
 ]
 
@@ -4633,7 +4864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4773,7 +5004,7 @@ dependencies = [
  "atomic",
  "atty",
  "binascii",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "either",
  "figment",
  "futures",
@@ -5021,7 +5252,7 @@ dependencies = [
  "async-compression",
  "async-trait",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "cookie 0.16.0",
  "encoding_rs",
  "enumflags2",
@@ -5289,7 +5520,7 @@ dependencies = [
  "async-tungstenite",
  "base64 0.13.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "cfg-if 1.0.0",
  "flate2",
  "futures",
@@ -5453,7 +5684,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "cargo",
  "cargo_metadata",
  "chrono",
@@ -5590,6 +5821,7 @@ dependencies = [
 name = "shuttle-service"
 version = "0.7.2"
 dependencies = [
+ "actix-web",
  "anyhow",
  "async-std",
  "async-trait",
@@ -5784,7 +6016,7 @@ dependencies = [
  "atoi 0.4.0",
  "bitflags",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "crc 2.1.0",
  "crossbeam-queue",
  "either",
@@ -5832,7 +6064,7 @@ dependencies = [
  "base64 0.13.0",
  "bitflags",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "chrono",
  "crc 3.0.0",
  "crossbeam-queue",
@@ -6276,7 +6508,7 @@ checksum = "4bc22b1c2267be6d1769c6d787936201341f03c915456ed8a8db8d40d665215f"
 dependencies = [
  "async-trait",
  "bytes 0.5.6",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "fnv",
  "futures",
  "http 0.1.21",
@@ -6426,7 +6658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
  "autocfg 1.1.0",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "libc",
  "memchr",
  "mio",
@@ -6511,7 +6743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
 dependencies = [
  "async-stream",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -6550,7 +6782,7 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -6566,7 +6798,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite 0.2.9",
@@ -6623,7 +6855,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.13.0",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "futures-util",
  "h2",
@@ -6685,7 +6917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
 dependencies = [
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "futures-util",
  "http 0.2.8",
@@ -6704,7 +6936,7 @@ checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
 dependencies = [
  "base64 0.13.0",
  "bitflags",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-core",
  "futures-util",
  "http 0.2.8",
@@ -6890,7 +7122,7 @@ checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "httparse",
  "log",
@@ -6909,7 +7141,7 @@ checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "http 0.2.8",
  "httparse",
  "log",
@@ -7228,7 +7460,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
 dependencies = [
- "bytes 1.1.0",
+ "bytes 1.3.0",
  "futures-channel",
  "futures-util",
  "headers",
@@ -7563,3 +7795,32 @@ name = "zeroize"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.3+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -146,32 +146,35 @@ pub struct RunArgs {
 
 #[derive(Parser, Debug)]
 pub struct InitArgs {
+    /// Initialize with actix-web framework
+    #[clap(long="actix-web", conflicts_with_all = &["axum", "rocket", "tide", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
+    pub actix_web: bool,
     /// Initialize with axum framework
-    #[clap(long, conflicts_with_all = &["rocket", "tide", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","rocket", "tide", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
     pub axum: bool,
     /// Initialize with rocket framework
-    #[clap(long, conflicts_with_all = &["axum", "tide", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "tide", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
     pub rocket: bool,
     /// Initialize with tide framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tower", "poem", "serenity", "warp", "salvo", "thruster"])]
     pub tide: bool,
     /// Initialize with tower framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "poem", "serenity", "warp", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tide", "poem", "serenity", "warp", "salvo", "thruster"])]
     pub tower: bool,
     /// Initialize with poem framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "tower", "serenity", "warp", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tide", "tower", "serenity", "warp", "salvo", "thruster"])]
     pub poem: bool,
     /// Initialize with salvo framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "tower", "poem", "warp", "serenity", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tide", "tower", "poem", "warp", "serenity", "thruster"])]
     pub salvo: bool,
     /// Initialize with serenity framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "tower", "poem", "warp", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tide", "tower", "poem", "warp", "salvo", "thruster"])]
     pub serenity: bool,
     /// Initialize with warp framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "tower", "poem", "serenity", "salvo", "thruster"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tide", "tower", "poem", "serenity", "salvo", "thruster"])]
     pub warp: bool,
     /// Initialize with thruster framework
-    #[clap(long, conflicts_with_all = &["axum", "rocket", "tide", "tower", "poem", "warp", "salvo", "serenity"])]
+    #[clap(long, conflicts_with_all = &["actix-web","axum", "rocket", "tide", "tower", "poem", "warp", "salvo", "serenity"])]
     pub thruster: bool,
     /// Path to initialize a new shuttle project
     #[clap(

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -59,9 +59,8 @@ impl ShuttleInit for ShuttleInitActixWeb {
         #[shuttle_service::main]
         async fn actix_web(
         ) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Copy + Clone + 'static> {
-            let h = hello_world;
             Ok(move |cfg: &mut ServiceConfig| {
-                cfg.service(resource("/hello").to(h));
+                cfg.service(resource("/hello").to(hello_world));
             })
         }"#}
     }

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -21,6 +21,51 @@ pub trait ShuttleInit {
     fn get_boilerplate_code_for_framework(&self) -> &'static str;
 }
 
+pub struct ShuttleInitActixWeb;
+
+impl ShuttleInit for ShuttleInitActixWeb {
+    fn set_cargo_dependencies(
+        &self,
+        dependencies: &mut Table,
+        manifest_path: &Path,
+        url: &Url,
+        get_dependency_version_fn: GetDependencyVersionFn,
+    ) {
+        set_key_value_dependency_version(
+            "actix-web",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_inline_table_dependency_features(
+            "shuttle-service",
+            dependencies,
+            vec!["web-actix-web".to_string()],
+        );
+    }
+
+    fn get_boilerplate_code_for_framework(&self) -> &'static str {
+        indoc! {r#"
+        use actix_web::web::{resource, ServiceConfig};
+        use shuttle_service::{ShuttleActixWeb};
+
+        async fn hello_world() -> &'static str {
+            "Hello World!"
+        }
+
+        #[shuttle_service::main]
+        async fn actix_web() -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Copy + Clone + 'static> {
+            let h = hello_world;
+            Ok(move |cfg: &mut ServiceConfig| {
+                cfg.service(resource("/").to(h));
+            })
+        }"#}
+    }
+}
+
 pub struct ShuttleInitAxum;
 
 impl ShuttleInit for ShuttleInitAxum {
@@ -556,6 +601,9 @@ impl ShuttleInit for ShuttleInitNoOp {
 /// for writing framework-specific dependencies to `Cargo.toml` and generating
 /// boilerplate code in `src/lib.rs`.
 pub fn get_framework(init_args: &InitArgs) -> Box<dyn ShuttleInit> {
+    if init_args.actix_web {
+        return Box::new(ShuttleInitActixWeb);
+    }
     if init_args.axum {
         return Box::new(ShuttleInitAxum);
     }
@@ -742,6 +790,7 @@ mod shuttle_init_tests {
 
     fn init_args_factory(framework: &str) -> InitArgs {
         let mut init_args = InitArgs {
+            actix_web: false,
             axum: false,
             rocket: false,
             tide: false,
@@ -755,6 +804,7 @@ mod shuttle_init_tests {
         };
 
         match framework {
+            "actix-web" => init_args.actix_web = true,
             "axum" => init_args.axum = true,
             "rocket" => init_args.rocket = true,
             "tide" => init_args.tide = true,
@@ -790,9 +840,19 @@ mod shuttle_init_tests {
     #[test]
     fn test_get_framework_via_get_boilerplate_code() {
         let frameworks = vec![
-            "axum", "rocket", "tide", "tower", "poem", "salvo", "serenity", "warp", "thruster",
+            "actix-web",
+            "axum",
+            "rocket",
+            "tide",
+            "tower",
+            "poem",
+            "salvo",
+            "serenity",
+            "warp",
+            "thruster",
         ];
         let framework_inits: Vec<Box<dyn ShuttleInit>> = vec![
+            Box::new(ShuttleInitActixWeb),
             Box::new(ShuttleInitAxum),
             Box::new(ShuttleInitRocket),
             Box::new(ShuttleInitTide),
@@ -875,6 +935,37 @@ mod shuttle_init_tests {
         let expected = indoc! {r#"
             [dependencies]
             shuttle-service = "1.0"
+        "#};
+
+        assert_eq!(cargo_toml.to_string(), expected);
+    }
+    #[test]
+    fn test_set_cargo_dependencies_actix_web() {
+        let mut cargo_toml = cargo_toml_factory();
+        let dependencies = cargo_toml["dependencies"].as_table_mut().unwrap();
+        let manifest_path = PathBuf::new();
+        let url = Url::parse("https://shuttle.rs").unwrap();
+
+        set_inline_table_dependency_version(
+            "shuttle-service",
+            dependencies,
+            &manifest_path,
+            &url,
+            false,
+            mock_get_latest_dependency_version,
+        );
+
+        ShuttleInitActixWeb.set_cargo_dependencies(
+            dependencies,
+            &manifest_path,
+            &url,
+            mock_get_latest_dependency_version,
+        );
+
+        let expected = indoc! {r#"
+            [dependencies]
+            shuttle-service = { version = "1.0", features = ["web-actix-web"] }
+            actix-web = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -50,17 +50,18 @@ impl ShuttleInit for ShuttleInitActixWeb {
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
         use actix_web::web::{resource, ServiceConfig};
-        use shuttle_service::{ShuttleActixWeb};
+        use shuttle_service::ShuttleActixWeb;
 
         async fn hello_world() -> &'static str {
             "Hello World!"
         }
 
         #[shuttle_service::main]
-        async fn actix_web() -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Copy + Clone + 'static> {
+        async fn actix_web(
+        ) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Copy + Clone + 'static> {
             let h = hello_world;
             Ok(move |cfg: &mut ServiceConfig| {
-                cfg.service(resource("/").to(h));
+                cfg.service(resource("/hello").to(h));
             })
         }"#}
     }

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -20,6 +20,7 @@ async fn cargo_shuttle_init(path: PathBuf) -> anyhow::Result<CommandOutcome> {
                 name: None,
             },
             cmd: Command::Init(InitArgs {
+                actix_web: false,
                 axum: false,
                 rocket: false,
                 tide: false,
@@ -48,6 +49,7 @@ async fn cargo_shuttle_init_framework(path: PathBuf) -> anyhow::Result<CommandOu
                 name: None,
             },
             cmd: Command::Init(InitArgs {
+                actix_web: false,
                 axum: false,
                 rocket: true,
                 tide: false,

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -169,6 +169,22 @@ async fn rocket_authentication() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn actix_web_hello_world() {
+    let port = cargo_shuttle_run("../examples/actix-web/hello-world").await;
+
+    let request_text = reqwest::Client::new()
+        .get(format!("http://localhost:{port}/hello"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(request_text, "Hello World!");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn axum_hello_world() {
     let port = cargo_shuttle_run("../examples/axum/hello-world").await;
 

--- a/e2e/tests/integration/actix_web.rs
+++ b/e2e/tests/integration/actix_web.rs
@@ -4,8 +4,11 @@ use crate::helpers::{self, APPS_FQDN};
 
 #[test]
 fn hello_world_actix_web() {
-    let client =
-        helpers::Services::new_docker("hello-world (actix-web)", "actix-web/hello-world", Color::Green);
+    let client = helpers::Services::new_docker(
+        "hello-world (actix-web)",
+        "actix-web/hello-world",
+        Color::Green,
+    );
     client.deploy();
 
     let request_text = client
@@ -16,5 +19,5 @@ fn hello_world_actix_web() {
         .text()
         .unwrap();
 
-    assert_eq!(request_text, "Hello, world!");
+    assert_eq!(request_text, "Hello World!");
 }

--- a/e2e/tests/integration/actix_web.rs
+++ b/e2e/tests/integration/actix_web.rs
@@ -1,0 +1,20 @@
+use crossterm::style::Color;
+
+use crate::helpers::{self, APPS_FQDN};
+
+#[test]
+fn hello_world_actix_web() {
+    let client =
+        helpers::Services::new_docker("hello-world (actix-web)", "actix-web/hello-world", Color::Green);
+    client.deploy();
+
+    let request_text = client
+        .get("hello")
+        .header("Host", format!("hello-world-actix-web-app.{}", *APPS_FQDN))
+        .send()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    assert_eq!(request_text, "Hello, world!");
+}

--- a/e2e/tests/integration/main.rs
+++ b/e2e/tests/integration/main.rs
@@ -1,5 +1,6 @@
 pub mod helpers;
 
+pub mod actix_web;
 pub mod axum;
 pub mod poem;
 pub mod rocket;

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.shuttle.rs"
 doctest = false
 
 [dependencies]
-actix-web = {version = "4.2.1", optional = true}
+actix-web = { version = "4.2.1", optional = true }
 anyhow = "1.0.62"
 async-trait = "0.1.57"
 axum = { version = "0.5.15", optional = true }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://www.shuttle.rs"
 doctest = false
 
 [dependencies]
+actix-web = {version = "4.2.1", optional = true}
 anyhow = "1.0.62"
 async-trait = "0.1.57"
 axum = { version = "0.5.15", optional = true }
@@ -66,6 +67,7 @@ default = ["codegen"]
 codegen = ["shuttle-codegen"]
 loader = ["cargo", "libloading"]
 
+web-actix-web = ["actix-web"]
 web-axum = ["axum", "sync_wrapper"]
 web-rocket = ["rocket"]
 web-thruster = ["thruster"]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -549,7 +549,9 @@ impl Service for sync_wrapper::SyncWrapper<axum::Router> {
 #[cfg(feature = "web-actix-web")]
 #[async_trait]
 impl<F> Service for F
-where F: FnOnce(&mut actix_web::web::ServiceConfig) + Sync + Send + Copy + Clone + 'static {
+where
+    F: FnOnce(&mut actix_web::web::ServiceConfig) + Sync + Send + Copy + Clone + 'static,
+{
     async fn bind(self: Box<Self>, addr: SocketAddr) -> Result<(), Error> {
         let srv = actix_web::HttpServer::new(move || actix_web::App::new().configure(*self))
             .bind(addr)?
@@ -560,7 +562,7 @@ where F: FnOnce(&mut actix_web::web::ServiceConfig) + Sync + Send + Copy + Clone
     }
 }
 #[cfg(feature = "web-actix-web")]
-pub type ShuttleActixWeb<F> = Result<F, Error> ;
+pub type ShuttleActixWeb<F> = Result<F, Error>;
 
 #[cfg(feature = "web-axum")]
 pub type ShuttleAxum = Result<sync_wrapper::SyncWrapper<axum::Router>, Error>;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -263,6 +263,8 @@ extern crate shuttle_codegen;
 /// | `ShuttlePoem`                         | web-poem     | [poem](https://docs.rs/poem/1.3.35)         | 1.3.35     | [GitHub](https://github.com/shuttle-hq/examples/tree/main/poem/hello-world)           |
 /// | `Result<T, shuttle_service::Error>`   | web-tower    | [tower](https://docs.rs/tower/0.4.12)       | 0.14.12    | [GitHub](https://github.com/shuttle-hq/examples/tree/main/tower/hello-world)          |
 /// | `ShuttleSerenity`                     | bot-serenity | [serenity](https://docs.rs/serenity/0.11.5) | 0.11.5     | [GitHub](https://github.com/shuttle-hq/examples/tree/main/serenity/hello-world)       |
+/// | `ShuttleActixWeb`                     | web-actix-web| [actix-web](https://docs.rs/actix-web/4.2.1)| 4.2.1      | [GitHub](https://github.com/shuttle-hq/examples/tree/main/actix-web/hello-world)           |
+
 ///
 /// # Getting shuttle managed resources
 /// Shuttle is able to manage resource dependencies for you. These resources are passed in as inputs to your `#[shuttle_service::main]` function and are configured using attributes:


### PR DESCRIPTION
#205 
implementation of Service for actix-web using [configure method](https://actix.rs/docs/application)
[Example](https://github.com/biryukovmaxim/shuttle-examples/tree/feature/actix-web-example/actix-web/hello-world)

cargo check/build without error, but when I try to deploy locally the example, deploy get crashed providing these logs:

<details>
  <summary>Logs</summary>
 `
[2m2022-11-27T16:57:11.637728131Z[0m [38;5;10m INFO[39m [38;5;12m[1mEntering queued state[0m

[2m2022-11-27T16:57:11.638499343Z[0m [38;5;10m INFO[39m [38;5;12m[1mEntering building state[0m
[2m2022-11-27T16:57:11.942690023Z[0m [38;5;10m INFO[39m     Updating crates.io index
[2m2022-11-27T16:57:20.806397961Z[0m [38;5;10m INFO[39m warning: Patch `shuttle-aws-rds v0.7.2 (/usr/src/shuttle/resources/aws-rds)` was not used in the crate graph.
[2m2022-11-27T16:57:20.806455747Z[0m [38;5;10m INFO[39m Patch `shuttle-persist v0.7.2 (/usr/src/shuttle/resources/persist)` was not used in the crate graph.
[2m2022-11-27T16:57:20.811746749Z[0m [38;5;10m INFO[39m Patch `shuttle-secrets v0.7.2 (/usr/src/shuttle/resources/secrets)` was not used in the crate graph.
[2m2022-11-27T16:57:20.816806560Z[0m [38;5;10m INFO[39m Patch `shuttle-shared-db v0.7.2 (/usr/src/shuttle/resources/shared-db)` was not used in the crate graph.
[2m2022-11-27T16:57:20.821676231Z[0m [38;5;10m INFO[39m Check that the patched package version and available features are compatible
[2m2022-11-27T16:57:20.826547901Z[0m [38;5;10m INFO[39m with the dependency requirements. If the patch has a different version from
[2m2022-11-27T16:57:20.831885817Z[0m [38;5;10m INFO[39m what is locked in the Cargo.lock file, run `cargo update` to use the new
[2m2022-11-27T16:57:20.837278048Z[0m [38;5;10m INFO[39m version. This may also occur with an optional dependency that is not enabled.
[2m2022-11-27T16:57:46.372509914Z[0m [38;5;10m INFO[39m    Compiling zstd-sys v2.0.3+zstd.1.5.2
[2m2022-11-27T16:57:46.560632521Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:218:21
    |
218 |     pub lowerBound: ::core::ffi::c_int,
    |                     ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.565495975Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:219:21
    |
219 |     pub upperBound: ::core::ffi::c_int,
    |                     ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.570742589Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:51:27
   |
51 |     pub compressionLevel: ::core::ffi::c_int,
   |                           ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.575906718Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:52:28
   |
52 |     pub notificationLevel: ::core::ffi::c_uint,
   |                            ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.581057989Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:53:17
   |
53 |     pub dictID: ::core::ffi::c_uint,
   |                 ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.601148984Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:53:36
   |
53 |     pub fn ZSTD_versionNumber() -> ::core::ffi::c_uint;
   |                                    ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.610123963Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:57:43
   |
57 |     pub fn ZSTD_versionString() -> *const ::core::ffi::c_char;
   |                                           ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.616819431Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:66:27
   |
66 |         compressionLevel: ::core::ffi::c_int,
   |                           ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.623070379Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:82:10
   |
82 |     ) -> ::core::ffi::c_ulonglong;
   |          ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.628803332Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:89:10
   |
89 |     ) -> ::core::ffi::c_ulonglong;
   |          ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.634203539Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:102:41
    |
102 |     pub fn ZSTD_isError(code: usize) -> ::core::ffi::c_uint;
    |                                         ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.639573315Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:105:53
    |
105 |     pub fn ZSTD_getErrorName(code: usize) -> *const ::core::ffi::c_char;
    |                                                     ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.644821276Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:108:32
    |
108 |     pub fn ZSTD_minCLevel() -> ::core::ffi::c_int;
    |                                ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.650085570Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:111:32
    |
111 |     pub fn ZSTD_maxCLevel() -> ::core::ffi::c_int;
    |                                ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.655443069Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:114:36
    |
114 |     pub fn ZSTD_defaultCLevel() -> ::core::ffi::c_int;
    |                                    ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.661930465Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:137:27
    |
137 |         compressionLevel: ::core::ffi::c_int,
    |                           ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.681132389Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:230:16
    |
230 |         value: ::core::ffi::c_int,
    |                ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.690501523Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:237:25
    |
237 |         pledgedSrcSize: ::core::ffi::c_ulonglong,
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.697097729Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:283:16
    |
283 |         value: ::core::ffi::c_int,
    |                ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.703152686Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:350:27
    |
350 |         compressionLevel: ::core::ffi::c_int,
    |                           ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.709034150Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:408:27
    |
408 |         compressionLevel: ::core::ffi::c_int,
    |                           ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.714705164Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:435:27
    |
435 |         compressionLevel: ::core::ffi::c_int,
    |                           ^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.720161582Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:486:10
    |
486 |     ) -> ::core::ffi::c_uint;
    |          ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.737224686Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:492:10
    |
492 |     ) -> ::core::ffi::c_uint;
    |          ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.741749379Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:498:10
    |
498 |     ) -> ::core::ffi::c_uint;
    |          ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.747551978Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
   --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zstd_std.rs:505:10
    |
505 |     ) -> ::core::ffi::c_uint;
    |          ^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.753276538Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:45:20
   |
45 |         nbSamples: ::core::ffi::c_uint,
   |                    ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.758725255Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:64:20
   |
64 |         nbSamples: ::core::ffi::c_uint,
   |                    ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.764300068Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:72:10
   |
72 |     ) -> ::core::ffi::c_uint;
   |          ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.769786361Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:81:47
   |
81 |     pub fn ZDICT_isError(errorCode: usize) -> ::core::ffi::c_uint;
   |                                               ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.787381341Z[0m [38;5;12mDEBUG[39m error[E0658]: use of unstable library feature 'core_ffi_c'
  --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zstd-sys-2.0.3+zstd.1.5.2/src/bindings_zdict_std.rs:84:59
   |
84 |     pub fn ZDICT_getErrorName(errorCode: usize) -> *const ::core::ffi::c_char;
   |                                                           ^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #94501 <https://github.com/rust-lang/rust/issues/94501> for more information


[2m2022-11-27T16:57:46.792197365Z[0m [38;5;12mDEBUG[39m error: aborting due to 31 previous errors


[2m2022-11-27T16:57:46.798011748Z[0m [38;5;12mDEBUG[39m For more information about this error, try `rustc --explain E0658`.

[2m2022-11-27T16:57:46.814472784Z[0m [38;5;10m INFO[39m error: could not compile `zstd-sys` due to 32 previous errors
[2m2022-11-27T16:57:46.819318702Z[0m [38;5;10m INFO[39m warning: build failed, waiting for other jobs to finish...

[2m2022-11-27T16:57:46.948204213Z[0m [38;5;10m INFO[39m [38;5;12m[1mEntering crashed state[0m
[2m2022-11-27T16:57:46.948441338Z[0m [38;5;9mERROR[39m {error="Build error: 1 job failed"} [2mshuttle_deployer::deployment::queue:[0m service build encountered an error
`

  
</details>
I have no idea how to fix this error

