### PR TITLE
feat: implement workspace inheritance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,9 @@ jobs:
       - install-protoc
       - run: cargo fmt --all --check
       - run: cargo install cargo-sort
-      - run: cargo sort --check --workspace
+      # TODO: this is incompatible with workspace inheritance, uncomment when 
+      # https://github.com/DevinR528/cargo-sort/pull/29 is merged
+      # - run: cargo sort --check --workspace
       - run: cargo check --workspace --all-targets
       - save-cargo-cache
   workspace-clippy:
@@ -176,7 +178,9 @@ jobs:
       - apply-patches
       - run: cargo fmt --all --check --manifest-path << parameters.path >>/Cargo.toml
       - run: cargo install cargo-sort
-      - run: cargo sort --check << parameters.path >>
+      # TODO: this is incompatible with workspace inheritance, uncomment when 
+      # https://github.com/DevinR528/cargo-sort/pull/29 is merged
+      # - run: cargo sort --check << parameters.path >>
       - run: |
           cargo clippy --tests \
                        --all-targets \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,16 +1311,16 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.64.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7019448b7d0ffe19d4ab26a340d2efe6da8cf86c8cc01a352b90853e31cd8f7c"
+checksum = "988ba7aa82c0944fd91d119ee24a5c1f865eb2797e0edd90f6c08c7252857ca5"
 dependencies = [
  "anyhow",
  "atty",
  "bytesize",
  "cargo-platform",
  "cargo-util",
- "clap 3.2.17",
+ "clap 3.2.23",
  "crates-io",
  "crossbeam-utils",
  "curl",
@@ -1422,7 +1422,7 @@ dependencies = [
  "cargo-edit",
  "cargo_metadata",
  "chrono",
- "clap 3.2.17",
+ "clap 3.2.23",
  "clap_complete",
  "crossbeam-channel",
  "crossterm",
@@ -1566,13 +1566,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.2.17",
+ "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -1594,7 +1594,7 @@ dependencies = [
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.2.2",
+ "terminal_size 0.2.3",
 ]
 
 [[package]]
@@ -1603,14 +1603,14 @@ version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
 dependencies = [
- "clap 3.2.17",
+ "clap 3.2.23",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -1922,15 +1922,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
- "once_cell",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
@@ -2349,9 +2348,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "either"
@@ -2788,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
 dependencies = [
  "bitflags",
  "libc",
@@ -3333,12 +3332,6 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
-
-[[package]]
-name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
@@ -3381,8 +3374,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
 dependencies = [
  "hermit-abi 0.2.6",
- "io-lifetimes 1.0.3",
- "rustix 0.36.3",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.42.0",
 ]
 
@@ -3489,9 +3482,9 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.2+1.4.2"
+version = "0.13.4+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
@@ -3563,12 +3556,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.0.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3695,6 +3682,15 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -3889,7 +3885,7 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
  "pin-utils",
 ]
 
@@ -4139,9 +4135,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.4.0"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eca3ecae1481e12c3d9379ec541b238a16f0b75c9a409942daa8ec20dbfdb62"
+checksum = "c4750134fb6a5d49afc80777394ad5d95b04bc12068c6abb92fae8f43817270f"
 dependencies = [
  "log",
  "serde",
@@ -4853,11 +4849,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -4865,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -5260,29 +5255,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 0.7.5",
- "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 1.0.3",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.1.3",
+ "linux-raw-sys",
  "windows-sys 0.42.0",
 ]
 
@@ -5812,7 +5793,7 @@ dependencies = [
  "cargo",
  "cargo_metadata",
  "chrono",
- "clap 3.2.17",
+ "clap 3.2.23",
  "crossbeam-channel",
  "ctor",
  "flate2",
@@ -5912,7 +5893,7 @@ version = "0.7.3"
 dependencies = [
  "aws-config",
  "aws-sdk-rds",
- "clap 3.2.17",
+ "clap 3.2.23",
  "ctor",
  "fqdn",
  "mongodb",
@@ -6468,11 +6449,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ca90c434fd12083d1a6bdcbe9f92a14f96c8a1ba600ba451734ac334521f7a"
+checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
- "rustix 0.35.13",
+ "rustix",
  "windows-sys 0.42.0",
 ]
 
@@ -6515,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,13 @@ edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-# TODO: these are different versions, and setting their version here can't 
-# be done without them using the worspace version. Using the workspace version 
-# means the resources can't resolve their dependency on shuttle-service. Look at
-# other repos that have implemented inheritance to figure out a solution for this.
-shuttle-common = { path = "common" }
-shuttle-proto = { path = "proto" }
-shuttle-service = { path = "service" }
-shuttle-codegen = { path = "codegen" }
+# TODO: these are different versions, so we end up setting the version in two
+# places for some of them. Using the workspace version also means the resources 
+# can't resolve their dependency on shuttle-service. 
+# shuttle-common = { path = "common" }
+# shuttle-proto = { path = "proto" }
+# shuttle-service = { path = "service" }
+# shuttle-codegen = { path = "codegen" }
 
 anyhow = "1.0.66"
 async-trait = "0.1.58"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,17 @@ exclude = [
 ]
 
 [workspace.package]
+version = "0.7.3"
 edition = "2021"
 license = "Apache-2.0"
 
-# TODO: add local crates to the workspace dependencies when it's
-# supported by cargo-chef: https://github.com/LukeMathWalker/cargo-chef/issues/167
-
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table
 [workspace.dependencies]
+shuttle-codegen = { path = "codegen", version = "0.7.2" }
+shuttle-common = { path = "common", version = "0.7.3" }
+shuttle-proto = { path = "proto", version = "0.7.3" }
+shuttle-service = { path = "service", version = "0.7.2" }
+
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 axum = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "provisioner",
   "service"
 ]
+
 exclude = [
   "e2e",
   "examples",
@@ -19,3 +20,21 @@ exclude = [
   "resources/shared-db",
   "resources/static-folder"
 ]
+
+[workspace.package]
+# TODO: should we have the same version for all crates?
+# version = "0.7.2"
+edition = "2021"
+license = "Apache-2.0"
+
+[workspace.dependencies]
+shuttle-common = { path = "common", version = "0.7.3" }
+shuttle-proto = { path = "proto", version = "0.7.3" }
+shuttle-service = { path = "service", version = "0.7.2" }
+shuttle-codegen = { path = "codegen", version = "0.7.2" }
+
+anyhow = "1.0.66"
+thiserror = "1.0.37"
+tracing = "0.1.37"
+tracing-subscriber = "0.3.16"
+once_cell = "1.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,15 @@ exclude = [
   "resources/static-folder"
 ]
 
-# TODO: should we have the same version for all crates?
-# currently backend crates are 0.7.3 and client side are 0.7.2
 [workspace.package]
-# version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 
-[workspace.dependencies]
-# TODO: these are different versions, so we end up setting the version in two
-# places for some of them. Using the workspace version also means the resources 
-# can't resolve their dependency on shuttle-service. 
-# shuttle-common = { path = "common" }
-# shuttle-proto = { path = "proto" }
-# shuttle-service = { path = "service" }
-# shuttle-codegen = { path = "codegen" }
+# TODO: add local crates to the workspace dependencies when it's
+# supported by cargo-chef: https://github.com/LukeMathWalker/cargo-chef/issues/167
 
+# https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table
+[workspace.dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 axum = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,14 @@ edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-shuttle-common = { path = "common", version = "0.7.3" }
-shuttle-proto = { path = "proto", version = "0.7.3" }
-shuttle-service = { path = "service", version = "0.7.2" }
-shuttle-codegen = { path = "codegen", version = "0.7.2" }
+# TODO: these are a different versions, and setting their version here can't 
+# be done without them using the worspace version. Using the workspace version 
+# means the resources can't resolve their dependency on shuttle-service. Look at
+# other repos that have implemented inheritance to figure out a solution for this.
+shuttle-common = { path = "common" }
+shuttle-proto = { path = "proto" }
+shuttle-service = { path = "service" }
+shuttle-codegen = { path = "codegen" }
 
 anyhow = "1.0.66"
 thiserror = "1.0.37"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,14 +21,15 @@ exclude = [
   "resources/static-folder"
 ]
 
-[workspace.package]
 # TODO: should we have the same version for all crates?
+# currently backend crates are 0.7.3 and client side are 0.7.2
+[workspace.package]
 # version = "0.7.2"
 edition = "2021"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-# TODO: these are a different versions, and setting their version here can't 
+# TODO: these are different versions, and setting their version here can't 
 # be done without them using the worspace version. Using the workspace version 
 # means the resources can't resolve their dependency on shuttle-service. Look at
 # other repos that have implemented inheritance to figure out a solution for this.
@@ -38,7 +39,13 @@ shuttle-service = { path = "service" }
 shuttle-codegen = { path = "codegen" }
 
 anyhow = "1.0.66"
+async-trait = "0.1.58"
+axum = "0.6.0"
+chrono = "0.4.23"
+once_cell = "1.16.0"
+uuid = "1.2.2"
 thiserror = "1.0.37"
+serde = "1.0.148"
+serde_json = "1.0.89"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-once_cell = "1.16.0"

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 clap = { version = "4.0.27", features = [ "derive", "env" ] }
 dirs = "4.0.0"
 reqwest = { version = "0.11.13", features = ["json"] }
@@ -12,9 +12,8 @@ serde = { version = "1.0.148", features = ["derive"] }
 serde_json = "1.0.89"
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5.9"
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dependencies.shuttle-common]
-version = "0.7.2"
-path = "../common"
+workspace = true

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -16,4 +16,5 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dependencies.shuttle-common]
-workspace = true
+version = "0.7.3"
+path = "../common"

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -16,5 +16,5 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dependencies.shuttle-common]
-version = "0.7.3"
-path = "../common"
+workspace = true
+features = ["models"]

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -8,8 +8,8 @@ anyhow = { workspace = true }
 clap = { version = "4.0.27", features = [ "derive", "env" ] }
 dirs = "4.0.0"
 reqwest = { version = "0.11.13", features = ["json"] }
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 toml = "0.5.9"
 tracing = { workspace = true }

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -8,12 +8,12 @@ homepage = "https://www.shuttle.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1.58"
+async-trait = { workspace = true }
 bollard = "0.13.0"
 cargo = "0.64.0"
 cargo-edit = { version = "0.11.6", features = ["cli"] }
 cargo_metadata = "0.15.2"
