### PR TITLE
fix: add repo url to cargo-shuttle for binstall

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
           command: |
             # From https://github.com/alexcrichton/openssl-src-rs/issues/45
             # Because of https://github.com/openssl/openssl/issues/9048
-            OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
+            export OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
             # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
             ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --features vendored-openssl --target x86_64-pc-windows-msvc
       - make-artifact:
@@ -426,27 +426,27 @@ workflows:
       #      filters:
       #        branches:
       #          only: production
-       - build-binaries-linux:
-           name: build-binaries-x86_64-gnu
-           image: ubuntu-2204:2022.04.1
-           target: x86_64-unknown-linux-gnu
-           resource_class: medium
+      #  - build-binaries-linux:
+      #      name: build-binaries-x86_64-gnu
+      #      image: ubuntu-2204:2022.04.1
+      #      target: x86_64-unknown-linux-gnu
+      #      resource_class: medium
           #  filters:
           #    branches:
           #      only: production
-       - build-binaries-linux:
-           name: build-binaries-x86_64-musl
-           image: ubuntu-2204:2022.04.1
-           target: x86_64-unknown-linux-musl
-           resource_class: medium
+      #  - build-binaries-linux:
+      #      name: build-binaries-x86_64-musl
+      #      image: ubuntu-2204:2022.04.1
+      #      target: x86_64-unknown-linux-musl
+      #      resource_class: medium
           #  filters:
           #    branches:
           #      only: production
-       - build-binaries-linux:
-           name: build-binaries-aarch64
-           image: ubuntu-2004:202101-01
-           target: aarch64-unknown-linux-musl
-           resource_class: arm.medium
+      #  - build-binaries-linux:
+      #      name: build-binaries-aarch64
+      #      image: ubuntu-2004:202101-01
+      #      target: aarch64-unknown-linux-musl
+      #      resource_class: arm.medium
           #  filters:
           #    branches:
           #      only: production
@@ -454,17 +454,17 @@ workflows:
           # filters:
           #   branches:
           #     only: production
-       - build-binaries-mac
+      #  - build-binaries-mac
           # filters:
           #   branches:
           #    only: production
        - publish-github-release:
           requires:
-            - build-binaries-x86_64-gnu
-            - build-binaries-x86_64-musl
-            - build-binaries-aarch64
+            # - build-binaries-x86_64-gnu
+            # - build-binaries-x86_64-musl
+            # - build-binaries-aarch64
             - build-binaries-windows
-            - build-binaries-mac
+            # - build-binaries-mac
           # filters:
           #   branches:
           #    only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,85 +388,85 @@ jobs:
 workflows:
   ci:
     jobs:
