### PR TITLE
bug: no networks

### DIFF
--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -15,6 +15,7 @@ pub struct Response {
 #[strum(serialize_all = "lowercase")]
 pub enum State {
     Creating,
+    Attaching,
     Starting,
     Started,
     Ready,
@@ -39,10 +40,10 @@ impl Display for Response {
 impl State {
     pub fn get_color(&self) -> Color {
         match self {
-            State::Creating | State::Starting | State::Started => Color::Cyan,
-            State::Ready => Color::Green,
-            State::Stopped | State::Stopping | State::Destroying | State::Destroyed => Color::Blue,
-            State::Errored => Color::Red,
+            Self::Creating | Self::Attaching | Self::Starting | Self::Started => Color::Cyan,
+            Self::Ready => Color::Green,
+            Self::Stopped | Self::Stopping | Self::Destroying | Self::Destroyed => Color::Blue,
+            Self::Errored => Color::Red,
         }
     }
 }

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -689,9 +689,7 @@ where
 
     #[instrument(skip_all)]
     async fn next(self, ctx: &Ctx) -> Result<Self::Next, Self::Error> {
-        let Self { container } = self;
-
-        let container_id = container.id.as_ref().unwrap();
+        let container_id = self.container.id.as_ref().unwrap();
 
         ctx.docker()
             .start_container::<String>(container_id, None)
@@ -705,7 +703,7 @@ where
                 }
             })?;
 
-        let container = container.refresh(ctx).await?;
+        let container = self.container.refresh(ctx).await?;
 
         Ok(Self::Next::new(container))
     }
@@ -839,7 +837,7 @@ impl Service {
         let network = safe_unwrap!(container.network_settings.networks)
             .values()
             .next()
-            .ok_or_else(|| ProjectError::no_network("project was not linked to a network"))?;
+            .ok_or_else(|| ProjectError::internal("project was not linked to a network"))?;
 
         let target = safe_unwrap!(network.ip_address)
             .parse()

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -1094,6 +1094,21 @@ pub mod exec {
                                 }))
                                 .send(&sender)
                                 .await;
+                        } else if safe_unwrap!(container.network_settings.networks).is_empty() {
+                            debug!(
+                                "{} is not connected to a network so will be restarted",
+                                project_name.clone()
+                            );
+                            _ = gateway
+                                .new_task()
+                                .project(project_name)
+                                .and_then(task::run(|ctx| async move {
+                                    TaskResult::Done(Project::Stopping(ProjectStopping {
+                                        container: ctx.state.container().unwrap(),
+                                    }))
+                                }))
+                                .send(&sender)
+                                .await;
                         }
                     }
                 }


### PR DESCRIPTION
After the VM upgrade a bunch of user containers are no longer connected to any network. This is potentially because they tried to start with the wrong network id (from the old VM). So this PR makes a change to connect to the user layer network when we start up deployers rather than when we create deployers. Moving the network attachment to start means containers that are restarted will also attach to the correct network correctly.

Lastly, the revive command is updated to detect and restart containers which are not on any networks.