-chrono = "0.4.23"
+chrono = { workspace = true }
 clap = { version = "3.2.17", features = ["derive", "env"] }
 clap_complete = "3.2.5"
 crossbeam-channel = "0.5.6"
@@ -30,8 +30,8 @@ portpicker = "0.1.1"
 reqwest = { version = "0.11.13", features = ["json"] }
 reqwest-middleware = "0.2.0"
 reqwest-retry = "0.2.0"
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 strum = { version = "0.24.1", features = ["derive"] }
 tar = "0.4.38"
@@ -42,7 +42,7 @@ toml_edit = "0.15.0"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = "2.3.1"
-uuid = { version = "1.2.2", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 webbrowser = "0.8.2"
 
 [dependencies.shuttle-common]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -46,14 +46,16 @@ uuid = { workspace = true, features = ["v4"] }
 webbrowser = "0.8.2"
 
 [dependencies.shuttle-common]
-workspace = true
+version = "0.7.3"
+path = "../common"
 
 [dependencies.shuttle-secrets]
 version = "0.7.2"
 path = "../resources/secrets"
 
 [dependencies.shuttle-service]
-workspace = true
+version = "0.7.2"
+path = "../service"
 features = ["loader"]
 
 [features]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cargo-shuttle"
 version = "0.7.2"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+license.workspace = true
 description = "A cargo command for the shuttle platform (https://www.shuttle.rs/)"
 homepage = "https://www.shuttle.rs"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 async-trait = "0.1.58"
 bollard = "0.13.0"
 cargo = "0.64.0"
@@ -39,23 +39,21 @@ tokio = { version = "1.22.0", features = ["macros"] }
 tokio-tungstenite = { version = "0.17.2", features = ["native-tls"] }
 toml = "0.5.9"
 toml_edit = "0.15.0"
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = "2.3.1"
 uuid = { version = "1.2.2", features = ["v4"] }
 webbrowser = "0.8.2"
 
 [dependencies.shuttle-common]
-version = "0.7.2"
-path = "../common"
+workspace = true
 
 [dependencies.shuttle-secrets]
 version = "0.7.2"
 path = "../resources/secrets"
 
 [dependencies.shuttle-service]
-version = "0.7.2"
-path = "../service"
+workspace = true
 features = ["loader"]
 
 [features]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -10,7 +10,8 @@ homepage = "https://www.shuttle.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bollard = "0.13.0"
-cargo = "0.64.0"
+# TODO: debug the libgit2-sys conflict with cargo-edit when upgrading cargo to 0.66
+cargo = "0.65.0"
 cargo-edit = { version = "0.11.6", features = ["cli"] }
 cargo_metadata = "0.15.2"
 chrono = { workspace = true }

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -47,16 +47,15 @@ uuid = { workspace = true, features = ["v4"] }
 webbrowser = "0.8.2"
 
 [dependencies.shuttle-common]
-version = "0.7.3"
-path = "../common"
+workspace = true
+features= ["models"]
 
 [dependencies.shuttle-secrets]
 version = "0.7.2"
 path = "../resources/secrets"
 
 [dependencies.shuttle-service]
-version = "0.7.2"
-path = "../service"
+workspace = true
 features = ["loader"]
 
 [features]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shuttle-codegen"
 version = "0.7.2"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+licence.workspace = true
 description = "Proc-macro code generator for the shuttle.rs service"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "shuttle-common"
 version = "0.7.3"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+licence.workspace = true
 description = "Common library for the shuttle platform (https://www.shuttle.rs/)"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.66", optional = true }
+anyhow = { workspace = true, optional = true }
 async-trait = { version = "0.1.58", optional = true }
 axum = { version = "0.6.0", optional = true }
 chrono = { version = "0.4.23", features = ["serde"] }
 comfy-table = { version = "6.1.3", optional = true }
 crossterm =  { version = "0.25.0", optional = true }
 http = { version = "0.2.8", optional = true }
-once_cell = "1.16.0"
+once_cell = { workspace = true }
 reqwest = { version = "0.11.13", optional = true }
 rustrict = "0.5.5"
 serde = { version = "1.0.148", features = ["derive"] }
 serde_json = { version = "1.0.89", optional = true }
 strum = { version = "0.24.1", features = ["derive"] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 uuid = { version = "1.2.2", features = ["v4", "serde"] }
 
 [features]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,20 +8,20 @@ description = "Common library for the shuttle platform (https://www.shuttle.rs/)
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-async-trait = { version = "0.1.58", optional = true }
-axum = { version = "0.6.0", optional = true }
-chrono = { version = "0.4.23", features = ["serde"] }
+async-trait = { workspace = true , optional = true }
+axum = { workspace = true, optional = true }
+chrono = { workspace = true, features = ["serde"] }
 comfy-table = { version = "6.1.3", optional = true }
 crossterm =  { version = "0.25.0", optional = true }
 http = { version = "0.2.8", optional = true }
 once_cell = { workspace = true }
 reqwest = { version = "0.11.13", optional = true }
 rustrict = "0.5.5"
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = { version = "1.0.89", optional = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 strum = { version = "0.24.1", features = ["derive"] }
 tracing = { workspace = true }
-uuid = { version = "1.2.2", features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "serde"] }
 
 [features]
 default = ["models"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-common"
-version = "0.7.3"
+version.workspace = true
 edition.workspace = true
 licence.workspace = true
 description = "Common library for the shuttle platform (https://www.shuttle.rs/)"
@@ -24,8 +24,6 @@ tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 [features]
-default = ["models"]
-
 backend = ["async-trait", "axum"]
 display = ["comfy-table", "crossterm"]
 models = ["anyhow", "async-trait", "display", "http", "reqwest", "serde_json"]

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -44,14 +44,17 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [dependencies.shuttle-common]
-workspace = true
+version = "0.7.3"
+path = "../common"
 features = ["backend"]
 
 [dependencies.shuttle-proto]
-workspace = true
+version = "0.7.2"
+path = "../proto"
 
 [dependencies.shuttle-service]
-workspace = true
+version = "0.7.2"
+path = "../service"
 features = ["loader"]
 
 [dev-dependencies]

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -7,12 +7,12 @@ description = "Service with instances created per project for handling the compi
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = "0.1.58"
-axum = { version = "0.6.0", features = ["ws"] }
+async-trait = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
 bytes = "1.3.0"
 cargo = "0.64.0"
 cargo_metadata = "0.15.2"
-chrono = "0.4.23"
+chrono = { workspace = true }
 clap = { version = "3.2.8", features = ["derive"] }
 crossbeam-channel = "0.5.6"
 flate2 = "1.0.25"
@@ -27,8 +27,8 @@ opentelemetry-datadog = { version = "0.6.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.7.0"
 pipe = "0.4.0"
 portpicker = "0.1.1"
-serde = "1.0.148"
-serde_json = "1.0.89"
+serde = { workspace = true }
+serde_json = { workspace = true }
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "sqlite", "chrono", "json", "migrate", "uuid"] }
 strum = { version = "0.24.1", features = ["derive"] }
 tar = "0.4.38"
@@ -41,7 +41,7 @@ tower-http = { version = "0.3.4", features = ["auth", "trace"] }
 tracing = { workspace = true }
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-uuid = { version = "1.2.2", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 
 [dependencies.shuttle-common]
 workspace = true

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -10,7 +10,8 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["ws"] }
 bytes = "1.3.0"
-cargo = "0.64.0"
+# TODO: debug the libgit2-sys conflict with cargo-edit when upgrading cargo to 0.66
+cargo = "0.65.0"
 cargo_metadata = "0.15.2"
 chrono = { workspace = true }
 clap = { version = "3.2.8", features = ["derive"] }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "shuttle-deployer"
 version = "0.7.3"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
 description = "Service with instances created per project for handling the compilation, loading, and execution of Shuttle services"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 async-trait = "0.1.58"
 axum = { version = "0.6.0", features = ["ws"] }
 bytes = "1.3.0"
@@ -20,7 +21,7 @@ futures = "0.3.25"
 hyper = { version = "0.14.23", features = ["client", "http1", "http2", "tcp" ] }
 # not great, but waiting for WebSocket changes to be merged
 hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "master" }
-once_cell = "1.16.0"
+once_cell = { workspace = true }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-datadog = { version = "0.6.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.7.0"
@@ -31,29 +32,26 @@ serde_json = "1.0.89"
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "sqlite", "chrono", "json", "migrate", "uuid"] }
 strum = { version = "0.24.1", features = ["derive"] }
 tar = "0.4.38"
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 tokio = { version = "1.22.0", features = ["fs"] }
 toml = "0.5.9"
 tonic = "0.8.3"
 tower = { version = "0.4.13", features = ["make"] }
 tower-http = { version = "0.3.4", features = ["auth", "trace"] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 tracing-opentelemetry = "0.18.0"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { version = "1.2.2", features = ["v4"] }
 
 [dependencies.shuttle-common]
-version = "0.7.2"
-path = "../common"
+workspace = true
 features = ["backend"]
 
 [dependencies.shuttle-proto]
-version = "0.7.2"
-path = "../proto"
+workspace = true
 
 [dependencies.shuttle-service]
-version = "0.7.2"
-path = "../service"
+workspace = true
 features = ["loader"]
 
 [dev-dependencies]

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-deployer"
-version = "0.7.3"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Service with instances created per project for handling the compilation, loading, and execution of Shuttle services"
@@ -45,17 +45,14 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }
 
 [dependencies.shuttle-common]
