### PR TITLE
feat: build tests in release profile, limit build workers

### DIFF
--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shuttle-codegen"
 version = "0.7.2"
 edition.workspace = true
-licence.workspace = true
+license.workspace = true
 description = "Proc-macro code generator for the shuttle.rs service"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "shuttle-common"
 version.workspace = true
 edition.workspace = true
-licence.workspace = true
+license.workspace = true
 description = "Common library for the shuttle platform (https://www.shuttle.rs/)"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -178,6 +178,12 @@ fn get_compile_options(config: &Config, release_mode: bool) -> anyhow::Result<Co
         InternedString::new("dev")
     };
 
+    // This sets the max workers for cargo build to 8 for release mode (aka deployment),
+    // but leaves it as default (num cpus) for local runs
+    if release_mode {
+        opts.build_config.jobs = 8
+    };
+
     Ok(opts)
 }
 


### PR DESCRIPTION
This limits the workers used by `cargo build` to 8 for deployments, reducing memory usage during deployments while still keeping build times low. 

It also set tests that are ran after building a project for deployment to build in the release profile, this means that this step doesn't have to recompile the crates in the debug profile for testing.