### PR TITLE
Respect $PORT environment variable

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -141,7 +141,7 @@ pub struct DeployArgs {
 #[derive(Parser, Debug)]
 pub struct RunArgs {
     /// port to start service on
-    #[clap(long, default_value = "8000")]
+    #[clap(long, env, default_value = "8000")]
     pub port: u16,
     /// use 0.0.0.0 instead of localhost (for usage with local external devices)
     #[clap(long)]


### PR DESCRIPTION
It is a common pattern for dev servers to let the `$PORT` environment variable dictate which port they will listen on. This change allows the port to be passed to `cargo shuttle run` via the `$PORT` environment variable in addition to the `--port` argument.