-version = "0.7.3"
-path = "../common"
-features = ["backend"]
+workspace = true
+features= ["backend", "models"]
 
 [dependencies.shuttle-proto]
-version = "0.7.2"
-path = "../proto"
+workspace = true
 
 [dependencies.shuttle-service]
-version = "0.7.2"
-path = "../service"
+workspace = true
 features = ["loader"]
 
 [dev-dependencies]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -44,7 +44,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = [ "v4" ] }
 
 [dependencies.shuttle-common]
-workspace = true
+version = "0.7.3"
+path = "../common"
 features = ["backend"]
 
 [dev-dependencies]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-gateway"
-version = "0.7.3"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false
@@ -44,9 +44,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = [ "v4" ] }
 
 [dependencies.shuttle-common]
-version = "0.7.3"
-path = "../common"
-features = ["backend"]
+workspace = true
+features = ["backend", "models"]
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "shuttle-gateway"
 version = "0.7.3"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]
@@ -21,7 +22,7 @@ hyper = { version = "0.14.23", features = [ "stream" ] }
 hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "bug/host_header" }
 instant-acme = "0.1.1"
 lazy_static = "1.4.0"
-once_cell = "1.16.0"
+once_cell = { workspace = true }
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-datadog = { version = "0.6.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.7.0"
@@ -37,18 +38,17 @@ strum = { version = "0.24.1", features = ["derive"] }
 tokio = { version = "1.22.0", features = [ "full" ] }
 tower = { version = "0.4.13", features = [ "steer" ] }
 tower-http = { version = "0.3.4", features = ["trace"] }
-tracing = "0.1.37"
+tracing = { workspace = true }
 tracing-opentelemetry = "0.18.0"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { version = "1.2.2", features = [ "v4" ] }
 
 [dependencies.shuttle-common]
-version = "0.7.2"
-path = "../common"
+workspace = true
 features = ["backend"]
 
 [dev-dependencies]
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 base64 = "0.13.1"
 colored = "2.0.0"
 portpicker = "0.1.1"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 
 [dependencies]
 acme2 = "0.5.1"
-async-trait = "0.1.58"
-axum = { version = "0.6.0", features = [ "headers" ] }
+async-trait = { workspace = true }
+axum = { workspace = true, features = [ "headers" ] }
 axum-server = { version = "0.4.4", features = [ "tls-rustls" ] }
 base64 = "0.13.1"
 bollard = "0.13.0"
-chrono = "0.4.23"
+chrono = { workspace = true }
 clap = { version = "4.0.27", features = [ "derive" ] }
 fqdn = "0.2.3"
 futures = "0.3.25"
@@ -31,8 +31,8 @@ rand = "0.8.5"
 rcgen = "0.10.0"
 rustls = "0.20.7"
 rustls-pemfile = "1.0.1"
-serde = { version = "1.0.148", features = [ "derive" ] }
-serde_json = "1.0.89"
+serde = { workspace = true, features = [ "derive" ] }
+serde_json = { workspace = true }
 sqlx = { version = "0.6.2", features = [ "sqlite", "json", "runtime-tokio-native-tls", "migrate" ] }
 strum = { version = "0.24.1", features = ["derive"] }
 tokio = { version = "1.22.0", features = [ "full" ] }
@@ -41,7 +41,7 @@ tower-http = { version = "0.3.4", features = ["trace"] }
 tracing = { workspace = true }
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-uuid = { version = "1.2.2", features = [ "v4" ] }
+uuid = { workspace = true, features = [ "v4" ] }
 
 [dependencies.shuttle-common]
 workspace = true

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,7 +11,8 @@ prost = "0.11.2"
 tonic = "0.8.3"
 
 [dependencies.shuttle-common]
-workspace = true
+version = "0.7.3"
+path = "../common"
 
 [build-dependencies]
 tonic-build = "0.8.3"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-proto"
-version = "0.7.3"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -11,8 +11,8 @@ prost = "0.11.2"
 tonic = "0.8.3"
 
 [dependencies.shuttle-common]
-version = "0.7.3"
-path = "../common"
+workspace = true
+features = ["models"]
 
 [build-dependencies]
 tonic-build = "0.8.3"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "shuttle-proto"
 version = "0.7.3"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,8 +11,7 @@ prost = "0.11.2"
 tonic = "0.8.3"
 
 [dependencies.shuttle-common]
-version = "0.7.2"
-path = "../common"
+workspace = true
 
 [build-dependencies]
 tonic-build = "0.8.3"

--- a/provisioner/Cargo.toml
+++ b/provisioner/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "shuttle-provisioner"
 version = "0.7.3"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
 description = "Service responsible for provisioning and managing resources for services"
 publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -15,19 +16,18 @@ mongodb = "2.3.1"
 prost = "0.11.2"
 rand = "0.8.5"
 sqlx = { version = "0.6.2", features = ["postgres", "runtime-tokio-native-tls"] }
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 tonic = "0.8.3"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dependencies.shuttle-proto]
-version = "0.7.2"
-path = "../proto"
+workspace = true
 
 [dev-dependencies]
 ctor = "0.1.26"
