### PR TITLE
feat: create `init` project from correct dir

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -173,7 +173,7 @@ impl Shuttle {
 
         // 5. Initialize locally
         init::cargo_init(path.clone())?;
-        init::cargo_shuttle_init(path, framework)?;
+        init::cargo_shuttle_init(path.clone(), framework)?;
         println!();
 
         // 6. Confirm that the user wants to create the project environment on Shuttle
@@ -182,12 +182,20 @@ impl Shuttle {
         } else if args.new {
             true
         } else {
-            Confirm::with_theme(&theme)
+            let should_create = Confirm::with_theme(&theme)
                 .with_prompt("Do you want to create the project environment on Shuttle?")
                 .default(true)
-                .interact()?
+                .interact()?;
+
+            println!();
+            should_create
         };
+
         if should_create_environment {
+            // Set the project working directory path to the init path,
+            // so `load_project` is ran with the correct project path
+            project_args.working_directory = path;
+
             self.load_project(&mut project_args)?;
             let mut client = Client::new(self.ctx.api_url());
             client.set_api_key(self.ctx.api_key()?);


### PR DESCRIPTION
When using `init` to bootstrap a project, at the end a user is prompted to create their project container. The path to load the project from is the `ProjectArgs` working directory, which would be different from the the path to the directory the user created via `init` (unless working dir was default `.` and user selected default `.` for project dir). In most cases this would result in an error: "could not locate the root of a cargo project".