### PR TITLE
feat: add logout function

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -87,6 +87,8 @@ pub enum Command {
     Secrets,
     /// login to the shuttle platform
     Login(LoginArgs),
+    /// log out of the shuttle platform
+    Logout,
     /// run a shuttle service locally
     Run(RunArgs),
     /// manage a project on shuttle

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -136,6 +136,10 @@ impl GlobalConfig {
         self.api_key.replace(api_key)
     }
 
+    pub fn clear_api_key(&mut self) {
+        self.api_key = None;
+    }
+
     pub fn api_url(&self) -> Option<ApiKey> {
         self.api_url.clone()
     }
@@ -375,6 +379,11 @@ impl RequestContext {
         Ok(res)
     }
 
+    pub fn clear_api_key(&mut self) -> Result<()> {
+        self.global.as_mut().unwrap().clear_api_key();
+        self.global.save()?;
+        Ok(())
+    }
     /// Get the current project name.
     ///
     /// # Panics

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -73,6 +73,7 @@ impl Shuttle {
             Command::Init(init_args) => self.init(init_args, args.project_args).await,
             Command::Generate { shell, output } => self.complete(shell, output).await,
             Command::Login(login_args) => self.login(login_args).await,
+            Command::Logout => self.logout().await,
             Command::Run(run_args) => self.local_run(run_args).await,
             need_client => {
                 let mut client = Client::new(self.ctx.api_url());
@@ -245,6 +246,13 @@ impl Shuttle {
 
         self.ctx.set_api_key(api_key)?;
 
+        Ok(())
+    }
+
+    async fn logout(&mut self) -> Result<()> {
+        self.ctx.set_api_key("".to_string())?;
+
+        println!("Successfully logged out of shuttle.");
         Ok(())
     }
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -260,7 +260,7 @@ impl Shuttle {
     }
 
     async fn logout(&mut self) -> Result<()> {
-        self.ctx.set_api_key("".to_string())?;
+        self.ctx.clear_api_key()?;
 
         println!("Successfully logged out of shuttle.");
         Ok(())


### PR DESCRIPTION
* add logout function for CLI

Reference: issue #594 

Current queries:
- api_key is currently defined as a String type, which means I've had to set the API key in the logout function as an empty string. This technically works, but I'm wondering if it's more correct to set it as None?