-once_cell = "1.16.0"
+once_cell = { workspace = true }
 portpicker = "0.1.1"
 serde_json = "1.0.89"
 

--- a/provisioner/Cargo.toml
+++ b/provisioner/Cargo.toml
@@ -29,7 +29,7 @@ workspace = true
 ctor = "0.1.26"
 once_cell = { workspace = true }
 portpicker = "0.1.1"
-serde_json = "1.0.89"
+serde_json = { workspace = true }
 
 [build-dependencies]
 tonic-build = "0.8.3"

--- a/provisioner/Cargo.toml
+++ b/provisioner/Cargo.toml
@@ -23,7 +23,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dependencies.shuttle-proto]
-workspace = true
+version = "0.7.3"
+path = "../proto"
 
 [dev-dependencies]
 ctor = "0.1.26"

--- a/provisioner/Cargo.toml
+++ b/provisioner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-provisioner"
-version = "0.7.3"
+version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Service responsible for provisioning and managing resources for services"
@@ -23,8 +23,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dependencies.shuttle-proto]
-version = "0.7.3"
-path = "../proto"
+workspace = true
 
 [dev-dependencies]
 ctor = "0.1.26"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -15,8 +15,8 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, optional = true }
 bincode = { version = "1.3.3", optional = true }
-# TODO: debug the libgit2-sys conflict arising from upgrading cargo to 0.66
-cargo = { version = "0.64.0", optional = true }
+# TODO: debug the libgit2-sys conflict with cargo-edit when upgrading cargo to 0.66
+cargo = { version = "0.65.0", optional = true }
 cargo_metadata = "0.15.2"
 chrono = { workspace = true }
 crossbeam-channel = "0.5.6"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -48,11 +48,13 @@ optional = true
 features = ["tokio1"]
 
 [dependencies.shuttle-codegen]
