### PR TITLE
fix: delete the deployments before deleting a service

### DIFF
--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -277,6 +277,10 @@ async fn delete_service(
             .map(Into::into)
             .collect();
 
+        // TODO wrap this in a transaction
+        persistence
+            .delete_deployments_by_service_id(&service.id)
+            .await?;
         persistence.delete_service(&service.id).await?;
 
         let response = shuttle_common::models::service::Detailed {


### PR DESCRIPTION
Right now, the database doesn't have a defined strategy when a service gets deleted in the database and therefore, where the is a foreign key, the request fails.
This change makes sure to remove the deployments from a service after killing them allowing the service to be deleted properly.

For later: the `Persistence` struct should be updated to be able to start a transaction so that we can rollback if something goes wrong.

This should fix #561

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>