### PR TITLE
feat: change log read to spawn blocking

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -5,7 +5,7 @@ Both the legacy and next examples can be run using the local client:
 
 ``` bash
 cd path/to/example
-cargo run --manifest ../../../Cargo.toml --bin cargo-shuttle -- run
+cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- run
 ```
 
 When a more fine controlled testing is needed, use the instructions below.

--- a/runtime/src/axum/mod.rs
+++ b/runtime/src/axum/mod.rs
@@ -268,14 +268,14 @@ impl Router {
             .data_mut()
             .insert_file(BODY_READ_FD, Box::new(body_read_client), FileCaps::all());
 
-        tokio::task::spawn(async move {
+        tokio::task::spawn_blocking(move || {
             let mut iter = logs_stream.bytes().filter_map(Result::ok);
 
             while let Some(log) = Log::from_bytes(&mut iter) {
                 let mut log: runtime::LogItem = log.into();
                 log.id = deployment_id.clone();
 
-                logs_tx.send(Ok(log)).await.unwrap();
+                logs_tx.blocking_send(Ok(log)).unwrap();
             }
         });
 


### PR DESCRIPTION
This improves throughput by about 10%, but the issue of tasks spawning perpetually after a stress test remains.