-workspace = true 
+version = "0.7.2"
+path = "../codegen"
 optional = true
 
 [dependencies.shuttle-common]
-workspace = true
+version = "0.7.3"
+path = "../common"
 default-features = false
 
 [dev-dependencies]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -48,14 +48,11 @@ optional = true
 features = ["tokio1"]
 
 [dependencies.shuttle-codegen]
-version = "0.7.2"
-path = "../codegen"
+workspace = true
 optional = true
 
 [dependencies.shuttle-common]
-version = "0.7.3"
-path = "../common"
-default-features = false
+workspace = true
 
 [dev-dependencies]
 portpicker = "0.1.1"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,13 +12,13 @@ doctest = false
 [dependencies]
 actix-web = { version = "4.2.1", optional = true }
 anyhow = { workspace = true }
-async-trait = "0.1.58"
-axum = { version = "0.6.0", optional = true }
+async-trait = { workspace = true }
+axum = { workspace = true, optional = true }
 bincode = { version = "1.3.3", optional = true }
 # TODO: debug the libgit2-sys conflict arising from upgrading cargo to 0.66
 cargo = { version = "0.64.0", optional = true }
 cargo_metadata = "0.15.2"
-chrono = "0.4.23"
+chrono = { workspace = true }
 crossbeam-channel = "0.5.6"
 futures = { version = "0.3.25", features = ["std"] }
 hyper = { version = "0.14.23", features = ["server", "tcp", "http1"], optional = true }
