### PR TITLE
feat: static file support for a single folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ commands:
             shuttle-persist = { path = "$PWD/resources/persist" }
             shuttle-shared-db = { path = "$PWD/resources/shared-db" }
             shuttle-secrets = { path = "$PWD/resources/secrets" }
+            shuttle-static-folder = { path = "$PWD/resources/static-folder" }
             EOF
   install-rust:
     steps:
@@ -260,6 +261,7 @@ workflows:
                 - resources/persist
                 - resources/secrets
                 - resources/shared-db
+                - resources/static-folder
       - service-test:
           requires:
             - workspace-clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ shuttle-aws-rds = { path = "[base]/shuttle/resources/aws-rds" }
 shuttle-persist = { path = "[base]/shuttle/resources/persist" }
 shuttle-shared-db = { path = "[base]/shuttle/resources/shared-db" }
 shuttle-secrets = { path = "[base]/shuttle/resources/secrets" }
+shuttle-static-folder = { path = "[base]/shuttle/resources/static-folder" }
 ```
 
 Prime gateway database with an admin user:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ exclude = [
   "resources/aws-rds",
   "resources/persist",
   "resources/secrets",
-  "resources/shared-db"
+  "resources/shared-db",
+  "resources/static-folder"
 ]

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ publish: publish-resources publish-cargo-shuttle
 publish-resources: publish-resources/aws-rds \
 	publish-resources/persist \
 	publish-resources/shared-db
+	publish-resources/static-folder
 
 publish-cargo-shuttle: publish-resources/secrets
 	cd cargo-shuttle; cargo publish

--- a/cargo-shuttle/src/factory.rs
+++ b/cargo-shuttle/src/factory.rs
@@ -184,12 +184,12 @@ impl Factory for LocalFactory {
         self.service_name.clone()
     }
 
-    fn get_build_path(&self) -> PathBuf {
-        self.working_directory.clone()
+    fn get_build_path(&self) -> Result<PathBuf, shuttle_service::Error> {
+        Ok(self.working_directory.clone())
     }
 
-    fn get_storage_path(&self) -> PathBuf {
-        self.working_directory.clone()
+    fn get_storage_path(&self) -> Result<PathBuf, shuttle_service::Error> {
+        Ok(self.working_directory.clone())
     }
 }
 

--- a/cargo-shuttle/src/factory.rs
+++ b/cargo-shuttle/src/factory.rs
@@ -23,6 +23,7 @@ use shuttle_service::{database::Type, error::CustomError, Factory, ServiceName};
 use std::{
     collections::{BTreeMap, HashMap},
     io::stdout,
+    path::PathBuf,
     time::Duration,
 };
 use tokio::time::sleep;
@@ -32,14 +33,20 @@ pub struct LocalFactory {
     docker: Docker,
     service_name: ServiceName,
     secrets: BTreeMap<String, String>,
+    working_directory: PathBuf,
 }
 
 impl LocalFactory {
-    pub fn new(service_name: ServiceName, secrets: BTreeMap<String, String>) -> Result<Self> {
+    pub fn new(
+        service_name: ServiceName,
+        secrets: BTreeMap<String, String>,
+        working_directory: PathBuf,
+    ) -> Result<Self> {
         Ok(Self {
             docker: Docker::connect_with_local_defaults()?,
             service_name,
             secrets,
+            working_directory,
         })
     }
 }
@@ -175,6 +182,14 @@ impl Factory for LocalFactory {
 
     fn get_service_name(&self) -> ServiceName {
         self.service_name.clone()
+    }
+
+    fn get_build_path(&self) -> PathBuf {
+        self.working_directory.clone()
+    }
+
+    fn get_storage_path(&self) -> PathBuf {
+        self.working_directory.clone()
     }
 }
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -309,7 +309,11 @@ impl Shuttle {
 
         let loader = Loader::from_so_file(so_path)?;
 
-        let mut factory = LocalFactory::new(self.ctx.project_name().clone(), secrets)?;
+        let mut factory = LocalFactory::new(
+            self.ctx.project_name().clone(),
+            secrets,
+            working_directory.to_path_buf(),
+        )?;
         let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), run_args.port);
 
         trace!("loading project");

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -12,7 +12,8 @@ shuttle-service = { path = "/usr/src/shuttle/service" }
 shuttle-aws-rds = { path = "/usr/src/shuttle/resources/aws-rds" }
 shuttle-persist = { path = "/usr/src/shuttle/resources/persist" }
 shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" }
-shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }' > $CARGO_HOME/config.toml
+shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }
+shuttle-static-folder = { path = "/usr/src/shuttle/resources/static-folder" }' > $CARGO_HOME/config.toml
 
 # Prefetch crates.io index
 cd /usr/src/shuttle/service

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -362,8 +362,9 @@ mod tests {
 
     use crate::{
         deployment::{
-            deploy_layer::LogType, provisioner_factory, runtime_logger, ActiveDeploymentsGetter,
-            Built, DeploymentManager, Queued,
+            deploy_layer::LogType, provisioner_factory, runtime_logger,
+            storage_manager::StorageManager, ActiveDeploymentsGetter, Built, DeploymentManager,
+            Queued,
         },
         persistence::{SecretRecorder, State},
     };
@@ -460,6 +461,8 @@ mod tests {
             &self,
             _project_name: shuttle_common::project::ProjectName,
             _service_id: Uuid,
+            _deployment_id: Uuid,
+            _storage_manager: StorageManager,
         ) -> Result<Self::Output, Self::Error> {
             Ok(StubProvisionerFactory)
         }
@@ -484,6 +487,14 @@ mod tests {
 
         fn get_service_name(&self) -> shuttle_service::ServiceName {
             panic!("did not expect any deploy_layer test to get the service name")
+        }
+
+        fn get_build_path(&self) -> Result<PathBuf, shuttle_service::Error> {
+            panic!("did not expect any deploy_layer test to get the build path")
+        }
+
+        fn get_storage_path(&self) -> Result<PathBuf, shuttle_service::Error> {
+            panic!("did not expect any deploy_layer test to get the storage path")
         }
     }
 

--- a/deployer/src/deployment/provisioner_factory.rs
+++ b/deployer/src/deployment/provisioner_factory.rs
@@ -194,13 +194,15 @@ impl<R: ResourceRecorder, S: SecretGetter> Factory for ProvisionerFactory<R, S> 
         self.service_name.clone()
     }
 
-    fn get_build_path(&self) -> PathBuf {
+    fn get_build_path(&self) -> Result<PathBuf, shuttle_service::Error> {
         self.storage_manager
             .service_build_path(self.service_name.as_str())
+            .map_err(Into::into)
     }
 
-    fn get_storage_path(&self) -> PathBuf {
+    fn get_storage_path(&self) -> Result<PathBuf, shuttle_service::Error> {
         self.storage_manager
             .deployment_storage_path(self.service_name.as_str(), &self.deployment_id)
+            .map_err(Into::into)
     }
 }

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -333,7 +333,7 @@ async fn store_lib(
     so_path: impl AsRef<Path>,
     id: &Uuid,
 ) -> Result<()> {
-    let new_so_path = storage_manager.deployment_library_path(&id)?;
+    let new_so_path = storage_manager.deployment_library_path(id)?;
 
     fs::rename(so_path, new_so_path).await?;
 

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -1,4 +1,5 @@
 use super::deploy_layer::{Log, LogRecorder, LogType};
+use super::storage_manager::StorageManager;
 use super::{Built, QueueReceiver, RunSender, State};
 use crate::error::{Error, Result, TestError};
 use crate::persistence::{LogLevel, SecretRecorder};
@@ -31,22 +32,9 @@ pub async fn task(
     run_send: RunSender,
     log_recorder: impl LogRecorder,
     secret_recorder: impl SecretRecorder,
-    artifacts_path: PathBuf,
+    storage_manager: StorageManager,
 ) {
     info!("Queue task started");
-
-    // Path of the directory that contains extracted service Cargo projects.
-    let builds_path = artifacts_path.join("shuttle-builds");
-
-    // The directory in which compiled '.so' files are stored.
-    let libs_path = artifacts_path.join("shuttle-libs");
-
-    fs::create_dir_all(&builds_path)
-        .await
-        .expect("could not create builds directory");
-    fs::create_dir_all(&libs_path)
-        .await
-        .expect("could not create libs directory");
 
     while let Some(queued) = recv.recv().await {
         let id = queued.id;
@@ -56,8 +44,7 @@ pub async fn task(
         let run_send_cloned = run_send.clone();
         let log_recorder = log_recorder.clone();
         let secret_recorder = secret_recorder.clone();
-        let builds_path = builds_path.clone();
-        let libs_path = libs_path.clone();
+        let storage_manager = storage_manager.clone();
 
         tokio::spawn(async move {
             let parent_cx = global::get_text_map_propagator(|propagator| {
@@ -68,7 +55,7 @@ pub async fn task(
 
             async move {
                 match queued
-                    .handle(builds_path, libs_path, log_recorder, secret_recorder)
+                    .handle(storage_manager, log_recorder, secret_recorder)
                     .await
                 {
                     Ok(built) => promote_to_run(built, run_send_cloned).await,
@@ -112,17 +99,16 @@ pub struct Queued {
 }
 
 impl Queued {
-    #[instrument(skip(self, builds_path, libs_path, log_recorder, secret_recorder), fields(id = %self.id, state = %State::Building))]
+    #[instrument(skip(self, storage_manager, log_recorder, secret_recorder), fields(id = %self.id, state = %State::Building))]
     async fn handle(
         self,
-        builds_path: PathBuf,
-        libs_path: PathBuf,
+        storage_manager: StorageManager,
         log_recorder: impl LogRecorder,
         secret_recorder: impl SecretRecorder,
     ) -> Result<Built> {
         info!("Extracting received data");
 
-        let project_path = builds_path.join(&self.service_name);
+        let project_path = storage_manager.service_build_path(&self.service_name);
 
         extract_tar_gz_data(self.data.as_slice(), &project_path).await?;
 
@@ -182,7 +168,7 @@ impl Queued {
 
         info!("Moving built library");
 
-        store_lib(libs_path, so_path, &self.id).await?;
+        store_lib(&storage_manager, so_path, &self.id).await?;
 
         let built = Built {
             id: self.id,
@@ -247,8 +233,6 @@ async fn extract_tar_gz_data(data: impl Read, dest: impl AsRef<Path>) -> Result<
     let tar = GzDecoder::new(data);
     let mut archive = Archive::new(tar);
     archive.set_overwrite(true);
-
-    fs::create_dir_all(&dest).await?;
 
     // Clear directory first
     let mut entries = fs::read_dir(&dest).await?;
@@ -343,13 +327,13 @@ async fn run_pre_deploy_tests(
 }
 
 /// Store 'so' file in the libs folder
-#[instrument(skip(storage_dir_path, so_path, id))]
+#[instrument(skip(storage_manager, so_path, id))]
 async fn store_lib(
-    storage_dir_path: impl AsRef<Path>,
+    storage_manager: &StorageManager,
     so_path: impl AsRef<Path>,
     id: &Uuid,
 ) -> Result<()> {
-    let new_so_path = storage_dir_path.as_ref().join(id.to_string());
+    let new_so_path = storage_manager.deployment_library_path(&id);
 
     fs::rename(so_path, new_so_path).await?;
 

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -108,7 +108,7 @@ impl Queued {
     ) -> Result<Built> {
         info!("Extracting received data");
 
-        let project_path = storage_manager.service_build_path(&self.service_name);
+        let project_path = storage_manager.service_build_path(&self.service_name)?;
 
         extract_tar_gz_data(self.data.as_slice(), &project_path).await?;
 
@@ -333,7 +333,7 @@ async fn store_lib(
     so_path: impl AsRef<Path>,
     id: &Uuid,
 ) -> Result<()> {
-    let new_so_path = storage_manager.deployment_library_path(&id);
+    let new_so_path = storage_manager.deployment_library_path(&id)?;
 
     fs::rename(so_path, new_so_path).await?;
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -215,7 +215,7 @@ impl Built {
             + Send
             + 'static,
     ) -> Result<()> {
-        let so_path = storage_manager.deployment_library_path(&self.id);
+        let so_path = storage_manager.deployment_library_path(&self.id)?;
         let service = load_deployment(address, so_path, factory, logger).await?;
 
         kill_old_deployments.await?;

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -34,6 +34,9 @@ pub async fn task(
 ) {
     info!("Run task started");
 
+    // Path of the directory that contains extracted service Cargo projects.
+    let builds_path = artifacts_path.join("shuttle-builds");
+
     // The directory in which compiled '.so' files are stored.
     let libs_path = artifacts_path.join("shuttle-libs");
 
@@ -66,7 +69,7 @@ pub async fn task(
             }
         };
         let mut factory = match abstract_factory
-            .get_factory(service_name, built.service_id)
+            .get_factory(service_name, built.service_id, builds_path.clone())
             .await
         {
             Ok(factory) => factory,

--- a/deployer/src/deployment/storage_manager.rs
+++ b/deployer/src/deployment/storage_manager.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::{fs, io, path::PathBuf};
 
 use uuid::Uuid;
 
@@ -14,40 +14,42 @@ impl StorageManager {
     }
 
     /// Path of the directory that contains extracted service Cargo projects.
-    pub fn builds_path(&self) -> PathBuf {
+    pub fn builds_path(&self) -> Result<PathBuf, io::Error> {
         let builds_path = self.artifacts_path.join("shuttle-builds");
-        fs::create_dir_all(&builds_path).expect("could not create builds directory");
+        fs::create_dir_all(&builds_path)?;
 
-        builds_path
+        Ok(builds_path)
     }
 
     /// Path for a specific service
-    pub fn service_build_path<S: AsRef<str>>(&self, service_name: S) -> PathBuf {
-        let builds_path = self.builds_path().join(service_name.as_ref());
-        fs::create_dir_all(&builds_path).expect("could not create service builds directory");
+    pub fn service_build_path<S: AsRef<str>>(&self, service_name: S) -> Result<PathBuf, io::Error> {
+        let builds_path = self.builds_path()?.join(service_name.as_ref());
+        fs::create_dir_all(&builds_path)?;
 
-        builds_path
+        Ok(builds_path)
     }
 
     /// The directory in which compiled '.so' files are stored.
-    pub fn libraries_path(&self) -> PathBuf {
+    pub fn libraries_path(&self) -> Result<PathBuf, io::Error> {
         let libs_path = self.artifacts_path.join("shuttle-libs");
-        fs::create_dir_all(&libs_path).expect("could not create libs directory");
+        fs::create_dir_all(&libs_path)?;
 
-        libs_path
+        Ok(libs_path)
     }
 
     /// Path to `.so` for a service
-    pub fn deployment_library_path(&self, deployment_id: &Uuid) -> PathBuf {
-        self.libraries_path().join(deployment_id.to_string())
+    pub fn deployment_library_path(&self, deployment_id: &Uuid) -> Result<PathBuf, io::Error> {
+        let library_path = self.libraries_path()?.join(deployment_id.to_string());
+
+        Ok(library_path)
     }
 
     /// Path of the directory to store user files
-    pub fn storage_path(&self) -> PathBuf {
+    pub fn storage_path(&self) -> Result<PathBuf, io::Error> {
         let storage_path = self.artifacts_path.join("shuttle-storage");
-        fs::create_dir_all(&storage_path).expect("could not create storage directory");
+        fs::create_dir_all(&storage_path)?;
 
-        storage_path
+        Ok(storage_path)
     }
 
     /// Path to folder for storing deployment files
@@ -55,13 +57,13 @@ impl StorageManager {
         &self,
         service_name: S,
         deployment_id: &Uuid,
-    ) -> PathBuf {
+    ) -> Result<PathBuf, io::Error> {
         let storage_path = self
-            .storage_path()
+            .storage_path()?
             .join(service_name.as_ref())
             .join(deployment_id.to_string());
-        fs::create_dir_all(&storage_path).expect("could not create deployment storage directory");
+        fs::create_dir_all(&storage_path)?;
 
-        storage_path
+        Ok(storage_path)
     }
 }

--- a/deployer/src/deployment/storage_manager.rs
+++ b/deployer/src/deployment/storage_manager.rs
@@ -2,6 +2,7 @@ use std::{fs, path::PathBuf};
 
 use uuid::Uuid;
 
+/// Manager to take care of directories for storing project, services and deployment files
 #[derive(Clone)]
 pub struct StorageManager {
     artifacts_path: PathBuf,
@@ -12,7 +13,7 @@ impl StorageManager {
         Self { artifacts_path }
     }
 
-    // Path of the directory that contains extracted service Cargo projects.
+    /// Path of the directory that contains extracted service Cargo projects.
     pub fn builds_path(&self) -> PathBuf {
         let builds_path = self.artifacts_path.join("shuttle-builds");
         fs::create_dir_all(&builds_path).expect("could not create builds directory");
@@ -20,7 +21,7 @@ impl StorageManager {
         builds_path
     }
 
-    // Path for a specific service
+    /// Path for a specific service
     pub fn service_build_path<S: AsRef<str>>(&self, service_name: S) -> PathBuf {
         let builds_path = self.builds_path().join(service_name.as_ref());
         fs::create_dir_all(&builds_path).expect("could not create service builds directory");
@@ -28,7 +29,7 @@ impl StorageManager {
         builds_path
     }
 
-    // The directory in which compiled '.so' files are stored.
+    /// The directory in which compiled '.so' files are stored.
     pub fn libraries_path(&self) -> PathBuf {
         let libs_path = self.artifacts_path.join("shuttle-libs");
         fs::create_dir_all(&libs_path).expect("could not create libs directory");
@@ -36,12 +37,12 @@ impl StorageManager {
         libs_path
     }
 
-    // Path to `.so` for a service
+    /// Path to `.so` for a service
     pub fn deployment_library_path(&self, deployment_id: &Uuid) -> PathBuf {
         self.libraries_path().join(deployment_id.to_string())
     }
 
-    // Path of the directory to store user files
+    /// Path of the directory to store user files
     pub fn storage_path(&self) -> PathBuf {
         let storage_path = self.artifacts_path.join("shuttle-storage");
         fs::create_dir_all(&storage_path).expect("could not create storage directory");
@@ -49,7 +50,7 @@ impl StorageManager {
         storage_path
     }
 
-    // Path to folder for storing deployment files
+    /// Path to folder for storing deployment files
     pub fn deployment_storage_path<S: AsRef<str>>(
         &self,
         service_name: S,

--- a/deployer/src/deployment/storage_manager.rs
+++ b/deployer/src/deployment/storage_manager.rs
@@ -1,0 +1,66 @@
+use std::{fs, path::PathBuf};
+
+use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct StorageManager {
+    artifacts_path: PathBuf,
+}
+
+impl StorageManager {
+    pub fn new(artifacts_path: PathBuf) -> Self {
+        Self { artifacts_path }
+    }
+
+    // Path of the directory that contains extracted service Cargo projects.
+    pub fn builds_path(&self) -> PathBuf {
+        let builds_path = self.artifacts_path.join("shuttle-builds");
+        fs::create_dir_all(&builds_path).expect("could not create builds directory");
+
+        builds_path
+    }
+
+    // Path for a specific service
+    pub fn service_build_path<S: AsRef<str>>(&self, service_name: S) -> PathBuf {
+        let builds_path = self.builds_path().join(service_name.as_ref());
+        fs::create_dir_all(&builds_path).expect("could not create service builds directory");
+
+        builds_path
+    }
+
+    // The directory in which compiled '.so' files are stored.
+    pub fn libraries_path(&self) -> PathBuf {
+        let libs_path = self.artifacts_path.join("shuttle-libs");
+        fs::create_dir_all(&libs_path).expect("could not create libs directory");
+
+        libs_path
+    }
+
+    // Path to `.so` for a service
+    pub fn deployment_library_path(&self, deployment_id: &Uuid) -> PathBuf {
+        self.libraries_path().join(deployment_id.to_string())
+    }
+
+    // Path of the directory to store user files
+    pub fn storage_path(&self) -> PathBuf {
+        let storage_path = self.artifacts_path.join("shuttle-storage");
+        fs::create_dir_all(&storage_path).expect("could not create storage directory");
+
+        storage_path
+    }
+
+    // Path to folder for storing deployment files
+    pub fn deployment_storage_path<S: AsRef<str>>(
+        &self,
+        service_name: S,
+        deployment_id: &Uuid,
+    ) -> PathBuf {
+        let storage_path = self
+            .storage_path()
+            .join(service_name.as_ref())
+            .join(deployment_id.to_string());
+        fs::create_dir_all(&storage_path).expect("could not create deployment storage directory");
+
+        storage_path
+    }
+}

--- a/e2e/tests/integration/helpers/mod.rs
+++ b/e2e/tests/integration/helpers/mod.rs
@@ -42,12 +42,17 @@ shuttle-service = {{ path = "{}" }}
 shuttle-aws-rds = {{ path = "{}" }}
 shuttle-persist = {{ path = "{}" }}
 shuttle-shared-db = {{ path = "{}" }}
-shuttle-secrets = {{ path = "{}" }}"#,
+shuttle-secrets = {{ path = "{}" }}
+shuttle-static-folder = {{ path = "{}" }}"#,
                     WORKSPACE_ROOT.join("service").display(),
                     WORKSPACE_ROOT.join("resources").join("aws-rds").display(),
                     WORKSPACE_ROOT.join("resources").join("persist").display(),
                     WORKSPACE_ROOT.join("resources").join("shared-db").display(),
                     WORKSPACE_ROOT.join("resources").join("secrets").display(),
+                    WORKSPACE_ROOT
+                        .join("resources")
+                        .join("static-folder")
+                        .display(),
                 )
                 .unwrap();
 

--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-static-folder"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin get a static folder at runtime on Shuttle"
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "static-folder"]
 
 [dependencies]
 async-trait = "0.1.56"
-shuttle-service = { path = "../../service", version = "0.7.2", default-features = false }
+shuttle-service = { path = "../../service", version = "0.7.3", default-features = false }
 tokio = { version = "1.19.2", features = ["rt"] }
 
 [dev-dependencies]

--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -3,7 +3,7 @@ name = "shuttle-static-folder"
 version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
-description = "Plugin get a static folder at runtime on Shuttle"
+description = "Plugin to get a static folder at runtime on shuttle"
 keywords = ["shuttle-service", "static-folder"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "static-folder"]
 
 [dependencies]
 async-trait = "0.1.56"
-shuttle-service = { path = "../../service", version = "0.7.3", default-features = false }
+shuttle-service = { path = "../../service", version = "0.7.2", default-features = false }
 tokio = { version = "1.19.2", features = ["rt"] }
 
 [dev-dependencies]

--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "shuttle-static-folder"
+version = "0.7.2"
+edition = "2021"
+license = "Apache-2.0"
+description = "Plugin get a static folder at runtime on Shuttle"
+keywords = ["shuttle-service", "static-folder"]
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.56"
+shuttle-service = { path = "../../service", version = "0.7.2", default-features = false }
+tokio = { version = "1.19.2", features = ["rt"] }
+
+[dev-dependencies]
+tempdir = "0.3.7"
+tokio = { version = "1.19.2", features = ["macros"] }

--- a/resources/static-folder/README.md
+++ b/resources/static-folder/README.md
@@ -1,0 +1,1 @@
+# Shuttle Static Folder

--- a/resources/static-folder/README.md
+++ b/resources/static-folder/README.md
@@ -1,1 +1,7 @@
 # Shuttle Static Folder
+This plugin allows services to get the path to a static folder at runtime
+
+## Usage
+Add `shuttle-static-folder` to the dependencies for your service. This resource can be using by the `shuttle_static_folder::StaticFolder` attribute to get a `PathBuf` with the location of the static folder.
+
+An example using the Axum framework can be found on [GitHub](https://github.com/shuttle-hq/examples/tree/main/axum/websocket)

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -68,12 +68,12 @@ mod tests {
             panic!("no static folder test should try to get the service name")
         }
 
-        fn get_build_path(&self) -> std::path::PathBuf {
-            self.build_path.path().to_owned()
+        fn get_build_path(&self) -> Result<std::path::PathBuf, shuttle_service::Error> {
+            Ok(self.build_path.path().to_owned())
         }
 
-        fn get_storage_path(&self) -> std::path::PathBuf {
-            self.storage_path.path().to_owned()
+        fn get_storage_path(&self) -> Result<std::path::PathBuf, shuttle_service::Error> {
+            Ok(self.storage_path.path().to_owned())
         }
     }
 

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -1,0 +1,111 @@
+use async_trait::async_trait;
+use shuttle_service::{Factory, ResourceBuilder};
+use std::{fs::rename, path::PathBuf};
+use tokio::runtime::Runtime;
+
+pub struct StaticFolder;
+
+#[async_trait]
+impl ResourceBuilder<PathBuf> for StaticFolder {
+    fn new() -> Self {
+        Self {}
+    }
+
+    async fn build(
+        self,
+        factory: &mut dyn Factory,
+        _runtime: &Runtime,
+    ) -> Result<PathBuf, shuttle_service::Error> {
+        let input_dir = factory.get_build_path().join("public");
+        let output_dir = factory.get_storage_path().join("public");
+
+        rename(input_dir, output_dir.clone()).unwrap();
+
+        Ok(output_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self};
+
+    use async_trait::async_trait;
+    use shuttle_service::{Factory, ResourceBuilder};
+    use tempdir::TempDir;
+
+    use crate::StaticFolder;
+
+    struct MockFactory {
+        build_path: TempDir,
+        storage_path: TempDir,
+    }
+
+    impl MockFactory {
+        fn new() -> Self {
+            Self {
+                build_path: TempDir::new("build").unwrap(),
+                storage_path: TempDir::new("storage").unwrap(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Factory for MockFactory {
+        async fn get_db_connection_string(
+            &mut self,
+            _db_type: shuttle_service::database::Type,
+        ) -> Result<String, shuttle_service::Error> {
+            panic!("no static folder test should try to get a db connection string")
+        }
+
+        async fn get_secrets(
+            &mut self,
+        ) -> Result<std::collections::BTreeMap<String, String>, shuttle_service::Error> {
+            panic!("no static folder test should try to get secrets")
+        }
+
+        fn get_service_name(&self) -> shuttle_service::ServiceName {
+            panic!("no static folder test should try to get the service name")
+        }
+
+        fn get_build_path(&self) -> std::path::PathBuf {
+            self.build_path.path().to_owned()
+        }
+
+        fn get_storage_path(&self) -> std::path::PathBuf {
+            self.storage_path.path().to_owned()
+        }
+    }
+
+    #[tokio::test]
+    async fn copies_folder() {
+        let mut factory = MockFactory::new();
+
+        let input_file_path = factory.build_path.path().join("public").join("note.txt");
+        fs::create_dir_all(input_file_path.parent().unwrap()).unwrap();
+        fs::write(input_file_path, "Hello, test!").unwrap();
+
+        let expected_file = factory.storage_path.path().join("public").join("note.txt");
+        assert!(!expected_file.exists(), "input file should not exist yet");
+
+        // Call plugin
+        let static_folder = StaticFolder;
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let actual_folder = static_folder.build(&mut factory, &runtime).await.unwrap();
+
+        assert_eq!(
+            actual_folder,
+            factory.storage_path.path().join("public"),
+            "expect path to the static folder"
+        );
+        assert!(expected_file.exists(), "expected input file to be created");
+        assert_eq!(
+            fs::read_to_string(expected_file).unwrap(),
+            "Hello, test!",
+            "expected file content to match"
+        );
+
+        runtime.shutdown_background();
+    }
+}

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -19,7 +19,7 @@ impl ResourceBuilder<PathBuf> for StaticFolder {
         let input_dir = factory.get_build_path().join("public");
         let output_dir = factory.get_storage_path().join("public");
 
-        rename(input_dir, output_dir.clone()).unwrap();
+        rename(input_dir, output_dir.clone())?;
 
         Ok(output_dir)
     }

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -16,8 +16,8 @@ impl ResourceBuilder<PathBuf> for StaticFolder {
         factory: &mut dyn Factory,
         _runtime: &Runtime,
     ) -> Result<PathBuf, shuttle_service::Error> {
-        let input_dir = factory.get_build_path().join("public");
-        let output_dir = factory.get_storage_path().join("public");
+        let input_dir = factory.get_build_path().join("static");
+        let output_dir = factory.get_storage_path().join("static");
 
         rename(input_dir, output_dir.clone())?;
 
@@ -81,11 +81,11 @@ mod tests {
     async fn copies_folder() {
         let mut factory = MockFactory::new();
 
-        let input_file_path = factory.build_path.path().join("public").join("note.txt");
+        let input_file_path = factory.build_path.path().join("static").join("note.txt");
         fs::create_dir_all(input_file_path.parent().unwrap()).unwrap();
         fs::write(input_file_path, "Hello, test!").unwrap();
 
-        let expected_file = factory.storage_path.path().join("public").join("note.txt");
+        let expected_file = factory.storage_path.path().join("static").join("note.txt");
         assert!(!expected_file.exists(), "input file should not exist yet");
 
         // Call plugin
@@ -96,7 +96,7 @@ mod tests {
 
         assert_eq!(
             actual_folder,
-            factory.storage_path.path().join("public"),
+            factory.storage_path.path().join("static"),
             "expect path to the static folder"
         );
         assert!(expected_file.exists(), "expected input file to be created");

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -16,8 +16,8 @@ impl ResourceBuilder<PathBuf> for StaticFolder {
         factory: &mut dyn Factory,
         _runtime: &Runtime,
     ) -> Result<PathBuf, shuttle_service::Error> {
-        let input_dir = factory.get_build_path().join("static");
-        let output_dir = factory.get_storage_path().join("static");
+        let input_dir = factory.get_build_path()?.join("static");
+        let output_dir = factory.get_storage_path()?.join("static");
 
         rename(input_dir, output_dir.clone())?;
 

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -313,10 +313,10 @@ pub trait Factory: Send + Sync {
     fn get_service_name(&self) -> ServiceName;
 
     /// Get the where the build files are stored for this service
-    fn get_build_path(&self) -> PathBuf;
+    fn get_build_path(&self) -> Result<PathBuf, crate::Error>;
 
     /// Get the path where files can be stored for this deployment
-    fn get_storage_path(&self) -> PathBuf;
+    fn get_storage_path(&self) -> Result<PathBuf, crate::Error>;
 }
 
 /// Used to get resources of type `T` from factories.

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -213,6 +213,7 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::pin::Pin;
 
 pub use async_trait::async_trait;
@@ -310,6 +311,12 @@ pub trait Factory: Send + Sync {
 
     /// Get the name for the service being deployed
     fn get_service_name(&self) -> ServiceName;
+
+    /// Get the where the build files are stored for this service
+    fn get_build_path(&self) -> PathBuf;
+
+    /// Get the path where files can be stored for this deployment
+    fn get_storage_path(&self) -> PathBuf;
 }
 
 /// Used to get resources of type `T` from factories.

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -312,7 +312,7 @@ pub trait Factory: Send + Sync {
     /// Get the name for the service being deployed
     fn get_service_name(&self) -> ServiceName;
 
-    /// Get the where the build files are stored for this service
+    /// Get the path where the build files are stored for this service
     fn get_build_path(&self) -> Result<PathBuf, crate::Error>;
 
     /// Get the path where files can be stored for this deployment

--- a/service/tests/integration/loader.rs
+++ b/service/tests/integration/loader.rs
@@ -60,6 +60,14 @@ impl Factory for DummyFactory {
     async fn get_secrets(&mut self) -> Result<BTreeMap<String, String>, Error> {
         panic!("did not expect any loader test to get secrets")
     }
+
+    fn get_build_path(&self) -> Result<std::path::PathBuf, shuttle_service::Error> {
+        panic!("did not expect any loader test to get the build path")
+    }
+
+    fn get_storage_path(&self) -> Result<std::path::PathBuf, shuttle_service::Error> {
+        panic!("did not expect any loader test to get the storage path")
+    }
 }
 
 #[test]


### PR DESCRIPTION
This resource will allow getting access to the `static` folder in a crate's root as follow

```rust
#[shuttle_service::main]
async fn main(#[shuttle_static_folder::StaticFolder] static_folder: PathBuf) -> ShuttleAxum {
    let serve_dir = get_service(ServeDir::new(static_folder)).handle_error(handle_error);

    let router = Router::new()
        .fallback(serve_dir);

    let sync_wrapper = SyncWrapper::new(router);

    Ok(sync_wrapper)
}
```

This example is based on the [Axum static-file-server example](https://github.com/tokio-rs/axum/blob/main/examples/static-file-server/src/main.rs)