-      #  - workspace-fmt
-      #  - workspace-clippy:
-      #      name: workspace-clippy-<< matrix.framework >>
-      #      requires:
-      #        - workspace-fmt
-      #      matrix:
-      #        parameters:
-      #          framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
-      #  - check-standalone:
-      #      matrix:
-      #        parameters:
-      #          path:
-      #            - resources/aws-rds
-      #            - resources/persist
-      #            - resources/secrets
-      #            - resources/shared-db
-      #            - resources/static-folder
-      #  - service-test:
-      #      requires:
-      #        - workspace-clippy
-      #  - platform-test:
-      #      requires:
-      #        - workspace-clippy
-      #      matrix:
-      #        parameters:
-      #          crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
-      #  - e2e-test:
-      #      requires:
-      #        - service-test
-      #        - platform-test
-      #        - check-standalone
-      #      filters:
-      #        branches:
-      #          only: production
-      #  - build-and-push:
-      #      requires:
-      #        - e2e-test
-      #      filters:
-      #        branches:
-      #          only: production
-      #  - build-binaries-linux:
-      #      name: build-binaries-x86_64-gnu
-      #      image: ubuntu-2204:2022.04.1
-      #      target: x86_64-unknown-linux-gnu
-      #      resource_class: medium
-          #  filters:
-          #    branches:
-          #      only: production
-      #  - build-binaries-linux:
-      #      name: build-binaries-x86_64-musl
-      #      image: ubuntu-2204:2022.04.1
-      #      target: x86_64-unknown-linux-musl
-      #      resource_class: medium
-          #  filters:
-          #    branches:
-          #      only: production
-      #  - build-binaries-linux:
-      #      name: build-binaries-aarch64
-      #      image: ubuntu-2004:202101-01
-      #      target: aarch64-unknown-linux-musl
-      #      resource_class: arm.medium
-          #  filters:
-          #    branches:
-          #      only: production
-       - build-binaries-windows
-          # filters:
-          #   branches:
-          #     only: production
-      #  - build-binaries-mac
-          # filters:
-          #   branches:
-          #    only: production
+       - workspace-fmt
+       - workspace-clippy:
+           name: workspace-clippy-<< matrix.framework >>
+           requires:
+             - workspace-fmt
+           matrix:
+             parameters:
+               framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
+       - check-standalone:
+           matrix:
+             parameters:
+               path:
+                 - resources/aws-rds
+                 - resources/persist
+                 - resources/secrets
+                 - resources/shared-db
+                 - resources/static-folder
+       - service-test:
+           requires:
+             - workspace-clippy
+       - platform-test:
+           requires:
+             - workspace-clippy
+           matrix:
+             parameters:
+               crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
+       - e2e-test:
+           requires:
+             - service-test
+             - platform-test
+             - check-standalone
+           filters:
+             branches:
+               only: production
+       - build-and-push:
+           requires:
+             - e2e-test
+           filters:
+             branches:
+               only: production
+       - build-binaries-linux:
+           name: build-binaries-x86_64-gnu
+           image: ubuntu-2204:2022.04.1
+           target: x86_64-unknown-linux-gnu
+           resource_class: medium
+           filters:
+             branches:
+               only: production
+       - build-binaries-linux:
+           name: build-binaries-x86_64-musl
+           image: ubuntu-2204:2022.04.1
+           target: x86_64-unknown-linux-musl
+           resource_class: medium
+           filters:
+             branches:
+               only: production
+       - build-binaries-linux:
+           name: build-binaries-aarch64
+           image: ubuntu-2004:202101-01
+           target: aarch64-unknown-linux-musl
+           resource_class: arm.medium
+           filters:
+             branches:
+               only: production
+       - build-binaries-windows:
+          filters:
+            branches:
+              only: production
+       - build-binaries-mac:
+          filters:
+            branches:
+             only: production
        - publish-github-release:
           requires:
-            # - build-binaries-x86_64-gnu
-            # - build-binaries-x86_64-musl
-            # - build-binaries-aarch64
+            - build-binaries-x86_64-gnu
+            - build-binaries-x86_64-musl
+            - build-binaries-aarch64
             - build-binaries-windows
-            # - build-binaries-mac
-          # filters:
-          #   branches:
-          #    only: production
+            - build-binaries-mac
+          filters:
+            branches:
+             only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,15 +125,14 @@ commands:
       - run:
           name: Make artifact
           command: |
-            mkdir -p cargo-shuttle-<< parameters.target >>-$TAG
-            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> \ 
-              cargo-shuttle-<< parameters.target >>-$TAG/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
-            mv LICENSE cargo-shuttle-<< parameters.target >>-$TAG/
-            mv README.md cargo-shuttle-<< parameters.target >>-$TAG/
+            BIN_FOLDER=cargo-shuttle-<< parameters.target >>-$TAG
+            mkdir $BIN_FOLDER
+            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> $BIN_FOLDER/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
+            mv LICENSE $BIN_FOLDER/
+            mv README.md $BIN_FOLDER/
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/<< parameters.target >>.env
-            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz \ 
-              cargo-shuttle-<< parameters.target >>-$TAG
+            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz $BIN_FOLDER
       # Persist the bash environment to the workspace as well, we need it for the release job.
       # Make sure the name is unique, since the binaries will be built in parallel.
       # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
           command: |
             BIN_FOLDER=cargo-shuttle-<< parameters.target >>-$TAG
             mkdir $BIN_FOLDER
-            
+
             mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> \ 
               $BIN_FOLDER/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
             mv LICENSE $BIN_FOLDER/
@@ -386,76 +386,76 @@ workflows:
   version: 2
   ci:
     jobs:
