### PR TITLE
ci: fix bin builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,8 +358,6 @@ jobs:
           at: artifacts
       - run:
           name: "Publish Release on GitHub"
-          environment:
-            GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             go install github.com/tcnksm/ghr@v0.16.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,6 @@ commands:
           name: "Set git tag in the environment"
           command: |
             echo TAG=$(git describe --tags) >> $BASH_ENV
-            printenv TAG
       - run:
           name: Make artifact
           command: |
@@ -365,7 +364,6 @@ jobs:
           command: |
             ls artifacts
             cat bash.env > $BASH_ENV
-            printenv TAG
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             ls artifacts
             echo ${TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ commands:
             mv README.md shuttle/
             mkdir artifacts
             tar -cvzf artifacts/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
+            echo $(ls artifacts)
       - persist_to_workspace:
           root: artifacts
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ jobs:
           name: "Set tag in environment"
           command: |
             cat artifacts/bash.env >> "$BASH_ENV"
-            rm bash.env
+            rm artifacts/bash.env
       - run:
           name: "Publish Release on GitHub"
           # Since each binary is in a sub directory named after its target, we flatten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,13 +135,13 @@ commands:
             mv LICENSE shuttle/
             mv README.md shuttle/
             mkdir artifacts
-            tar -cvzf artifacts/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
+            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
             echo $(ls artifacts)
             echo << parameters.tag >>
       - persist_to_workspace:
           root: artifacts
           paths:
-            - cargo-shuttle-<< parameters.tag >>-<< parameters.target >>.tar.gz
+            - << parameters.target >>/*
 
 jobs:
   workspace-fmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,8 +362,9 @@ jobs:
             ls artifacts
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             ls artifacts
+            echo ${TAG}
             go install github.com/tcnksm/ghr@v0.16.0
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft ${TAG} ./artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,14 +128,12 @@ commands:
             mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> shuttle/cargo-shuttle<< parameters.suffix >>
             mv LICENSE shuttle/
             mv README.md shuttle/
-            mkdir artifacts
-            mkdir tmp
-            tar -cvzf tmp/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
-            ln -s tmp/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz artifacts/<< parameters.target >>
+            mkdir -p artifacts/<< parameters.target >>
+            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
       - persist_to_workspace:
           root: artifacts
           paths:
-            - << parameters.target >>
+            - << parameters.target >>/*
 
 jobs:
   workspace-fmt:
@@ -369,8 +367,10 @@ jobs:
           environment:
             GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
+            mkdir binaries
+            find artifacts -type f -exec cp -t binaries {} +
             go install github.com/tcnksm/ghr@v0.16.0
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG binaries/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             ls artifacts
-            cat bash.env > $BASH_ENV
+            cat artifacts/bash.env > $BASH_ENV
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             ls artifacts
             echo ${TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,11 +409,11 @@ workflows:
       #     filters:
       #       branches:
       #         only: production
-      - build-binaries-linux:
-          name: build-binaries-x86_64
-          image: ubuntu-2204:2022.04.1
-          target: x86_64-unknown-linux-musl
-          resource_class: medium
+      # - build-binaries-linux:
+      #     name: build-binaries-x86_64
+      #     image: ubuntu-2204:2022.04.1
+      #     target: x86_64-unknown-linux-musl
+      #     resource_class: medium
           # filters:
           #   branches:
           #     only: production
@@ -427,13 +427,11 @@ workflows:
       #         only: /^v.*/
       #       branches:
       #         only: production
-      # - build-binaries-windows:
+      - build-binaries-windows
       #     filters:
-      #       tags:
-      #         only: /^v.*/
       #       branches:
       #         only: production
-      # - build-binaries-mac:
+      # # - build-binaries-mac:
       #     filters:
       #       tags:
       #         only: /^v.*/
@@ -441,9 +439,9 @@ workflows:
       #         only: production
       - publish-github-release:
           requires:
-            - build-binaries-x86_64
+            # - build-binaries-x86_64
             # - build-binaries-aarch64
-            # - build-binaries-windows
+            - build-binaries-windows
             # - build-binaries-mac
           # filters:
           #   tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,11 +126,11 @@ commands:
             mv LICENSE shuttle/
             mv README.md shuttle/
             mkdir artifacts
-            tar -cvzf artifacts/cargo-shuttle-${CIRCLE_TAG}-<< parameters.target >>.tar.gz shuttle
+            tar -cvzf artifacts/cargo-shuttle--<< parameters.target >>.tar.gz shuttle
       - persist_to_workspace:
           root: artifacts
           paths:
-            - cargo-shuttle-${CIRCLE_TAG}-<< parameters.target >>.tar.gz
+            - cargo-shuttle--<< parameters.target >>.tar.gz
 
 jobs:
   workspace-fmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ orbs:
   win: circleci/windows@5.0
 
 executors:
-    docker-rust:
-      docker:
-        - image: cimg/rust:1.65.0
-    image-ubuntu:
-      machine:
-        image: ubuntu-2204:2022.04.1
-        docker_layer_caching: true
+  docker-rust:
+    docker:
+      - image: cimg/rust:1.65.0
+  image-ubuntu:
+    machine:
+      image: ubuntu-2204:2022.04.1
+      docker_layer_caching: true
 
 # sscache steps are from this guide
 # https://medium.com/@edouard.oger/rust-caching-on-circleci-using-sccache-c996344f0115

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,11 @@ commands:
         default: ""
     steps:
       - run:
-            name: "Get git tag"
+            name: "Set tag with git describe"
             command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
+      - run:
+            name: "Echo git tag"
+            command: echo $TAG
       - run:
           name: Make artifact
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,11 +108,6 @@ commands:
               sudo unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
               sudo unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
               rm -f protoc-21.9-linux-x86_64.zip
-  set-tag:
-    steps:
-      - run:
-            name: "Set git tag in the environment"
-            command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
   make-artifact:
     parameters:
       target:
@@ -123,6 +118,9 @@ commands:
         type: string
         default: ""
     steps:
+      - run:
+          name: "Set git tag in the environment"
+          command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
       - run:
           name: Make artifact
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,86 +365,86 @@ workflows:
   version: 2
   ci:
     jobs:
-      - workspace-fmt
-      - workspace-clippy:
-          name: workspace-clippy-<< matrix.framework >>
-          requires:
-            - workspace-fmt
-          matrix:
-            parameters:
-              framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity"]
-      - check-standalone:
-          matrix:
-            parameters:
-              path:
-                - resources/aws-rds
-                - resources/persist
-                - resources/secrets
-                - resources/shared-db
-                - resources/static-folder
-      - service-test:
-          requires:
-            - workspace-clippy
-      - platform-test:
-          requires:
-            - workspace-clippy
-          matrix:
-            parameters:
-              crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
-      - e2e-test:
-          requires:
-            - service-test
-            - platform-test
-            - check-standalone
-          filters:
-            branches:
-              only: production
-      - build-and-push:
-          requires:
-            - e2e-test
-          filters:
-            branches:
-              only: production
+      # - workspace-fmt
+      # - workspace-clippy:
+      #     name: workspace-clippy-<< matrix.framework >>
+      #     requires:
+      #       - workspace-fmt
+      #     matrix:
+      #       parameters:
+      #         framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity"]
+      # - check-standalone:
+      #     matrix:
+      #       parameters:
+      #         path:
+      #           - resources/aws-rds
+      #           - resources/persist
+      #           - resources/secrets
+      #           - resources/shared-db
+      #           - resources/static-folder
+      # - service-test:
+      #     requires:
+      #       - workspace-clippy
+      # - platform-test:
+      #     requires:
+      #       - workspace-clippy
+      #     matrix:
+      #       parameters:
+      #         crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
+      # - e2e-test:
+      #     requires:
+      #       - service-test
+      #       - platform-test
+      #       - check-standalone
+      #     filters:
+      #       branches:
+      #         only: production
+      # - build-and-push:
+      #     requires:
+      #       - e2e-test
+      #     filters:
+      #       branches:
+      #         only: production
       - build-binaries-linux:
           name: build-binaries-x86_64
           image: ubuntu-2204:2022.04.1
           target: x86_64-unknown-linux-musl
           resource_class: medium
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: production
-      - build-binaries-linux:
-          name: build-binaries-aarch64
-          image: ubuntu-2004:202101-01
-          target: aarch64-unknown-linux-musl
-          resource_class: arm.medium
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: production
-      - build-binaries-windows:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: production
-      - build-binaries-mac:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: production
-      - publish-github-release:
-          requires:
-            - build-binaries-x86_64
-            - build-binaries-aarch64
-            - build-binaries-windows
-            - build-binaries-mac
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: production
+          # filters:
+          #   tags:
+          #     only: /^v.*/
+          #   branches:
+          #     only: production
+      # - build-binaries-linux:
+      #     name: build-binaries-aarch64
+      #     image: ubuntu-2004:202101-01
+      #     target: aarch64-unknown-linux-musl
+      #     resource_class: arm.medium
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         only: production
+      # - build-binaries-windows:
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         only: production
+      # - build-binaries-mac:
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         only: production
+      # - publish-github-release:
+      #     requires:
+      #       - build-binaries-x86_64
+      #       - build-binaries-aarch64
+      #       - build-binaries-windows
+      #       - build-binaries-mac
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ jobs:
             GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             go install github.com/tcnksm/ghr@v0.16.0
-            ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
         default: ""
     steps:
       - run:
-          name: "Set git tag in the environment"
+          name: Set git tag in the environment"
           command: |
             echo TAG=$(git describe --tags) >> $BASH_ENV
       - run:
@@ -132,6 +132,8 @@ commands:
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/bash.env
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
+      # Persist the bash environment to the workspace as well, we need it for the release job.
+      # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4
       - persist_to_workspace:
           root: artifacts
           paths:
@@ -362,15 +364,14 @@ jobs:
       - run:
           name: "Set tag in environment"
           command: |
-            cat artifacts/bash.env
             cat artifacts/bash.env >> "$BASH_ENV"
+            rm bash.env
       - run:
           name: "Publish Release on GitHub"
+          # Since each binary is in a sub directory named after its target, we flatten
+          # the artifacts directory before passing it to ghr
           command: |
-            ls artifacts
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
-            ls artifacts
-            echo ${TAG}
             go install github.com/tcnksm/ghr@v0.16.0
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft ${TAG} ./artifacts/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,9 @@ commands:
       target:
         description: "Rust target to put in artifact"
         type: string
+      tag:
+        description: "Git tag to put in artifact"
+        type: string
       suffix:
         description: "Suffix that is on the binary"
         type: string
@@ -134,10 +137,11 @@ commands:
             mkdir artifacts
             tar -cvzf artifacts/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
             echo $(ls artifacts)
+            echo << parameters.tag >>
       - persist_to_workspace:
           root: artifacts
           paths:
-            - cargo-shuttle-$TAG-<< parameters.target >>.tar.gz
+            - cargo-shuttle-<< parameters.tag >>-<< parameters.target >>.tar.gz
 
 jobs:
   workspace-fmt:
@@ -319,6 +323,7 @@ jobs:
             cargo build --release --package cargo-shuttle --features vendored-openssl --target << parameters.target >>
       - make-artifact:
           target: << parameters.target >>
+          tag: $TAG
   build-binaries-windows:
     executor:
       name: win/server-2022

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ orbs:
   win: circleci/windows@5.0
 
 executors:
-  docker-rust:
-    docker:
-      - image: cimg/rust:1.65.0
-  image-ubuntu:
-    machine:
-      image: ubuntu-2204:2022.04.1
-      docker_layer_caching: true
+    docker-rust:
+      docker:
+        - image: cimg/rust:1.65.0
+    image-ubuntu:
+      machine:
+        image: ubuntu-2204:2022.04.1
+        docker_layer_caching: true
 
 # sscache steps are from this guide
 # https://medium.com/@edouard.oger/rust-caching-on-circleci-using-sccache-c996344f0115
@@ -379,82 +379,76 @@ workflows:
   version: 2
   ci:
     jobs:
-      # - workspace-fmt
-      # - workspace-clippy:
-      #     name: workspace-clippy-<< matrix.framework >>
-      #     requires:
-      #       - workspace-fmt
-      #     matrix:
-      #       parameters:
-      #         framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity"]
-      # - check-standalone:
-      #     matrix:
-      #       parameters:
-      #         path:
-      #           - resources/aws-rds
-      #           - resources/persist
-      #           - resources/secrets
-      #           - resources/shared-db
-      #           - resources/static-folder
-      # - service-test:
-      #     requires:
-      #       - workspace-clippy
-      # - platform-test:
-      #     requires:
-      #       - workspace-clippy
-      #     matrix:
-      #       parameters:
-      #         crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
-      # - e2e-test:
-      #     requires:
-      #       - service-test
-      #       - platform-test
-      #       - check-standalone
-      #     filters:
-      #       branches:
-      #         only: production
-      # - build-and-push:
-      #     requires:
-      #       - e2e-test
-      #     filters:
-      #       branches:
-      #         only: production
-      - build-binaries-linux:
-          name: build-binaries-x86_64
-          image: ubuntu-2204:2022.04.1
-          target: x86_64-unknown-linux-musl
-          resource_class: medium
-          # filters:
-          #   branches:
-          #     only: production
-      # - build-binaries-linux:
-      #     name: build-binaries-aarch64
-      #     image: ubuntu-2004:202101-01
-      #     target: aarch64-unknown-linux-musl
-      #     resource_class: arm.medium
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         only: production
-      # - build-binaries-windows
-      #     filters:
-      #       branches:
-      #         only: production
-      # # - build-binaries-mac:
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         only: production
-      - publish-github-release:
+       - workspace-fmt
+       - workspace-clippy:
+           name: workspace-clippy-<< matrix.framework >>
+           requires:
+             - workspace-fmt
+           matrix:
+             parameters:
+               framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity"]
+       - check-standalone:
+           matrix:
+             parameters:
+               path:
+                 - resources/aws-rds
+                 - resources/persist
+                 - resources/secrets
+                 - resources/shared-db
+                 - resources/static-folder
+       - service-test:
+           requires:
+             - workspace-clippy
+       - platform-test:
+           requires:
+             - workspace-clippy
+           matrix:
+             parameters:
+               crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
+       - e2e-test:
+           requires:
+             - service-test
+             - platform-test
+             - check-standalone
+           filters:
+             branches:
+               only: production
+       - build-and-push:
+           requires:
+             - e2e-test
+           filters:
+             branches:
+               only: production
+       - build-binaries-linux:
+           name: build-binaries-x86_64
+           image: ubuntu-2204:2022.04.1
+           target: x86_64-unknown-linux-musl
+           resource_class: medium
+           filters:
+             branches:
+               only: production
+       - build-binaries-linux:
+           name: build-binaries-aarch64
+           image: ubuntu-2004:202101-01
+           target: aarch64-unknown-linux-musl
+           resource_class: arm.medium
+           filters:
+             branches:
+               only: production
+       - build-binaries-windows:
+          filters:
+            branches:
+              only: production
+       - build-binaries-mac:
+          filters:
+            branches:
+             only: production
+       - publish-github-release:
           requires:
             - build-binaries-x86_64
-            # - build-binaries-aarch64
-            # - build-binaries-windows
-            # - build-binaries-mac
-          # filters:
-          #   tags:
-          #     only: /^v.*/
-          #   branches:
-          #     only: production
+            - build-binaries-aarch64
+            - build-binaries-windows
+            - build-binaries-mac
+          filters:
+            branches:
+             only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,9 @@ jobs:
       - run:
           name: "Publish Release on GitHub"
           command: |
+            ls artifacts
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
+            ls artifacts
             go install github.com/tcnksm/ghr@v0.16.0
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
 
@@ -425,7 +427,7 @@ workflows:
       #         only: /^v.*/
       #       branches:
       #         only: production
-      - build-binaries-windows
+      # - build-binaries-windows
       #     filters:
       #       branches:
       #         only: production
@@ -439,7 +441,7 @@ workflows:
           requires:
             - build-binaries-x86_64
             # - build-binaries-aarch64
-            - build-binaries-windows
+            # - build-binaries-windows
             # - build-binaries-mac
           # filters:
           #   tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,10 +367,9 @@ jobs:
           environment:
             GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
-            mkdir binaries
-            find artifacts -type f -exec cp -t binaries {} +
+            find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             go install github.com/tcnksm/ghr@v0.16.0
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG binaries/
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
             mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> shuttle/cargo-shuttle<< parameters.suffix >>
             mv LICENSE shuttle/
             mv README.md shuttle/
-            mkdir artifacts
+            mkdir -p artifacts/<< parameters.target >>
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
             echo $(ls artifacts)
             echo << parameters.tag >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,9 @@ commands:
         default: ""
     steps:
       - run:
+            name: "Get git tag"
+            command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
+      - run:
           name: Make artifact
           command: |
             mkdir shuttle
@@ -126,11 +129,11 @@ commands:
             mv LICENSE shuttle/
             mv README.md shuttle/
             mkdir artifacts
-            tar -cvzf artifacts/cargo-shuttle--<< parameters.target >>.tar.gz shuttle
+            tar -cvzf artifacts/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
       - persist_to_workspace:
           root: artifacts
           paths:
-            - cargo-shuttle--<< parameters.target >>.tar.gz
+            - cargo-shuttle-$TAG-<< parameters.target >>.tar.gz
 
 jobs:
   workspace-fmt:
@@ -359,7 +362,7 @@ jobs:
             GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             go install github.com/tcnksm/ghr@v0.16.0
-            ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft ${CIRCLE_TAG} artifacts/
+            ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft $TAG artifacts/
 
 workflows:
   version: 2
@@ -411,8 +414,6 @@ workflows:
           target: x86_64-unknown-linux-musl
           resource_class: medium
           # filters:
-          #   tags:
-          #     only: /^v.*/
           #   branches:
           #     only: production
       # - build-binaries-linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,12 +128,14 @@ commands:
             mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> shuttle/cargo-shuttle<< parameters.suffix >>
             mv LICENSE shuttle/
             mv README.md shuttle/
-            mkdir -p artifacts/<< parameters.target >>
-            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
+            mkdir artifacts
+            mkdir tmp
+            tar -cvzf tmp/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
+            ln -s tmp/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz artifacts/<< parameters.target >>
       - persist_to_workspace:
           root: artifacts
           paths:
-            - << parameters.target >>/*
+            - << parameters.target >>
 
 jobs:
   workspace-fmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,11 +409,11 @@ workflows:
       #     filters:
       #       branches:
       #         only: production
-      # - build-binaries-linux:
-      #     name: build-binaries-x86_64
-      #     image: ubuntu-2204:2022.04.1
-      #     target: x86_64-unknown-linux-musl
-      #     resource_class: medium
+      - build-binaries-linux:
+          name: build-binaries-x86_64
+          image: ubuntu-2204:2022.04.1
+          target: x86_64-unknown-linux-musl
+          resource_class: medium
           # filters:
           #   branches:
           #     only: production
@@ -439,7 +439,7 @@ workflows:
       #         only: production
       - publish-github-release:
           requires:
-            # - build-binaries-x86_64
+            - build-binaries-x86_64
             # - build-binaries-aarch64
             - build-binaries-windows
             # - build-binaries-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,10 +360,14 @@ jobs:
       - attach_workspace:
           at: artifacts
       - run:
+          name: "Set tag in environment"
+          command: |
+            cat artifacts/bash.env
+            cat artifacts/bash.env >> "$BASH_ENV"
+      - run:
           name: "Publish Release on GitHub"
           command: |
             ls artifacts
-            cat artifacts/bash.env > $BASH_ENV
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             ls artifacts
             echo ${TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,11 @@ commands:
               sudo unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
               sudo unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
               rm -f protoc-21.9-linux-x86_64.zip
+  set-tag:
+    steps:
+      - run:
+            name: "Set git tag in the environment"
+            command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
   make-artifact:
     parameters:
       target:
@@ -118,9 +123,6 @@ commands:
         type: string
         default: ""
     steps:
-      - run:
-            name: "Set tag using git describe"
-            command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
       - run:
           name: Make artifact
           command: |
@@ -296,12 +298,6 @@ jobs:
         type: string
     steps:
       - checkout
-      - run:
-            name: "Set tag with git describe"
-            command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
-      - run:
-            name: "Echo git tag"
-            command: echo $TAG
       - run: sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y libssl-dev musl-tools clang
       - run:
           name: Install Rust
@@ -375,6 +371,7 @@ workflows:
   version: 2
   ci:
     jobs:
+      - set-tag
       # - workspace-fmt
       # - workspace-clippy:
       #     name: workspace-clippy-<< matrix.framework >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,9 @@ commands:
     steps:
       - run:
           name: "Set git tag in the environment"
-          command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
+          command: |
+            echo TAG=$(git describe --tags) >> $BASH_ENV
+            printenv TAG
       - run:
           name: Make artifact
           command: |
@@ -129,11 +131,13 @@ commands:
             mv LICENSE shuttle/
             mv README.md shuttle/
             mkdir -p artifacts/<< parameters.target >>
+            cp $BASH_ENV artifacts/bash.env
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
       - persist_to_workspace:
           root: artifacts
           paths:
             - << parameters.target >>/*
+            - bash.env
 
 jobs:
   workspace-fmt:
@@ -360,6 +364,8 @@ jobs:
           name: "Publish Release on GitHub"
           command: |
             ls artifacts
+            cat bash.env > $BASH_ENV
+            printenv TAG
             find artifacts -mindepth 2 -type f -exec mv -t artifacts {} +
             ls artifacts
             echo ${TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,6 +299,12 @@ jobs:
         type: string
     steps:
       - checkout
+      - run:
+            name: "Set tag with git describe"
+            command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
+      - run:
+            name: "Echo git tag"
+            command: echo $TAG
       - run: sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y libssl-dev musl-tools clang
       - run:
           name: Install Rust

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,20 +113,14 @@ commands:
       target:
         description: "Rust target to put in artifact"
         type: string
-      tag:
-        description: "Git tag to put in artifact"
-        type: string
       suffix:
         description: "Suffix that is on the binary"
         type: string
         default: ""
     steps:
       - run:
-            name: "Set tag with git describe"
+            name: "Set tag using git describe"
             command: echo TAG=$(git describe --tags) >> "$BASH_ENV"
-      - run:
-            name: "Echo git tag"
-            command: echo $TAG
       - run:
           name: Make artifact
           command: |
@@ -136,8 +130,6 @@ commands:
             mv README.md shuttle/
             mkdir -p artifacts/<< parameters.target >>
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
-            echo $(ls artifacts)
-            echo << parameters.tag >>
       - persist_to_workspace:
           root: artifacts
           paths:
@@ -323,7 +315,6 @@ jobs:
             cargo build --release --package cargo-shuttle --features vendored-openssl --target << parameters.target >>
       - make-artifact:
           target: << parameters.target >>
-          tag: $TAG
   build-binaries-windows:
     executor:
       name: win/server-2022
@@ -453,14 +444,14 @@ workflows:
       #         only: /^v.*/
       #       branches:
       #         only: production
-      # - publish-github-release:
-      #     requires:
-      #       - build-binaries-x86_64
-      #       - build-binaries-aarch64
-      #       - build-binaries-windows
-      #       - build-binaries-mac
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         only: production
+      - publish-github-release:
+          requires:
+            - build-binaries-x86_64
+            # - build-binaries-aarch64
+            # - build-binaries-windows
+            # - build-binaries-mac
+          # filters:
+          #   tags:
+          #     only: /^v.*/
+          #   branches:
+          #     only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - set-tag
       # - workspace-fmt
       # - workspace-clippy:
       #     name: workspace-clippy-<< matrix.framework >>


### PR DESCRIPTION
The `publish-github-release` workflow wasn't working since we can't use interpolated environment variables in circleci paths. To get around this and keep the git tag in the name, I move each binary archive to a subdirectory named after its target, and then flatten these sub-directories before running `ghr`.

Successful workflow run: https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/1391/workflows/8ce94b4f-d14f-456f-bf10-b1fd15575082