### PR TITLE
Feat: optimize sqlite db in deployer and gateway

### DIFF
--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -61,7 +61,13 @@ impl Persistence {
             std::fs::canonicalize(path).unwrap().to_string_lossy()
         );
 
-        let pool = SqlitePool::connect(path).await.unwrap();
+        let sqlite_options = SqliteConnectOptions::from_str(path)
+            .unwrap()
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal);
+
+        let pool = SqlitePool::connect_with(sqlite_options).await.unwrap();
+
         Self::from_pool(pool).await
     }
 

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -20,7 +20,9 @@ use chrono::Utc;
 use serde_json::json;
 use shuttle_common::STATE_MESSAGE;
 use sqlx::migrate::{MigrateDatabase, Migrator};
-use sqlx::sqlite::{Sqlite, SqlitePool};
+use sqlx::sqlite::{
+    Sqlite, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqliteSynchronous,
+};
 use tokio::sync::broadcast::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
 use tracing::{error, info, instrument, trace};

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -14,9 +14,11 @@ use shuttle_gateway::task;
 use shuttle_gateway::tls::{make_tls_acceptor, ChainAndPrivateKey};
 use shuttle_gateway::worker::{Worker, WORKER_QUEUE_SIZE};
 use sqlx::migrate::MigrateDatabase;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, PSqliteSynchronous};
 use sqlx::{query, Sqlite, SqlitePool};
 use std::io::{self, Cursor};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
@@ -60,8 +62,13 @@ async fn main() -> io::Result<()> {
             .unwrap()
             .to_string_lossy()
     );
-    let db = SqlitePool::connect(db_uri).await.unwrap();
 
+    let sqlite_options = SqliteConnectOptions::from_str(db_uri)
+        .unwrap()
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Normal);
+
+    let db = SqlitePool::connect_with(sqlite_options).await.unwrap();
     MIGRATIONS.run(&db).await.unwrap();
 
     match args.command {

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -14,7 +14,7 @@ use shuttle_gateway::task;
 use shuttle_gateway::tls::{make_tls_acceptor, ChainAndPrivateKey};
 use shuttle_gateway::worker::{Worker, WORKER_QUEUE_SIZE};
 use sqlx::migrate::MigrateDatabase;
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, PSqliteSynchronous};
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
 use sqlx::{query, Sqlite, SqlitePool};
 use std::io::{self, Cursor};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Up until sqlx 0.6.1 sqlite databases were created in [WAL mode](https://www.sqlite.org/wal.html) by default, which should be more performant. Our gateway DB was created before 0.6.1 and WAL mode is a permanent setting, so it's still in WAL mode. Since we're now on 0.6.2 we need to explicitly set it to WAL mode so new DBs are created in it. 

On top of that, using the `NORMAL` [synchronous setting](https://www.sqlite.org/pragma.html#pragma_synchronous) is durable and corruption-proof in WAL mode, and it is more performant then the default `FULL` setting.

Sources: sqlite docs linked above, https://phiresky.github.io/blog/2020/sqlite-performance-tuning/ and https://activesphere.com/blog/2018/12/24/understanding-sqlite-busy

TODO: stress test this and see if it resolves the deadlock.