### PR TITLE
Feat/set cpu limit

### DIFF
--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -318,9 +318,6 @@ async fn run_pre_deploy_tests(
     // recompiled in debug mode for the tests, reducing memory usage during deployment.
     compile_opts.build_config.requested_profile = InternedString::new("release");
 
-    // Build tests with a maximum of 8 workers.
-    compile_opts.build_config.jobs = 8;
-
     let opts = TestOptions {
         compile_opts,
         no_run: false,

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -318,6 +318,9 @@ async fn run_pre_deploy_tests(
     // recompiled in debug mode for the tests, reducing memory usage during deployment.
     compile_opts.build_config.requested_profile = InternedString::new("release");
 
+    // Build tests with a maximum of 4 workers.
+    compile_opts.build_config.jobs = 4;
+
     let opts = TestOptions {
         compile_opts,
         no_run: false,

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -534,8 +534,12 @@ impl ProjectCreating {
                 "Source": format!("{prefix}{project_name}_vol"),
                 "Type": "volume"
             }],
+            // https://docs.docker.com/config/containers/resource_constraints/#memory
             "Memory": 6442450000i64, // 6 GiB hard limit
             "MemoryReservation": 4295000000i64, // 4 GiB soft limit, applied if host is low on memory
+            // https://docs.docker.com/config/containers/resource_constraints/#cpu
+            "CpuPeriod": 100000i64,
+            "CpuQuota": 400000i64
         });
 
         debug!(

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -560,7 +560,11 @@ where
     F: FnOnce(&mut actix_web::web::ServiceConfig) + Sync + Send + Clone + 'static,
 {
     async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), Error> {
+        // Start a worker for each cpu, but no more than 4.
+        let worker_count = num_cpus::get().max(4);
+
         let srv = actix_web::HttpServer::new(move || actix_web::App::new().configure(self.clone()))
+            .workers(worker_count)
             .bind(addr)?
             .run();
         srv.await.map_err(error::CustomError::new)?;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -560,11 +560,7 @@ where
     F: FnOnce(&mut actix_web::web::ServiceConfig) + Sync + Send + Clone + 'static,
 {
     async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), Error> {
-        // Start a worker for each cpu, but no more than 8.
-        let worker_count = num_cpus::get().max(8);
-
         let srv = actix_web::HttpServer::new(move || actix_web::App::new().configure(self.clone()))
-            .workers(worker_count)
             .bind(addr)?
             .run();
         srv.await.map_err(error::CustomError::new)?;

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -178,6 +178,12 @@ fn get_compile_options(config: &Config, release_mode: bool) -> anyhow::Result<Co
         InternedString::new("dev")
     };
 
+    // This sets the max workers for cargo build to 4 for release mode (aka deployment),
+    // but leaves it as default (num cpus) for local runs
+    if release_mode {
+        opts.build_config.jobs = 4
+    };
+
     Ok(opts)
 }
 

--- a/service/src/loader.rs
+++ b/service/src/loader.rs
@@ -178,12 +178,6 @@ fn get_compile_options(config: &Config, release_mode: bool) -> anyhow::Result<Co
         InternedString::new("dev")
     };
 
-    // This sets the max workers for cargo build to 8 for release mode (aka deployment),
-    // but leaves it as default (num cpus) for local runs
-    if release_mode {
-        opts.build_config.jobs = 8
-    };
-
     Ok(opts)
 }
 


### PR DESCRIPTION
Cap the max amount of cpus to 4 in deployer containers. ~Also remove jobs restriction on cargo build in deployer and the worker cap on actix applications, since they are made redundant by the cpu cap.~ I added back the limits (set to 4) since they will still think they have all CPUs available.
According to bollard the "--cpus" flag is for windows only, but setting shares to "100000" and quota to "400000" is equivalent to --cpus="4". For reference: https://docs.docker.com/config/containers/resource_constraints/#cpu