### PR TITLE
Refactor: remove deprecated auth command

### DIFF
--- a/cargo-shuttle/README.md
+++ b/cargo-shuttle/README.md
@@ -77,10 +77,15 @@ To initialize a shuttle project with boilerplates, run `cargo shuttle init [OPTI
 Currently, `cargo shuttle init` supports the following frameworks:
 
 - `--axum`: for [axum](https://github.com/tokio-rs/axum) framework
+- `--actix-web`: for [actix web](https://actix.rs/) framework
 - `--poem`: for [poem](https://github.com/poem-web/poem) framework
 - `--rocket`: for [rocket](https://rocket.rs/) framework
+- `--salvo`: for [salvo](https://salvo.rs/) framework
+- `--serenity`: for [serenity](https://serenity.rs/) discord bot framework
+- `--thruster`: for [thruster](https://github.com/thruster-rs/Thruster) framework
 - `--tide`: for [tide](https://github.com/http-rs/tide) framework
 - `--tower`: for [tower](https://github.com/tower-rs/tower) library
+- `--warp`: for [warp](https://github.com/seanmonstar/warp) framework
 
 For example, running the following command will initialize a project for [rocket](https://rocket.rs/):
 
@@ -175,14 +180,6 @@ Check the logs of your deployed shuttle project with:
 
 ```sh
 $ cargo shuttle logs
-```
-
-### Subcommand: `auth`
-
-Run the following to create user credentials for shuttle platform:
-
-```sh
-$ cargo shuttle auth your-desired-username
 ```
 
 ### Subcommand: `delete`

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -85,8 +85,6 @@ pub enum Command {
     Delete,
     /// manage secrets for this shuttle service
     Secrets,
-    /// create user credentials for the shuttle platform
-    Auth(AuthArgs),
     /// login to the shuttle platform
     Login(LoginArgs),
     /// run a shuttle service locally
@@ -126,13 +124,6 @@ pub struct LoginArgs {
     /// api key for the shuttle platform
     #[clap(long)]
     pub api_key: Option<String>,
-}
-
-#[derive(Parser)]
-pub struct AuthArgs {
-    /// the desired username for the shuttle platform
-    #[clap()]
-    pub username: String,
 }
 
 #[derive(Parser)]

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -7,7 +7,7 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
 use reqwest_retry::policies::ExponentialBackoff;
 use reqwest_retry::RetryTransientMiddleware;
 use serde::Deserialize;
-use shuttle_common::models::{deployment, project, secret, service, user, ToJson};
+use shuttle_common::models::{deployment, project, secret, service, ToJson};
 use shuttle_common::project::ProjectName;
 use shuttle_common::{ApiKey, ApiUrl, LogItem};
 use tokio::net::TcpStream;
@@ -31,16 +31,6 @@ impl Client {
 
     pub fn set_api_key(&mut self, api_key: ApiKey) {
         self.api_key = Some(api_key);
-    }
-
-    pub async fn auth(&self, username: String) -> Result<user::Response> {
-        let path = format!("/users/{}", username);
-
-        self.post(path, Option::<String>::None)
-            .await
-            .context("failed to get API key from Shuttle server")?
-            .to_json()
-            .await
     }
 
     pub async fn deploy(

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -13,7 +13,6 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
-use args::AuthArgs;
 pub use args::{Args, Command, DeployArgs, InitArgs, LoginArgs, ProjectArgs, RunArgs};
 use cargo_metadata::Message;
 use clap::CommandFactory;
@@ -94,7 +93,6 @@ impl Shuttle {
                     Command::Delete => self.delete(&client).await,
                     Command::Clean => self.clean(&client).await,
                     Command::Secrets => self.secrets(&client).await,
-                    Command::Auth(auth_args) => self.auth(auth_args, &client).await,
                     Command::Project(ProjectCommand::New) => self.project_create(&client).await,
                     Command::Project(ProjectCommand::Status { follow }) => {
                         self.project_status(&client, follow).await
@@ -245,17 +243,6 @@ impl Shuttle {
         let api_key = api_key_str.trim().parse()?;
 
         self.ctx.set_api_key(api_key)?;
-
-        Ok(())
-    }
-
-    async fn auth(&mut self, auth_args: AuthArgs, client: &Client) -> Result<()> {
-        let user = client.auth(auth_args.username).await?;
-
-        self.ctx.set_api_key(user.key)?;
-
-        println!("User authorized!!!");
-        println!("Run `cargo shuttle init --help` next");
 
         Ok(())
     }


### PR DESCRIPTION
Remove the auth command from the cargo-shuttle CLI, as it's no longer used. 