### PR TITLE
feat: show progress bar on stopping service

### DIFF
--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -56,7 +56,7 @@ impl Client {
             .await
     }
 
-    pub async fn stop_service(&self, project: &ProjectName) -> Result<service::Detailed> {
+    pub async fn stop_service(&self, project: &ProjectName) -> Result<service::Summary> {
         let path = format!(
             "/projects/{}/services/{}",
             project.as_str(),


### PR DESCRIPTION
In the previous implementation stop service would just return a list of the deployments fetched before stopping the service, so it would show as running. This changes it to return a summary of the active deployment and a progress bar until it's stopped (which is almost immediate).