-       - workspace-fmt
-       - workspace-clippy:
-           name: workspace-clippy-<< matrix.framework >>
-           requires:
-             - workspace-fmt
-           matrix:
-             parameters:
-               framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
-       - check-standalone:
-           matrix:
-             parameters:
-               path:
-                 - resources/aws-rds
-                 - resources/persist
-                 - resources/secrets
-                 - resources/shared-db
-                 - resources/static-folder
-       - service-test:
-           requires:
-             - workspace-clippy
-       - platform-test:
-           requires:
-             - workspace-clippy
-           matrix:
-             parameters:
-               crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
-       - e2e-test:
-           requires:
-             - service-test
-             - platform-test
-             - check-standalone
-           filters:
-             branches:
-               only: production
-       - build-and-push:
-           requires:
-             - e2e-test
-           filters:
-             branches:
-               only: production
+      #  - workspace-fmt
+      #  - workspace-clippy:
+      #      name: workspace-clippy-<< matrix.framework >>
+      #      requires:
+      #        - workspace-fmt
+      #      matrix:
+      #        parameters:
+      #          framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
+      #  - check-standalone:
+      #      matrix:
+      #        parameters:
+      #          path:
+      #            - resources/aws-rds
+      #            - resources/persist
+      #            - resources/secrets
+      #            - resources/shared-db
+      #            - resources/static-folder
+      #  - service-test:
+      #      requires:
+      #        - workspace-clippy
+      #  - platform-test:
+      #      requires:
+      #        - workspace-clippy
+      #      matrix:
+      #        parameters:
+      #          crate: ["shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
+      #  - e2e-test:
+      #      requires:
+      #        - service-test
+      #        - platform-test
+      #        - check-standalone
+      #      filters:
+      #        branches:
+      #          only: production
+      #  - build-and-push:
+      #      requires:
+      #        - e2e-test
+      #      filters:
+      #        branches:
+      #          only: production
        - build-binaries-linux:
            name: build-binaries-x86_64
            image: ubuntu-2204:2022.04.1
            target: x86_64-unknown-linux-musl
            resource_class: medium
-           filters:
-             branches:
-               only: production
+          #  filters:
+          #    branches:
+          #      only: production
        - build-binaries-linux:
            name: build-binaries-aarch64
            image: ubuntu-2004:202101-01
            target: aarch64-unknown-linux-musl
            resource_class: arm.medium
-           filters:
-             branches:
-               only: production
-       - build-binaries-windows:
-          filters:
-            branches:
-              only: production
-       - build-binaries-mac:
-          filters:
-            branches:
-             only: production
+          #  filters:
+          #    branches:
+          #      only: production
+       - build-binaries-windows
+          # filters:
+          #   branches:
+          #     only: production
+       - build-binaries-mac
+          # filters:
+          #   branches:
+          #    only: production
        - publish-github-release:
           requires:
             - build-binaries-x86_64
             - build-binaries-aarch64
             - build-binaries-windows
             - build-binaries-mac
-          filters:
-            branches:
-             only: production
+          # filters:
+          #   branches:
+          #    only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,10 +122,12 @@ commands:
           name: Set git tag in the environment
           command: |
             echo TAG=$(git describe --tags) >> $BASH_ENV
+          shell: bash.exe
       - run:
           name: Set binary directory in the environment
           command: |
             echo BIN_DIR=cargo-shuttle-<< parameters.target >>-$TAG >> $BASH_ENV
+          shell: bash.exe
       - run:
           name: Make artifact
           command: |
@@ -136,6 +138,7 @@ commands:
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/<< parameters.target >>.env
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz $BIN_DIR
+          shell: bash.exe
       # Persist the bash environment to the workspace as well, we need it for the release job.
       # Make sure the name is unique, since the binaries will be built in parallel.
       # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -460,7 +460,8 @@ workflows:
           #    only: production
        - publish-github-release:
           requires:
-            - build-binaries-x86_64
+            - build-binaries-x86_64-gnu
+            - build-binaries-x86_64-musl
             - build-binaries-aarch64
             - build-binaries-windows
             - build-binaries-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,17 +125,15 @@ commands:
       - run:
           name: Make artifact
           command: |
-            BIN_FOLDER=cargo-shuttle-<< parameters.target >>-$TAG
-            mkdir $BIN_FOLDER
-
+            mkdir cargo-shuttle-<< parameters.target >>-$TAG
             mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> \ 
