### PR TITLE
feat: allow string interpolation on resource options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6015,6 +6015,7 @@ dependencies = [
  "shuttle-codegen",
  "shuttle-common",
  "sqlx",
+ "strfmt",
  "sync_wrapper",
  "thiserror",
  "thruster",
@@ -6335,6 +6336,12 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "strfmt"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26cdabcdab6da7e8c2ac1160e917ec83e78bbe3e10325e17d532718c67a4828f"
 
 [[package]]
 name = "stringprep"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -31,6 +31,7 @@ salvo = { version = "0.37.5", optional = true }
 serde_json = { workspace = true }
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"], optional = true }
 poise = { version = "0.5.2", optional = true }
+strfmt = "0.2.2"
 sync_wrapper = { version = "0.1.1", optional = true }
 thiserror = { workspace = true }
 thruster = { version = "1.3.0", optional = true }

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     BuildPanic(String),
     #[error("Panic occurred in `Service::bind`: {0}")]
     BindPanic(String),
-    #[error("Failed to interpolate string: {0}")]
+    #[error("Failed to interpolate string. Is your Secrets.toml correct?")]
     StringInterpolation(#[from] strfmt::FmtError),
     #[error("Custom error: {0}")]
     Custom(#[from] CustomError),

--- a/service/src/error.rs
+++ b/service/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     BuildPanic(String),
     #[error("Panic occurred in `Service::bind`: {0}")]
     BindPanic(String),
+    #[error("Failed to interpolate string: {0}")]
+    StringInterpolation(#[from] strfmt::FmtError),
     #[error("Custom error: {0}")]
     Custom(#[from] CustomError),
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -220,6 +220,7 @@ pub use async_trait::async_trait;
 
 // Pub uses by `codegen`
 pub use anyhow::Context;
+pub use strfmt::strfmt;
 pub use tokio::runtime::Runtime;
 pub use tracing;
 pub use tracing_subscriber;


### PR DESCRIPTION
This PR allows options passed to resources to be string interpolated. For example in this `local_uri` option, the password is being read from the `Secrets.toml` file

```rust
#[shuttle_service::main]
async fn main(
    #[shuttle_shared_db::Postgres(
        local_uri = "postgres://postgres:{secrets.password}@localhost:16695/postgres"
    )]
    pool: PgPool,
) -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
    ...
}
```

With #596, this closes #497 