### PR TITLE
fix: canonicalize repo path in `Shuttle::is_dirty`

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -641,12 +641,13 @@ impl Shuttle {
         if let Ok(repo) = Repository::discover(working_directory) {
             let repo_path = repo
                 .workdir()
-                .context("getting working directory of repository")?;
+                .context("getting working directory of repository")?
+                .canonicalize()?;
 
             trace!(?repo_path, "found git repository");
 
             let repo_rel_path = working_directory
-                .strip_prefix(repo_path)
+                .strip_prefix(repo_path.as_path())
                 .context("stripping repository path from working directory")?;
 
             trace!(


### PR DESCRIPTION
On windows attempting to deploy without `--allow-dirty` would lead to an error from the `Shuttle::is_dirty` function:
```
Error: stripping repository path from working directory

Caused by:
    prefix not found
```

This was because it was trying to strip the repo path from the working dir, but only the working dir was canonicalized. Fixed by canonicalizing repo path.