@@ -27,7 +27,7 @@ pipe = "0.4.0"
 poem = { version = "1.3.49", optional = true }
 rocket = { version = "0.5.0-rc.2", optional = true }
 salvo = { version = "0.37.5", optional = true }
-serde_json = "1.0.89"
+serde_json = { workspace = true }
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"], optional = true }
 sync_wrapper = { version = "0.1.1", optional = true }
 thiserror = { workspace = true }
@@ -36,8 +36,8 @@ tide = { version = "0.16.0", optional = true }
 tokio = { version = "=1.22.0", features = ["rt", "rt-multi-thread", "sync"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-uuid = { version = "1.2.2", features = ["v4"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { workspace = true, features = ["v4"] }
 warp = { version = "0.3.3", optional = true }
 
 # Tide does not have tokio support. So make sure async-std is compatible with tokio
@@ -59,7 +59,7 @@ default-features = false
 portpicker = "0.1.1"
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.22.0", features = ["macros"] }
-uuid = { version = "1.2.2", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 
 [features]
 default = ["codegen"]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "shuttle-service"
 version = "0.7.2"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+license.workspace = true
 description = "Service traits and macros to deploy on the shuttle platform (https://www.shuttle.rs/)"
 homepage = "https://www.shuttle.rs"
 
@@ -11,11 +11,11 @@ doctest = false
 
 [dependencies]
 actix-web = { version = "4.2.1", optional = true }
-anyhow = "1.0.66"
+anyhow = { workspace = true }
 async-trait = "0.1.58"
 axum = { version = "0.6.0", optional = true }
 bincode = { version = "1.3.3", optional = true }
-# todo: debug updating this to 0.66
+# TODO: debug the libgit2-sys conflict arising from upgrading cargo to 0.66
 cargo = { version = "0.64.0", optional = true }
 cargo_metadata = "0.15.2"
 chrono = "0.4.23"
@@ -30,12 +30,12 @@ salvo = { version = "0.37.5", optional = true }
 serde_json = "1.0.89"
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"], optional = true }
 sync_wrapper = { version = "0.1.1", optional = true }
-thiserror = "1.0.37"
+thiserror = { workspace = true }
 thruster = { version = "1.3.0", optional = true }
 tide = { version = "0.16.0", optional = true }
 tokio = { version = "=1.22.0", features = ["rt", "rt-multi-thread", "sync"] }
 tower = { version = "0.4.13", features = ["make"], optional = true }
-tracing = "0.1.37"
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 uuid = { version = "1.2.2", features = ["v4"] }
 warp = { version = "0.3.3", optional = true }
@@ -48,20 +48,18 @@ optional = true
 features = ["tokio1"]
 
 [dependencies.shuttle-codegen]
-version = "0.7.2"
-path = "../codegen"
+workspace = true 
 optional = true
+
+[dependencies.shuttle-common]
+workspace = true
+default-features = false
 
 [dev-dependencies]
 portpicker = "0.1.1"
 sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls", "postgres"] }
 tokio = { version = "1.22.0", features = ["macros"] }
 uuid = { version = "1.2.2", features = ["v4"] }
-
-[dependencies.shuttle-common]
-version = "0.7.2"
-default-features = false
-path = "../common"
 
 [features]
 default = ["codegen"]


### PR DESCRIPTION
This implements the new workspace inheritance feature from 1.64. For this PR I elected to just add some external crates to the workspace dependencies, since `cargo-chef` does not support local crate workspace deps yet. When it does, we can add more. I'm happy to add more external deps to this PR, but it should also be easy to do as part of other PRs as we see commonly used deps that aren't inherited.