-              $BIN_FOLDER/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
-            mv LICENSE $BIN_FOLDER/
-            mv README.md $BIN_FOLDER/
+              cargo-shuttle-<< parameters.target >>-$TAG/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
+            mv LICENSE cargo-shuttle-<< parameters.target >>-$TAG/
+            mv README.md cargo-shuttle-<< parameters.target >>-$TAG/
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/<< parameters.target >>.env
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz \ 
-              $BIN_FOLDER
+              cargo-shuttle-<< parameters.target >>-$TAG
       # Persist the bash environment to the workspace as well, we need it for the release job.
       # Make sure the name is unique, since the binaries will be built in parallel.
       # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,12 +122,10 @@ commands:
           name: Set git tag in the environment
           command: |
             echo TAG=$(git describe --tags) >> $BASH_ENV
-          shell: bash.exe
       - run:
           name: Set binary directory in the environment
           command: |
             echo BIN_DIR=cargo-shuttle-<< parameters.target >>-$TAG >> $BASH_ENV
-          shell: bash.exe
       - run:
           name: Make artifact
           command: |
@@ -138,7 +136,6 @@ commands:
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/<< parameters.target >>.env
             tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz $BIN_DIR
-          shell: bash.exe
       # Persist the bash environment to the workspace as well, we need it for the release job.
       # Make sure the name is unique, since the binaries will be built in parallel.
       # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4
@@ -326,6 +323,7 @@ jobs:
     executor:
       name: win/server-2022
       size: medium
+    shell: bash.exe
     environment:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
@@ -336,6 +334,7 @@ jobs:
           command: |
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
             C:\rustup-init.exe -y --default-toolchain 1.65.0 --target x86_64-pc-windows-msvc
+          shell: powershell.exe
       - run:
           name: Build
           command: |
@@ -344,6 +343,7 @@ jobs:
             $env:OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
             # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
             ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --features vendored-openssl --target x86_64-pc-windows-msvc
+          shell: powershell.exe
       - make-artifact:
           target: x86_64-pc-windows-msvc
           suffix: ".exe"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,16 +334,14 @@ jobs:
           command: |
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
             C:\rustup-init.exe -y --default-toolchain 1.65.0 --target x86_64-pc-windows-msvc
-          shell: powershell.exe
       - run:
           name: Build
           command: |
             # From https://github.com/alexcrichton/openssl-src-rs/issues/45
             # Because of https://github.com/openssl/openssl/issues/9048
-            $env:OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
+            OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
             # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
             ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --features vendored-openssl --target x86_64-pc-windows-msvc
-          shell: powershell.exe
       - make-artifact:
           target: x86_64-pc-windows-msvc
           suffix: ".exe"
@@ -386,7 +384,6 @@ jobs:
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete -draft ${TAG} ./artifacts/
 
 workflows:
-  version: 2
   ci:
     jobs:
       #  - workspace-fmt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
       - run:
           name: Make artifact
           command: |
-            mkdir cargo-shuttle-<< parameters.target >>-$TAG
+            mkdir -p cargo-shuttle-<< parameters.target >>-$TAG
             mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> \ 
               cargo-shuttle-<< parameters.target >>-$TAG/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
             mv LICENSE cargo-shuttle-<< parameters.target >>-$TAG/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,20 +119,23 @@ commands:
         default: ""
     steps:
       - run:
-          name: Set git tag in the environment"
+          name: Set git tag in the environment
           command: |
             echo TAG=$(git describe --tags) >> $BASH_ENV
       - run:
+          name: Set binary directory in the environment
+          command: |
+            echo BIN_DIR=cargo-shuttle-<< parameters.target >>-$TAG >> $BASH_ENV
+      - run:
           name: Make artifact
           command: |
-            BIN_FOLDER=cargo-shuttle-<< parameters.target >>-$TAG
-            mkdir $BIN_FOLDER
-            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> $BIN_FOLDER/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
-            mv LICENSE $BIN_FOLDER/
-            mv README.md $BIN_FOLDER/
+            mkdir $BIN_DIR
+            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> $BIN_DIR/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
+            mv LICENSE $BIN_DIR/
+            mv README.md $BIN_DIR/
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/<< parameters.target >>.env
-            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz $BIN_FOLDER
+            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz $BIN_DIR
       # Persist the bash environment to the workspace as well, we need it for the release job.
       # Make sure the name is unique, since the binaries will be built in parallel.
       # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4
