### PR TITLE
feat: retry on bollard errors

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -523,7 +523,12 @@ impl Shuttle {
 
     async fn project_create(&self, client: &Client) -> Result<()> {
         self.wait_with_spinner(
-            &[project::State::Ready, project::State::Errored],
+            &[
+                project::State::Ready,
+                project::State::Errored {
+                    message: Default::default(),
+                },
+            ],
             Client::create_project,
             self.ctx.project_name(),
             client,
@@ -549,7 +554,9 @@ impl Shuttle {
                     &[
                         project::State::Ready,
                         project::State::Destroyed,
-                        project::State::Errored,
+                        project::State::Errored {
+                            message: Default::default(),
+                        },
                     ],
                     Client::get_project,
                     self.ctx.project_name(),
@@ -612,7 +619,12 @@ impl Shuttle {
 
     async fn project_delete(&self, client: &Client) -> Result<()> {
         self.wait_with_spinner(
-            &[project::State::Destroyed, project::State::Errored],
+            &[
+                project::State::Destroyed,
+                project::State::Errored {
+                    message: Default::default(),
+                },
+            ],
             Client::delete_project,
             self.ctx.project_name(),
             client,

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -5,7 +5,6 @@ use comfy_table::{
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
-use strum::Display;
 
 #[derive(Deserialize, Serialize)]
 pub struct Response {
@@ -13,15 +12,14 @@ pub struct Response {
     pub state: State,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
 pub enum State {
-    Creating,
-    Attaching,
-    Recreating,
-    Starting,
-    Restarting,
+    Creating { recreate_count: usize },
+    Attaching { recreate_count: usize },
+    Recreating { recreate_count: usize },
+    Starting { restart_count: usize },
+    Restarting { restart_count: usize },
     Started,
     Ready,
     Stopping,
@@ -29,33 +27,129 @@ pub enum State {
     Rebooting,
     Destroying,
     Destroyed,
-    Errored,
+    Errored { message: String },
 }
+
+impl PartialEq for State {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Creating { .. }, Self::Creating { .. })
+                | (Self::Attaching { .. }, Self::Attaching { .. })
+                | (Self::Recreating { .. }, Self::Recreating { .. })
+                | (Self::Starting { .. }, Self::Starting { .. })
+                | (Self::Restarting { .. }, Self::Restarting { .. })
+                | (Self::Started, Self::Started)
+                | (Self::Ready, Self::Ready)
+                | (Self::Stopping, Self::Stopping)
+                | (Self::Stopped, Self::Stopped)
+                | (Self::Rebooting, Self::Rebooting)
+                | (Self::Destroying, Self::Destroying)
+                | (Self::Destroyed, Self::Destroyed)
+                | (Self::Errored { .. }, Self::Errored { .. })
+        )
+    }
+}
+
+impl Eq for State {}
 
 impl Display for Response {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "project '{}' is {}",
-            self.name,
-            self.state.to_string().with(self.state.get_color())
-        )
+        write!(f, "project '{}' is {}", self.name, self.state)
+    }
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            State::Creating { recreate_count } => {
+                if *recreate_count > 0 {
+                    write!(
+                        f,
+                        "{} (attempt {})",
+                        "creating".dark_yellow(),
+                        recreate_count
+                    )
+                } else {
+                    write!(f, "{}", "creating".cyan())
+                }
+            }
+            State::Attaching { recreate_count } => {
+                if *recreate_count > 0 {
+                    write!(
+                        f,
+                        "{} (attempt {})",
+                        "attaching".dark_yellow(),
+                        recreate_count
+                    )
+                } else {
+                    write!(f, "{}", "attaching".cyan())
+                }
+            }
+            State::Recreating { recreate_count } => {
+                if *recreate_count > 0 {
+                    write!(
+                        f,
+                        "{} (attempt {})",
+                        "recreating".dark_yellow(),
+                        recreate_count
+                    )
+                } else {
+                    write!(f, "{}", "recreating".dark_yellow())
+                }
+            }
+            State::Starting { restart_count } => {
+                if *restart_count > 0 {
+                    write!(
+                        f,
+                        "{} (attempt {})",
+                        "starting".dark_yellow(),
+                        restart_count
+                    )
+                } else {
+                    write!(f, "{}", "starting".cyan())
+                }
+            }
+            State::Restarting { restart_count } => {
+                if *restart_count > 0 {
+                    write!(
+                        f,
+                        "{} (attempt {})",
+                        "restarting".dark_yellow(),
+                        restart_count
+                    )
+                } else {
+                    write!(f, "{}", "restarting".dark_yellow())
+                }
+            }
+            State::Started => write!(f, "{}", "started".cyan()),
+            State::Ready => write!(f, "{}", "ready".green()),
+            State::Stopping => write!(f, "{}", "stopping".blue()),
+            State::Stopped => write!(f, "{}", "stopped".blue()),
+            State::Rebooting => write!(f, "{}", "rebooting".dark_yellow()),
+            State::Destroying => write!(f, "{}", "destroying".blue()),
+            State::Destroyed => write!(f, "{}", "destroyed".blue()),
+            State::Errored { message } => {
+                writeln!(f, "{}", "errored".red())?;
+                write!(f, "\tmessage: {}", message)
+            }
+        }
     }
 }
 
 impl State {
     pub fn get_color(&self) -> Color {
         match self {
-            Self::Creating
-            | Self::Attaching
-            | Self::Recreating
-            | Self::Starting
-            | Self::Restarting
+            Self::Creating { .. }
+            | Self::Attaching { .. }
+            | Self::Recreating { .. }
+            | Self::Starting { .. }
+            | Self::Restarting { .. }
             | Self::Started
             | Self::Rebooting => Color::Cyan,
             Self::Ready => Color::Green,
             Self::Stopped | Self::Stopping | Self::Destroying | Self::Destroyed => Color::Blue,
-            Self::Errored => Color::Red,
+            Self::Errored { .. } => Color::Red,
         }
     }
 }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -25,6 +25,7 @@ pub enum State {
     Ready,
     Stopping,
     Stopped,
+    Rebooting,
     Destroying,
     Destroyed,
     Errored,
@@ -48,7 +49,8 @@ impl State {
             | Self::Attaching
             | Self::Starting
             | Self::Restarting
-            | Self::Started => Color::Cyan,
+            | Self::Started
+            | Self::Rebooting => Color::Cyan,
             Self::Ready => Color::Green,
             Self::Stopped | Self::Stopping | Self::Destroying | Self::Destroyed => Color::Blue,
             Self::Errored => Color::Red,

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -20,6 +20,7 @@ pub enum State {
     Creating,
     Attaching,
     Starting,
+    Restarting,
     Started,
     Ready,
     Stopping,
@@ -43,7 +44,11 @@ impl Display for Response {
 impl State {
     pub fn get_color(&self) -> Color {
         match self {
-            Self::Creating | Self::Attaching | Self::Starting | Self::Started => Color::Cyan,
+            Self::Creating
+            | Self::Attaching
+            | Self::Starting
+            | Self::Restarting
+            | Self::Started => Color::Cyan,
             Self::Ready => Color::Green,
             Self::Stopped | Self::Stopping | Self::Destroying | Self::Destroyed => Color::Blue,
             Self::Errored => Color::Red,

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -19,6 +19,7 @@ pub struct Response {
 pub enum State {
     Creating,
     Attaching,
+    Recreating,
     Starting,
     Restarting,
     Started,
@@ -47,6 +48,7 @@ impl State {
         match self {
             Self::Creating
             | Self::Attaching
+            | Self::Recreating
             | Self::Starting
             | Self::Restarting
             | Self::Started

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -600,9 +600,7 @@ pub mod tests {
                 },
             };
 
-            let settings = ContainerSettings::builder(&docker)
-                .from_args(&args.context)
-                .await;
+            let settings = ContainerSettings::builder().from_args(&args.context).await;
 
             let hyper = HyperClient::builder().build(HttpConnector::new());
 

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -513,7 +513,7 @@ where
             {
                 Ok(container) => match safe_unwrap!(container.state.status) {
                     ContainerStateStatusEnum::RUNNING => {
-                        Self::Started(ProjectStarted::new(container))
+                        Self::Stopping(ProjectStopping{ container })
                     }
                     ContainerStateStatusEnum::EXITED => Self::Stopped(ProjectStopped { container }),
                     _ => {

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -453,7 +453,7 @@ where
                 .refresh(ctx)
                 .await
             {
-                Ok(container) => match container.state.as_ref().unwrap().status.as_ref().unwrap() {
+                Ok(container) => match safe_unwrap!(container.state.status) {
                     ContainerStateStatusEnum::RUNNING => {
                         Self::Started(ProjectStarted::new(container))
                     }
@@ -486,7 +486,7 @@ where
                 .refresh(ctx)
                 .await
             {
-                Ok(container) => match container.state.as_ref().unwrap().status.as_ref().unwrap() {
+                Ok(container) => match safe_unwrap!(container.state.status) {
                     ContainerStateStatusEnum::RUNNING => {
                         Self::Started(ProjectStarted::new(container))
                     }
@@ -746,7 +746,7 @@ where
     async fn next(self, ctx: &Ctx) -> Result<Self::Next, Self::Error> {
         let Self { container, .. } = self;
 
-        let container_id = container.id.as_ref().unwrap();
+        let container_id = safe_unwrap!(container.id);
         let ContainerSettings { network_name, .. } = ctx.container_settings();
 
         // Disconnect the bridge network before trying to start up
@@ -825,7 +825,7 @@ where
             container,
             recreate_count,
         } = self;
-        let container_id = container.id.as_ref().unwrap();
+        let container_id = safe_unwrap!(container.id);
 
         ctx.docker()
             .stop_container(container_id, Some(StopContainerOptions { t: 1 }))
@@ -873,7 +873,8 @@ where
 
     #[instrument(skip_all)]
     async fn next(self, ctx: &Ctx) -> Result<Self::Next, Self::Error> {
-        let container_id = self.container.id.as_ref().unwrap();
+        let Self { container, .. } = self;
+        let container_id = safe_unwrap!(container.id);
 
         ctx.docker()
             .start_container::<String>(container_id, None)
@@ -887,7 +888,7 @@ where
                 }
             })?;
 
-        let container = self.container.refresh(ctx).await?;
+        let container = container.refresh(ctx).await?;
 
         Ok(Self::Next::new(container))
     }
@@ -915,7 +916,7 @@ where
             restart_count,
         } = self;
 
-        let container_id = container.id.as_ref().unwrap();
+        let container_id = safe_unwrap!(container.id);
 
         // Stop it just to be safe
         ctx.docker()
@@ -1112,7 +1113,7 @@ where
         let Self { mut container } = self;
         ctx.docker()
             .stop_container(
-                container.id.as_ref().unwrap(),
+                safe_unwrap!(container.id),
                 Some(StopContainerOptions { t: 30 }),
             )
             .await?;
@@ -1176,7 +1177,7 @@ where
         let Self { container } = self;
         ctx.docker()
             .stop_container(
-                container.id.as_ref().unwrap(),
+                safe_unwrap!(container.id),
                 Some(StopContainerOptions { t: 30 }),
             )
             .await?;
@@ -1220,7 +1221,8 @@ where
 
     #[instrument(skip_all)]
     async fn next(self, ctx: &Ctx) -> Result<Self::Next, Self::Error> {
-        let container_id = self.container.id.as_ref().unwrap();
+        let Self { container } = self;
+        let container_id = safe_unwrap!(container.id);
         ctx.docker()
             .stop_container(container_id, Some(StopContainerOptions { t: 1 }))
             .await
@@ -1236,7 +1238,7 @@ where
             .await
             .unwrap_or(());
         Ok(Self::Next {
-            destroyed: Some(self.container),
+            destroyed: Some(container),
         })
     }
 }

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -307,11 +307,21 @@ impl Project {
 impl From<Project> for shuttle_common::models::project::State {
     fn from(project: Project) -> Self {
         match project {
-            Project::Creating(_) => Self::Creating,
-            Project::Attaching(_) => Self::Attaching,
-            Project::Recreating(_) => Self::Recreating,
-            Project::Starting(_) => Self::Starting,
-            Project::Restarting(_) => Self::Restarting,
+            Project::Creating(ProjectCreating { recreate_count, .. }) => {
+                Self::Creating { recreate_count }
+            }
+            Project::Attaching(ProjectAttaching { recreate_count, .. }) => {
+                Self::Attaching { recreate_count }
+            }
+            Project::Recreating(ProjectRecreating { recreate_count, .. }) => {
+                Self::Recreating { recreate_count }
+            }
+            Project::Starting(ProjectStarting { restart_count, .. }) => {
+                Self::Starting { restart_count }
+            }
+            Project::Restarting(ProjectRestarting { restart_count, .. }) => {
+                Self::Restarting { restart_count }
+            }
             Project::Started(_) => Self::Started,
             Project::Ready(_) => Self::Ready,
             Project::Stopping(_) => Self::Stopping,
@@ -319,7 +329,7 @@ impl From<Project> for shuttle_common::models::project::State {
             Project::Rebooting(_) => Self::Rebooting,
             Project::Destroying(_) => Self::Destroying,
             Project::Destroyed(_) => Self::Destroyed,
-            Project::Errored(_) => Self::Errored,
+            Project::Errored(ProjectError { message, .. }) => Self::Errored { message },
         }
     }
 }

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -19,7 +19,7 @@ use hyper::Client;
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use serde::{Deserialize, Serialize};
-use tokio::time::{self, sleep, timeout};
+use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, instrument};
 
 use crate::{
@@ -988,8 +988,6 @@ where
 
     #[instrument(skip_all)]
     async fn next(self, ctx: &Ctx) -> Result<Self::Next, Self::Error> {
-        time::sleep(Duration::from_secs(1)).await;
-
         let container = self.container.refresh(ctx).await?;
         let mut service = match self.service {
             Some(service) => service,
@@ -1533,7 +1531,7 @@ pub mod tests {
             })) if id == container_id,
         );
 
-        let delay = time::sleep(Duration::from_secs(10));
+        let delay = sleep(Duration::from_secs(10));
         futures::pin_mut!(delay);
         let mut project_readying = project_started
             .unwrap()

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -446,9 +446,7 @@ where
         let refreshed = match self {
             Self::Creating(creating) => Self::Creating(creating),
             Self::Attaching(attaching) => Self::Attaching(attaching),
-            Self::Starting(ProjectStarting { container, restart_count })
-            | Self::Restarting(ProjectRestarting { container, restart_count })
-             => match container
+            Self::Starting(ProjectStarting { container, restart_count }) => match container
                 .clone()
                 .refresh(ctx)
                 .await
@@ -527,6 +525,7 @@ where
                 },
                 Err(err) => return Err(err.into()),
             },
+            Self::Restarting(restarting) => Self::Restarting(restarting),
             Self::Recreating(recreating) => Self::Recreating(recreating),
             Self::Stopped(stopped) => Self::Stopped(stopped),
             Self::Rebooting(rebooting) => Self::Rebooting(rebooting),

--- a/gateway/src/task.rs
+++ b/gateway/src/task.rs
@@ -133,7 +133,7 @@ pub fn check_health() -> impl Task<ProjectContext, Output = Project, Error = Err
                 if ready.is_healthy().await {
                     TaskResult::Done(Project::Ready(ready))
                 } else {
-                    TaskResult::Done(Project::Ready(ready).stop().unwrap())
+                    TaskResult::Done(Project::Ready(ready).reboot().unwrap())
                 }
             }
             Ok(update) => TaskResult::Done(update),


### PR DESCRIPTION
This adds three new project states to improve the stability of project creation:
1. `Recreating` to recreate a container from scratch that failed to connect to the network
2. `Restarting` to try to start a container that failed to start
3. `Rebooting` to reboot container that became unhealthy

This causes the `Stopped` state to become a sink / dead end.

Things still to do:
- [x] Communicate restart / recreate attempts on the CLI