@@ -424,7 +427,15 @@ workflows:
       #        branches:
       #          only: production
        - build-binaries-linux:
-           name: build-binaries-x86_64
+           name: build-binaries-x86_64-gnu
+           image: ubuntu-2204:2022.04.1
+           target: x86_64-unknown-linux-gnu
+           resource_class: medium
+          #  filters:
+          #    branches:
+          #      only: production
+       - build-binaries-linux:
+           name: build-binaries-x86_64-musl
            image: ubuntu-2204:2022.04.1
            target: x86_64-unknown-linux-musl
            resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,14 +334,16 @@ jobs:
           command: |
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
             C:\rustup-init.exe -y --default-toolchain 1.65.0 --target x86_64-pc-windows-msvc
+          shell: powershell.exe
       - run:
           name: Build
           command: |
             # From https://github.com/alexcrichton/openssl-src-rs/issues/45
             # Because of https://github.com/openssl/openssl/issues/9048
-            export OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
+            $env:OPENSSL_SRC_PERL=OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
             # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
             ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --features vendored-openssl --target x86_64-pc-windows-msvc
+          shell: powershell.exe
       - make-artifact:
           target: x86_64-pc-windows-msvc
           suffix: ".exe"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,13 +125,17 @@ commands:
       - run:
           name: Make artifact
           command: |
-            mkdir shuttle
-            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> shuttle/cargo-shuttle<< parameters.suffix >>
-            mv LICENSE shuttle/
-            mv README.md shuttle/
+            BIN_FOLDER=cargo-shuttle-<< parameters.target >>-$TAG
+            mkdir $BIN_FOLDER
+            
+            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> \ 
+              $BIN_FOLDER/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
+            mv LICENSE $BIN_FOLDER/
+            mv README.md $BIN_FOLDER/
             mkdir -p artifacts/<< parameters.target >>
             cp $BASH_ENV artifacts/<< parameters.target >>.env
-            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz shuttle
+            tar -cvzf artifacts/<< parameters.target >>/cargo-shuttle-$TAG-<< parameters.target >>.tar.gz \ 
+              $BIN_FOLDER
       # Persist the bash environment to the workspace as well, we need it for the release job.
       # Make sure the name is unique, since the binaries will be built in parallel.
       # https://discuss.circleci.com/t/share-environment-variable-between-different-job/45647/4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ jobs:
     executor:
       name: win/server-2022
       size: medium
-    shell: bash.exe
+      shell: bash.exe
     environment:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ jobs:
           command: |
             # From https://github.com/alexcrichton/openssl-src-rs/issues/45
             # Because of https://github.com/openssl/openssl/issues/9048
-            $env:OPENSSL_SRC_PERL=OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
+            $env:OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
             # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
             ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --features vendored-openssl --target x86_64-pc-windows-msvc
           shell: powershell.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
+repository = "https://github.com/shuttle-hq/shuttle"
 
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table
 [workspace.dependencies]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -3,6 +3,7 @@ name = "cargo-shuttle"
 version = "0.9.0"
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "A cargo command for the shuttle platform (https://www.shuttle.rs/)"
 homepage = "https://www.shuttle.rs"
 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -3,6 +3,7 @@ name = "shuttle-codegen"
 version = "0.9.0"
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Proc-macro code generator for the shuttle.rs service"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,6 +3,7 @@ name = "shuttle-common"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Common library for the shuttle platform (https://www.shuttle.rs/)"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -3,6 +3,7 @@ name = "shuttle-service"
 version = "0.9.0"
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
 description = "Service traits and macros to deploy on the shuttle platform (https://www.shuttle.rs/)"
 homepage = "https://www.shuttle.rs"
 


### PR DESCRIPTION
[`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md#support-for-cargo-binstall) needs the crate to have a repository set in its manifest for it to find the binary download. We should only need to set it for `cargo-shuttle`, but it's nice to have for all our published crates. 

There was also an issue with the windows bin build where the tag was not included in the archive name, due to that build running the `make-artifact` command with powershell. I resolved this by changing the shell for the windows build to bash, and using a powershell override for the other commands.

I also changed the name of the directory inside the archive to be [compatible](https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md#examples) with `cargo-binstall`.

And last but not least, I added the `x86_64-unknown-linux-gnu` target to the linux binary builds.