### PR TITLE
Renew LetsEncrypt certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "asn1-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +1843,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "der-parser"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1973,17 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3472,6 +3536,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,6 +4514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4995,6 +5077,7 @@ dependencies = [
  "tracing-subscriber",
  "ttl_cache",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]
@@ -5449,6 +5532,18 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
 
 [[package]]
 name = "system-interface"
@@ -7018,13 +7113,13 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9baf690e238840de84bbfad6ad72d6628c41d34c1a5e276dab7fb2c9167ca1ac"
+checksum = "5bdaa56ed83ae727e40236218955924a676426a690b61b133102f8390b60aec8"
 dependencies = [
  "bitflags 1.3.2",
  "io-lifetimes",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -7037,6 +7132,24 @@ dependencies = [
  "log",
  "thiserror",
  "wast 35.0.2",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs",
+ "base64",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -7103,3 +7216,23 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[patch.unused]]
+name = "shuttle-aws-rds"
+version = "0.12.0"
+
+[[patch.unused]]
+name = "shuttle-persist"
+version = "0.12.0"
+
+[[patch.unused]]
+name = "shuttle-poise"
+version = "0.12.0"
+
+[[patch.unused]]
+name = "shuttle-shared-db"
+version = "0.12.0"
+
+[[patch.unused]]
+name = "shuttle-static-folder"
+version = "0.12.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453e534d4f46dcdddd7aa8619e9a664e153f34383d14710db0b0d76c2964db89"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "hyper",
  "openssl",
  "reqwest",
@@ -171,7 +171,7 @@ dependencies = [
  "anyhow",
  "async-lock",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bincode",
  "blake3",
  "chrono",
@@ -535,7 +535,7 @@ checksum = "744864363a200a5e724a7e61bc8c11b6628cf2e3ec519c8a1a48e609a8156b40"
 dependencies = [
  "async-trait",
  "axum-core",
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -670,6 +670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +750,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -783,7 +789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8746d07211bb12a7c34d995539b4a2acd4e0b0e757de98ce2ab99bcf17443fad"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.13.1",
  "hex 0.4.3",
  "indexmap",
  "lazy_static",
@@ -932,7 +938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fdc51fbabb210bf9bb6ad6127a647cd6c96fb0f0ce6877fdabc6043d3013fe6"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bytesize",
  "cargo-platform",
  "cargo-util",
@@ -1364,7 +1370,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "hmac 0.12.1",
  "percent-encoding",
  "rand",
@@ -2537,7 +2543,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "bytes",
  "headers-core",
@@ -2919,11 +2925,11 @@ dependencies = [
 
 [[package]]
 name = "instant-acme"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c6a5dc426fcc25b99d91e4a283a8f5518339a0f63bf28588a6c5f31e089f8a"
+checksum = "fbbf90cf8ba6f21d654be86375ee5e516ea38540a842b7259d3ddb848181691c"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "hyper",
  "hyper-rustls",
  "ring",
@@ -3061,7 +3067,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "pem",
  "ring",
  "serde",
@@ -3355,7 +3361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a37fe10c1485a0cd603468e284a1a8535b4ecf46808f5f7de3639a1e1252dbf8"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "bson",
  "chrono",
@@ -3872,7 +3878,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4301,7 +4307,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4568,7 +4574,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -4942,7 +4948,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "cap-std",
  "chrono",
@@ -5037,7 +5043,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
- "base64",
+ "base64 0.13.1",
  "bollard",
  "chrono",
  "clap 4.1.11",
@@ -5356,7 +5362,7 @@ checksum = "dcbc16ddba161afc99e14d1713a453747a2b07fc097d2009f4c300ec99286105"
 dependencies = [
  "ahash",
  "atoi",
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "byteorder",
  "bytes",
@@ -5937,7 +5943,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6017,7 +6023,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "bytes",
  "futures-core",
@@ -6223,7 +6229,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",
@@ -6320,7 +6326,7 @@ version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "native-tls",
  "once_cell",
@@ -6622,7 +6628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e77abcf538af42517e188c109e4b50ecf6c0ee4d77ede76a438e0306b934dc"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
@@ -7141,7 +7147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs",
- "base64",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser",
  "lazy_static",

--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,8 @@ WORKDIR /build
 FROM shuttle-build as cache
 WORKDIR /src
 COPY . .
-RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" -or -name "*.pem" \) -type f -exec install -D \{\} /build/\{\} \;
+RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" \) -type f -exec install -D \{\} /build/\{\} \;
+RUN [ "$CARGO_PROFILE" != "release" ] && find ${SRC_CRATES} -name "*.pem" -type f -exec install -D \{\} /build/\{\} \;
 
 FROM shuttle-build AS planner
 COPY --from=cache /build .

--- a/Containerfile
+++ b/Containerfile
@@ -3,11 +3,14 @@ ARG RUSTUP_TOOLCHAIN
 FROM rust:${RUSTUP_TOOLCHAIN}-buster as shuttle-build
 RUN apt-get update &&\
     apt-get install -y curl
+
 # download protoc binary and unzip it in usr/bin
-RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip &&\
-    unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
-    unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
-    rm -f protoc-21.9-linux-x86_64.zip
+ARG PROTOC_ARCH
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-${PROTOC_ARCH}.zip &&\
+    unzip -o protoc-21.9-linux-${PROTOC_ARCH}.zip -d /usr bin/protoc &&\
+    unzip -o protoc-21.9-linux-${PROTOC_ARCH}.zip -d /usr/ 'include/*' &&\
+    rm -f protoc-21.9-linux-${PROTOC_ARCH}.zip
+
 RUN cargo install cargo-chef
 WORKDIR /build
 

--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ WORKDIR /build
 FROM shuttle-build as cache
 WORKDIR /src
 COPY . .
-RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" \) -type f -exec install -D \{\} /build/\{\} \;
+RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" -or -name "*.pem" \) -type f -exec install -D \{\} /build/\{\} \;
 
 FROM shuttle-build AS planner
 COPY --from=cache /build .
@@ -42,6 +42,7 @@ RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9
     unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
     rm -f protoc-21.9-linux-x86_64.zip
 RUN rustup component add rust-src
+
 COPY --from=cache /build/ /usr/src/shuttle/
 
 FROM shuttle-common

--- a/Containerfile
+++ b/Containerfile
@@ -18,6 +18,8 @@ FROM shuttle-build as cache
 WORKDIR /src
 COPY . .
 RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" \) -type f -exec install -D \{\} /build/\{\} \;
+# This is used to carry over in the docker images any *.pem files from shuttle root directory, to be used for TLS testing, as described
+# here in the admin README.md.
 RUN [ "$CARGO_PROFILE" != "release" ] && find ${SRC_CRATES} -name "*.pem" -type f -exec install -D \{\} /build/\{\} \;
 
 FROM shuttle-build AS planner

--- a/Containerfile
+++ b/Containerfile
@@ -37,10 +37,11 @@ FROM rust:${RUSTUP_TOOLCHAIN}-buster as shuttle-common
 RUN apt-get update &&\
     apt-get install -y curl
 # download protoc binary and unzip it in usr/bin
-RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-x86_64.zip &&\
-    unzip -o protoc-21.9-linux-x86_64.zip -d /usr bin/protoc &&\
-    unzip -o protoc-21.9-linux-x86_64.zip -d /usr/ 'include/*' &&\
-    rm -f protoc-21.9-linux-x86_64.zip
+ARG PROTOC_ARCH
+RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protoc-21.9-linux-${PROTOC_ARCH}.zip &&\
+    unzip -o protoc-21.9-linux-${PROTOC_ARCH}.zip -d /usr/ bin/protoc &&\
+    unzip -o protoc-21.9-linux-${PROTOC_ARCH}.zip -d /usr/ 'include/*' &&\
+    rm -f protoc-21.9-linux-${PROTOC_ARCH}.zip
 RUN rustup component add rust-src
 
 COPY --from=cache /build/ /usr/src/shuttle/

--- a/Makefile
+++ b/Makefile
@@ -141,17 +141,17 @@ down: docker-compose.rendered.yml
 
 shuttle-%: ${SRC} Cargo.lock
 	docker buildx build \
-				--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
-				--build-arg folder=$(*) \
-        --build-arg prepare_args=$(PREPARE_ARGS) \
-				--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
+			--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
+			--build-arg folder=$(*) \
+			--build-arg prepare_args=$(PREPARE_ARGS) \
+			--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
 		  	--build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
-				--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \
-				--tag $(CONTAINER_REGISTRY)/$(*):$(TAG) \
-				--tag $(CONTAINER_REGISTRY)/$(*):latest \
-				$(BUILDX_FLAGS) \
-				-f Containerfile \
-				.
+			--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \
+			--tag $(CONTAINER_REGISTRY)/$(*):$(TAG) \
+			--tag $(CONTAINER_REGISTRY)/$(*):latest \
+			$(BUILDX_FLAGS) \
+			-f Containerfile \
+			.
 
 # Bunch of targets to make bumping the shuttle version easier
 #

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ clean:
 
 images: shuttle-provisioner shuttle-deployer shuttle-gateway shuttle-auth postgres panamax otel
 
-# We must specify the platform tag so that
 postgres:
 	docker buildx build \
 			--build-arg POSTGRES_TAG=$(POSTGRES_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,12 @@ CARGO_PROFILE=debug
 RUST_LOG?=shuttle=trace,debug
 endif
 
+ARCH=$(shell uname -m)
+PROTOC_ARCH=$(ARCH)
+ifeq ($(ARCH), arm64)
+PROTOC_ARCH=aarch_64
+endif
+
 POSTGRES_EXTRA_PATH?=./extras/postgres
 POSTGRES_TAG?=14
 
@@ -90,6 +96,7 @@ images: shuttle-provisioner shuttle-deployer shuttle-gateway shuttle-auth postgr
 
 postgres:
 	docker buildx build \
+              --build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
 	       --build-arg POSTGRES_TAG=$(POSTGRES_TAG) \
 	       --tag $(CONTAINER_REGISTRY)/postgres:$(POSTGRES_TAG) \
 	       $(BUILDX_FLAGS) \
@@ -134,6 +141,7 @@ down: docker-compose.rendered.yml
 
 shuttle-%: ${SRC} Cargo.lock
 	docker buildx build \
+	       --build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
 	       --build-arg folder=$(*) \
            --build-arg prepare_args=$(PREPARE_ARGS) \
 	       --build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \

--- a/Makefile
+++ b/Makefile
@@ -94,14 +94,14 @@ clean:
 
 images: shuttle-provisioner shuttle-deployer shuttle-gateway shuttle-auth postgres panamax otel
 
+# We must specify the platform tag so that
 postgres:
 	docker buildx build \
-              --build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
-	       --build-arg POSTGRES_TAG=$(POSTGRES_TAG) \
-	       --tag $(CONTAINER_REGISTRY)/postgres:$(POSTGRES_TAG) \
-	       $(BUILDX_FLAGS) \
-	       -f $(POSTGRES_EXTRA_PATH)/Containerfile \
-	       $(POSTGRES_EXTRA_PATH)
+			--build-arg POSTGRES_TAG=$(POSTGRES_TAG) \
+			--tag $(CONTAINER_REGISTRY)/postgres:$(POSTGRES_TAG) \
+			$(BUILDX_FLAGS) \
+			-f $(POSTGRES_EXTRA_PATH)/Containerfile \
+			$(POSTGRES_EXTRA_PATH)
 
 panamax:
 	if [ $(USE_PANAMAX) = "enable" ]; then \
@@ -141,17 +141,17 @@ down: docker-compose.rendered.yml
 
 shuttle-%: ${SRC} Cargo.lock
 	docker buildx build \
-	       --build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
-	       --build-arg folder=$(*) \
-           --build-arg prepare_args=$(PREPARE_ARGS) \
-	       --build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
-		   --build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
-	       --tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \
-	       --tag $(CONTAINER_REGISTRY)/$(*):$(TAG) \
-	       --tag $(CONTAINER_REGISTRY)/$(*):latest \
-	       $(BUILDX_FLAGS) \
-	       -f Containerfile \
-	       .
+				--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
+				--build-arg folder=$(*) \
+        --build-arg prepare_args=$(PREPARE_ARGS) \
+				--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
+		  	--build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
+				--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \
+				--tag $(CONTAINER_REGISTRY)/$(*):$(TAG) \
+				--tag $(CONTAINER_REGISTRY)/$(*):latest \
+				$(BUILDX_FLAGS) \
+				-f Containerfile \
+				.
 
 # Bunch of targets to make bumping the shuttle version easier
 #

--- a/admin/README.md
+++ b/admin/README.md
@@ -23,6 +23,11 @@ setting the `SSL_CERT_FILE` environment variable. If you deploy the `gateway` th
 need to export the `SSL_CERT_FILE` environmanet variable through the `docker-compose.yml` file, for the `gateway`
 service.
 
+**Note**: Building the containers locally will carry over to the images any "*.pem" files from the shuttle root
+directory, given they are needed to enable the `SSL_CERT_FILE` on the gateway. You can have you Pebble CA root
+certificate under shuttle root directory and this will be carried in the gateway container under `/usr/src/shuttle`.
+Then the `SSL_CERT_FILE` can be set as `/usr/src/shuttle/{path_to_pebble.minica.pem}`.
+
 ``` shell
 export SSL_CERT_FILE="$PWD/test/certs/pebble.minica.pem"
 ```
@@ -33,7 +38,7 @@ container that `https://localhost:14000/dir` points to the host machine pebble i
 `gateway`s `/etc/hosts` a new entry for `localhost` to point also to the `host.docker.internal` IP. The `host.docker.internal`
 IP can be found by running `ping host.docker.internal` in the `gateway` container.
 
-Now you'll want this admin client to use the local `Pebble` server when making new account. Therefore, use the
+Now you'll want this admin client to use the local `Pebble` server when making a new account. Therefore, use the
 following command when you create new accounts:
 
 ``` shell

--- a/admin/README.md
+++ b/admin/README.md
@@ -10,29 +10,64 @@ whatever method works for your system. It is included in the nix environment if 
 
 To start the `Pebble` server you'll need some config, a root CA and a certificate signed with the CA. The easiest way
 to get all these is to get them from the [pebble/test](https://github.com/letsencrypt/pebble/tree/main/test) folder.
+At the same time, you'll need the [pebble/test/config/pebble-config.json](https://github.com/letsencrypt/pebble/tree/main/test/config/pebble-config.json)
+to have its `httpPort` and `tlsPort` set to `7999`, the port of the bouncer (which handles the HTTP-01 challenge handling).
 
-You should now be able to start `Pebble` locally. If you used the `pebble/test` folder, then your important
-variables are as follow:
+You should now be able to start `Pebble` locally. If you used the `pebble/test` folder, then your important variables are as follow:
 
 - *Server url*: `https://localhost:14000/dir`
-- *CA location*: `$PWD/test/certs/pebble.minica.pem`
+- *CA root certificate location*: `$PWD/test/certs/pebble.minica.pem`
 
 Next you'll need `gateway` to use this CA when checking the TLS connection with localhost. This can be done by
-setting the `SSL_CERT_FILE` environment variable.
+setting the `SSL_CERT_FILE` environment variable. If you deploy the `gateway` through docker compose then you'll
+need to export the `SSL_CERT_FILE` environmanet variable through the `docker-compose.yml` file, for the `gateway`
+service.
 
 ``` shell
 export SSL_CERT_FILE="$PWD/test/certs/pebble.minica.pem"
 ```
 
-When `gateway` now runs, it will use this root certificate to check the certificate presented by `Pebble`.
+When `gateway` now runs, it will use this root certificate to check the certificate presented by `Pebble`. At the same
+time, if `Pebble` runs on the `host` machine and your `gateway` runs in a container, you need to tell to the `gateway`
+container that `https://localhost:14000/dir` points to the host machine pebble instance. You'll need to append to the
+`gateway`s `/etc/hosts` a new entry for `localhost` to point also to the `host.docker.internal` IP. The `host.docker.internal`
+IP can be found by running `ping host.docker.internal` in the `gateway` container.
 
 Now you'll want this admin client to use the local `Pebble` server when making new account. Therefore, use the
-following command when you create new accounts
+following command when you create new accounts:
 
 ``` shell
 cargo run -p shuttle-admin -- --api-url http://localhost:8001 acme create-account --acme-server https://localhost:14000/dir --email <email>
 ```
 
-Safe the account JSON in a local file and use it to test creating new certificate. However, you'll the FQDN you're
-using for testnig to resolve to your local machine. So create an `A` record for it on your DNS with the value
-`127.0.0.1`. And Bob's your uncle 🎉
+Save the account JSON in a local file and use it to test creating a new certificate. Also, the FQDN you'll be using, to
+request a certificate for, must resolve to your localhost, so you either add an entry for that in `/etc/hosts` or set up
+a local DNS server (e.g. on MacOs: https://gist.github.com/ogrrd/5831371) to resolve specific domains to `127.0.0.1` (by adding
+an `A` entry into the `dnsmasq.conf` file).
+
+Requesting a new certificate for a custom-domain:
+
+```shell
+cargo run -p shuttle-admin -- --api-url http://localhost:8001 acme request --fqdn local.custom.domain.me --project <project-name> --credentials <pebble-account-credentials.json>
+```
+
+Renewing a new certificate for a custom-domain:
+```shell
+cargo run -p shuttle-admin -- --api-url http://localhost:8001 acme renew-custom-domain --fqdn local.custom.domain.me --project <project-name> --credentials <pebble-account-credentials.json>
+```
+
+## How to test gateway certificates locally
+
+You will need the same setup done for `Pebble` as for the custom domain certificates. The difference is that `Pebble` will do
+a DNS-01 challenge for requesting a gateway certificate. The gateway will log the actual challenge Pebble will check. It involves
+adding a TXT entry in your local DNS (e.g. `txt-record=_acme-challenge.local.shuttle.test,ZqS9r9z6UY0anHV-DIjLGi0GKps0RG4HxoFJO3hmtYs`).
+The gateway waits 1 minute before telling `Pebble` the challenge is ready, so you'll need to add the TXT record in the DNS within that time.
+Also, to be able to create an order and a certificate, the `gateway` will need to load pre-existing account credentials from `acme.json` for
+an account that lives in `Pebble` memory. Once everything is done correctly the `gateway` will generate its certificate under `ssl.pem`.
+
+To renew the gateway certificate you'll run:
+```shell
+shuttle-admin acme renew-gateway --credentials <CREDENTIALS>
+```
+
+

--- a/admin/src/args.rs
+++ b/admin/src/args.rs
@@ -61,6 +61,30 @@ pub enum AcmeCommand {
         #[arg(long)]
         credentials: PathBuf,
     },
+
+    /// Renew the certificate for a FQDN
+    RenewCustomDomainCertificate {
+        /// Fqdn to renew the certificate for
+        #[arg(long)]
+        fqdn: String,
+
+        /// Project to renew the certificate for
+        #[arg(long)]
+        project: ProjectName,
+
+        /// Path to acme credentials file
+        /// This should have been created with `acme create-account`
+        #[arg(long)]
+        credentials: PathBuf,
+    },
+
+    /// Renew certificate for the shuttle gateway
+    RenewGatewayCertificate {
+        /// Path to acme credentials file
+        /// This should have been created with `acme create-account`
+        #[arg(long)]
+        credentials: PathBuf,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/admin/src/args.rs
+++ b/admin/src/args.rs
@@ -78,7 +78,9 @@ pub enum AcmeCommand {
         credentials: serde_json::Value,
     },
 
-    /// Renew the certificate for the shuttle gateway
+    /// Renew the certificate for the shuttle gateway.
+    /// Note: this step should be completed manually in terms
+    /// of DNS-01 challenge completion.
     RenewGateway {
         /// Path to acme credentials file
         /// This should have been created with `acme create-account`

--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -43,6 +43,24 @@ impl Client {
         self.post(&path, Some(credentials)).await
     }
 
+    pub async fn acme_renew_custom_domain_certificate(
+        &self,
+        fqdn: &str,
+        project_name: &ProjectName,
+        credentials: &serde_json::Value,
+    ) -> Result<String> {
+        let path = format!("/admin/acme/renew/{project_name}/{fqdn}");
+        self.post(&path, Some(credentials)).await
+    }
+
+    pub async fn acme_renew_gateway_certificate(
+        &self,
+        credentials: &serde_json::Value,
+    ) -> Result<String> {
+        let path = "/admin//acme/gateway/renew".to_string();
+        self.post(&path, Some(credentials)).await
+    }
+
     pub async fn get_projects(&self) -> Result<Vec<project::AdminResponse>> {
         self.get("/admin/projects").await
     }

--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -57,7 +57,7 @@ impl Client {
         &self,
         credentials: &serde_json::Value,
     ) -> Result<String> {
-        let path = "/admin//acme/gateway/renew".to_string();
+        let path = "/admin/acme/gateway/renew".to_string();
         self.post(&path, Some(credentials)).await
     }
 

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -51,6 +51,30 @@ async fn main() {
                 .await
                 .expect("to get a certificate challenge response")
         }
+        Command::Acme(AcmeCommand::RenewCustomDomainCertificate {
+            fqdn,
+            project,
+            credentials,
+        }) => {
+            let credentials = fs::read_to_string(credentials).expect("to read credentials file");
+            let credentials =
+                serde_json::from_str(&credentials).expect("to parse content of credentials file");
+
+            client
+                .acme_renew_custom_domain_certificate(&fqdn, &project, &credentials)
+                .await
+                .expect("to get a certificate challenge response")
+        }
+        Command::Acme(AcmeCommand::RenewGatewayCertificate { credentials }) => {
+            let credentials = fs::read_to_string(credentials).expect("to read credentials file");
+            let credentials =
+                serde_json::from_str(&credentials).expect("to parse content of credentials file");
+
+            client
+                .acme_renew_gateway_certificate(&credentials)
+                .await
+                .expect("to get a certificate challenge response")
+        }
         Command::ProjectNames => {
             let projects = client
                 .get_projects()

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -7,7 +7,6 @@ use shuttle_admin::{
 use std::{
     collections::{hash_map::RandomState, HashMap},
     fmt::Write,
-    fs,
 };
 use tracing::trace;
 
@@ -37,44 +36,26 @@ async fn main() {
 
             res
         }
-        Command::Acme(AcmeCommand::RequestCertificate {
+        Command::Acme(AcmeCommand::Request {
             fqdn,
             project,
             credentials,
-        }) => {
-            let credentials = fs::read_to_string(credentials).expect("to read credentials file");
-            let credentials =
-                serde_json::from_str(&credentials).expect("to parse content of credentials file");
-
-            client
-                .acme_request_certificate(&fqdn, &project, &credentials)
-                .await
-                .expect("to get a certificate challenge response")
-        }
-        Command::Acme(AcmeCommand::RenewCustomDomainCertificate {
+        }) => client
+            .acme_request_certificate(&fqdn, &project, &credentials)
+            .await
+            .expect("to get a certificate challenge response"),
+        Command::Acme(AcmeCommand::RenewCustomDomain {
             fqdn,
             project,
             credentials,
-        }) => {
-            let credentials = fs::read_to_string(credentials).expect("to read credentials file");
-            let credentials =
-                serde_json::from_str(&credentials).expect("to parse content of credentials file");
-
-            client
-                .acme_renew_custom_domain_certificate(&fqdn, &project, &credentials)
-                .await
-                .expect("to get a certificate challenge response")
-        }
-        Command::Acme(AcmeCommand::RenewGatewayCertificate { credentials }) => {
-            let credentials = fs::read_to_string(credentials).expect("to read credentials file");
-            let credentials =
-                serde_json::from_str(&credentials).expect("to parse content of credentials file");
-
-            client
-                .acme_renew_gateway_certificate(&credentials)
-                .await
-                .expect("to get a certificate challenge response")
-        }
+        }) => client
+            .acme_renew_custom_domain_certificate(&fqdn, &project, &credentials)
+            .await
+            .expect("to get a certificate challenge response"),
+        Command::Acme(AcmeCommand::RenewGateway { credentials }) => client
+            .acme_renew_gateway_certificate(&credentials)
+            .await
+            .expect("to get a certificate challenge response"),
         Command::ProjectNames => {
             let projects = client
                 .get_projects()

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -205,6 +205,8 @@ impl From<AccountTier> for Vec<Scope> {
                 Scope::UserCreate,
                 Scope::AcmeCreate,
                 Scope::CustomDomainCreate,
+                Scope::CustomDomainCertificateRenew,
+                Scope::GatewayCertificateRenew,
                 Scope::Admin,
             ]);
         }

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -76,6 +76,14 @@ pub enum Scope {
     /// Create a custom domain,
     CustomDomainCreate,
 
+    /// Renew the certificate of a custom domain.
+    CustomDomainCertificateRenew,
+
+    /// Request renewal of the gateway certificate.
+    /// Note: this step should be completed manually in terms
+    /// of DNS-01 challenge completion.
+    GatewayCertificateRenew,
+
     /// Admin level scope to internals
     Admin,
 }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -44,6 +44,7 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["default", "env-filter"] }
 ttl_cache = { workspace = true }
 uuid = { workspace = true, features = [ "v4" ] }
+x509-parser = "0.14.0"
 
 [dependencies.shuttle-common]
 workspace = true

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -20,7 +20,7 @@ http = { workspace = true }
 hyper = { workspace = true, features = [ "stream" ] }
 # not great, but waiting for WebSocket changes to be merged
 hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "bug/host_header" }
-instant-acme = "0.1.1"
+instant-acme = "0.2.0"
 lazy_static = "1.4.0"
 num_cpus = "1.14.0"
 once_cell = { workspace = true }

--- a/gateway/src/acme.rs
+++ b/gateway/src/acme.rs
@@ -156,7 +156,7 @@ impl AcmeClient {
                 AcmeClientError::CertificateCreation
             })?;
             retries -= 1;
-            sleep(Duration::new(1, 0)).await;
+            sleep(Duration::from_secs(1)).await;
         }
 
         Ok((

--- a/gateway/src/acme.rs
+++ b/gateway/src/acme.rs
@@ -14,6 +14,7 @@ use instant_acme::{
     Identifier, KeyAuthorization, LetsEncrypt, NewAccount, NewOrder, Order, OrderStatus,
 };
 use rcgen::{Certificate, CertificateParams, DistinguishedName};
+
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 use tower::{Layer, Service};
@@ -30,11 +31,6 @@ pub struct CustomDomain {
     pub project_name: ProjectName,
     pub certificate: String,
     pub private_key: String,
-}
-
-pub enum AcmeCredentials<'a> {
-    InMemory(AccountCredentials<'a>),
-    GatewayState,
 }
 
 /// An ACME client implementation that completes Http01 challenges

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -376,9 +376,8 @@ async fn request_custom_domain_acme_certificate(
     resolver
         .serve_pem(&fqdn.to_string(), Cursor::new(buf))
         .await?;
-
     Ok(format!(
-        "New certificate created for {} project.",
+        r#""New certificate created for {} project.""#,
         project_name
     ))
 }
@@ -431,13 +430,16 @@ async fn renew_custom_domain_acme_certificate(
                         resolver
                             .serve_pem(&fqdn.to_string(), Cursor::new(buf))
                             .await?;
-                        Ok(format!("Certificate renewed for {} project.", project_name))
+                        Ok(format!(
+                            r#""Certificate renewed for {} project.""#,
+                            project_name
+                        ))
                     }
                     Err(err) => Err(err.into()),
                 };
             } else {
                 Ok(format!(
-                    "Certificate renewal skipped, {} project certificate still valid for {} days.",
+                    r#""Certificate renewal skipped, {} project certificate still valid for {} days.""#,
                     project_name, diff
                 ))
             }
@@ -456,7 +458,7 @@ async fn renew_gateway_acme_certificate(
     service
         .renew_certificate(&acme_client, resolver, credentials)
         .await;
-    Ok("Renewed the gate certificate.".to_string())
+    Ok(r#""Renewed the gateway certificate.""#.to_string())
 }
 
 async fn get_projects(

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -680,7 +680,7 @@ pub mod tests {
         });
 
         let mut router = ApiBuilder::new()
-            .with_service(Arc::<GatewayService>::clone(&service))
+            .with_service(Arc::clone(&service))
             .with_sender(sender)
             .with_default_routes()
             .with_auth_service(world.context().auth_uri)
@@ -837,7 +837,7 @@ pub mod tests {
         });
 
         let mut router = ApiBuilder::new()
-            .with_service(Arc::<GatewayService>::clone(&service))
+            .with_service(Arc::clone(&service))
             .with_sender(sender)
             .with_default_routes()
             .with_auth_service(world.context().auth_uri)

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -37,7 +37,7 @@ use crate::auth::{ScopedUser, User};
 use crate::project::{ContainerInspectResponseExt, Project, ProjectCreating};
 use crate::service::GatewayService;
 use crate::task::{self, BoxedTask, TaskResult};
-use crate::tls::GatewayCertResolver;
+use crate::tls::{GatewayCertResolver, RENEWAL_VALIDITY_THRESHOLD_IN_DAYS};
 use crate::worker::WORKER_QUEUE_SIZE;
 use crate::{Error, ProjectName};
 
@@ -408,7 +408,7 @@ async fn renew_custom_domain_acme_certificate(
                 .sub(ASN1Time::now())
                 .unwrap();
             // If current certificate validity less_or_eq than 30 days, attempt renewal.
-            if diff.whole_days() <= 30 {
+            if diff.whole_days() <= RENEWAL_VALIDITY_THRESHOLD_IN_DAYS {
                 return match acme_client
                     .create_certificate(&fqdn.to_string(), ChallengeType::Http01, credentials)
                     .await

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -14,6 +14,7 @@ use axum::Json;
 use bollard::Docker;
 use futures::prelude::*;
 use serde::{Deserialize, Deserializer, Serialize};
+use service::ContainerSettings;
 use shuttle_common::models::error::{ApiError, ErrorKind};
 use tokio::sync::mpsc::error::SendError;
 use tracing::error;
@@ -28,8 +29,6 @@ pub mod service;
 pub mod task;
 pub mod tls;
 pub mod worker;
-
-use crate::service::{ContainerSettings, GatewayService};
 
 /// Server-side errors that do not have to do with the user runtime
 /// should be [`Error`]s.
@@ -751,7 +750,7 @@ pub mod tests {
     #[tokio::test]
     async fn end_to_end() {
         let world = World::new().await;
-        let service = Arc::new(GatewayService::init(world.args(), world.pool()).await);
+        let service = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await);
         let worker = Worker::new();
 
         let (log_out, mut log_in) = channel(256);
@@ -770,7 +769,7 @@ pub mod tests {
 
         let api_client = world.client(world.args.control);
         let api = ApiBuilder::new()
-            .with_service(Arc::clone(&service))
+            .with_service(Arc::<GatewayService>::clone(&service))
             .with_sender(log_out.clone())
             .with_default_routes()
             .with_auth_service(world.context().auth_uri)
@@ -778,7 +777,7 @@ pub mod tests {
 
         let user = UserServiceBuilder::new()
             .with_service(Arc::clone(&service))
-            .with_task_sender(log_out.clone())
+            .with_task_sender(log_out)
             .with_public(world.fqdn())
             .with_user_proxy_binding_to(world.args.user);
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -769,7 +769,7 @@ pub mod tests {
 
         let api_client = world.client(world.args.control);
         let api = ApiBuilder::new()
-            .with_service(Arc::<GatewayService>::clone(&service))
+            .with_service(Arc::clone(&service))
             .with_sender(log_out.clone())
             .with_default_routes()
             .with_auth_service(world.context().auth_uri)

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -140,7 +140,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
     let acme_client = AcmeClient::new();
 
     let mut api_builder = ApiBuilder::new()
-        .with_service(Arc::<GatewayService>::clone(&gateway))
+        .with_service(Arc::clone(&gateway))
         .with_sender(sender.clone())
         .binding_to(args.control);
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use futures::prelude::*;
 
 use shuttle_common::backends::tracing::setup_tracing;
-use shuttle_gateway::acme::{AcmeClient, AcmeCredentials, CustomDomain};
+use shuttle_gateway::acme::{AcmeClient, CustomDomain};
 use shuttle_gateway::api::latest::{ApiBuilder, SVC_DEGRADED_THRESHOLD};
 use shuttle_gateway::args::StartArgs;
 use shuttle_gateway::args::{Args, Commands, UseTls};
@@ -179,11 +179,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
         tokio::spawn(async move {
             // Make sure we have a certificate for ourselves.
             gateway
-                .fetch_certificate(
-                    &acme_client,
-                    resolver.clone(),
-                    AcmeCredentials::GatewayState,
-                )
+                .fetch_certificate(&acme_client, resolver.clone(), gateway.credentials())
                 .await;
         });
     } else {

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -24,9 +24,9 @@ use shuttle_common::models::project::IDLE_MINUTES;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, instrument};
 
+use crate::service::ContainerSettings;
 use crate::{
-    ContainerSettings, DockerContext, EndState, Error, ErrorKind, IntoTryState, ProjectName,
-    Refresh, State, TryState,
+    DockerContext, EndState, Error, ErrorKind, IntoTryState, ProjectName, Refresh, State, TryState,
 };
 
 macro_rules! safe_unwrap {

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -1,4 +1,7 @@
+use std::io::Cursor;
 use std::net::Ipv4Addr;
+use std::ops::Sub;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -6,11 +9,12 @@ use axum::headers::HeaderMapExt;
 use axum::http::Request;
 use axum::response::Response;
 use bollard::{Docker, API_DEFAULT_VERSION};
-use fqdn::Fqdn;
+use fqdn::{Fqdn, FQDN};
 use hyper::client::connect::dns::GaiResolver;
 use hyper::client::HttpConnector;
 use hyper::Client;
 use hyper_reverse_proxy::ReverseProxy;
+use instant_acme::{AccountCredentials, ChallengeType};
 use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
@@ -21,13 +25,16 @@ use sqlx::sqlite::SqlitePool;
 use sqlx::types::Json as SqlxJson;
 use sqlx::{query, Error as SqlxError, Row};
 use tokio::sync::mpsc::Sender;
-use tracing::{debug, trace, Span};
+use tracing::{debug, trace, warn, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+use x509_parser::parse_x509_certificate;
+use x509_parser::time::ASN1Time;
 
-use crate::acme::CustomDomain;
+use crate::acme::{AccountWrapper, AcmeClient, AcmeCredentials, CustomDomain};
 use crate::args::ContextArgs;
 use crate::project::{Project, ProjectCreating};
 use crate::task::{self, BoxedTask, TaskBuilder};
+use crate::tls::{ChainAndPrivateKey, GatewayCertResolver};
 use crate::worker::TaskRouter;
 use crate::{AccountName, DockerContext, Error, ErrorKind, ProjectDetails, ProjectName};
 
@@ -177,6 +184,7 @@ pub struct GatewayService {
     provider: GatewayContextProvider,
     db: SqlitePool,
     task_router: TaskRouter<BoxedTask>,
+    state_location: PathBuf,
 }
 
 impl GatewayService {
@@ -184,7 +192,7 @@ impl GatewayService {
     ///
     /// * `args` - The [`Args`] with which the service was
     /// started. Will be passed as [`Context`] to workers and state.
-    pub async fn init(args: ContextArgs, db: SqlitePool) -> Self {
+    pub async fn init(args: ContextArgs, db: SqlitePool, state_location: PathBuf) -> Self {
         let docker = Docker::connect_with_unix(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
 
         let container_settings = ContainerSettings::builder().from_args(&args).await;
@@ -197,6 +205,7 @@ impl GatewayService {
             provider,
             db,
             task_router,
+            state_location,
         }
     }
 
@@ -455,14 +464,14 @@ impl GatewayService {
 
     pub async fn create_custom_domain(
         &self,
-        project_name: ProjectName,
+        project_name: &ProjectName,
         fqdn: &Fqdn,
         certs: &str,
         private_key: &str,
     ) -> Result<(), Error> {
         query("INSERT OR REPLACE INTO custom_domains (fqdn, project_name, certificate, private_key) VALUES (?1, ?2, ?3, ?4)")
             .bind(fqdn.to_string())
-            .bind(&project_name)
+            .bind(project_name)
             .bind(certs)
             .bind(private_key)
             .execute(&self.db)
@@ -540,6 +549,136 @@ impl GatewayService {
         Ok(iter)
     }
 
+    /// Returns the current certificate as a pair of the chain and private key.
+    /// If the pair doesn't exist for a specific project, create both the certificate
+    /// and the custom domain it will represent.
+    pub async fn create_custom_domain_certificate(
+        &self,
+        fqdn: &Fqdn,
+        acme_client: &AcmeClient,
+        project_name: &ProjectName,
+        creds: AccountCredentials<'_>,
+    ) -> Result<(String, String), Error> {
+        match self.project_details_for_custom_domain(fqdn).await {
+            Ok(CustomDomain {
+                certificate,
+                private_key,
+                ..
+            }) => Ok((certificate, private_key)),
+            Err(err) if err.kind() == ErrorKind::CustomDomainNotFound => {
+                let (certs, private_key) = acme_client
+                    .create_certificate(&fqdn.to_string(), ChallengeType::Http01, creds)
+                    .await?;
+                self.create_custom_domain(project_name, fqdn, &certs, &private_key)
+                    .await?;
+                Ok((certs, private_key))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn create_certificate<'a>(
+        &self,
+        acme: &AcmeClient,
+        resolver: Arc<GatewayCertResolver>,
+        creds: AccountCredentials<'a>,
+    ) -> ChainAndPrivateKey {
+        let public: FQDN = self.context().settings.fqdn.parse().unwrap();
+        let identifier = format!("*.{public}");
+
+        // Use ::Dns01 challenge because that's the only supported
+        // challenge type for wildcard domains.
+        let (chain, private_key) = acme
+            .create_certificate(&identifier, ChallengeType::Dns01, creds)
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        buf.extend(chain.as_bytes());
+        buf.extend(private_key.as_bytes());
+        let certs = ChainAndPrivateKey::parse_pem(Cursor::new(buf)).expect("Malformed PEM buffer.");
+        resolver
+            .serve_default_der(certs.clone())
+            .await
+            .expect("Failed to serve the default certs");
+
+        certs
+    }
+
+    /// Fetch the gateway certificate from the state location.
+    /// If not existent, create the gateway certificate and save it to the
+    /// gateway state.
+    pub async fn fetch_certificate(
+        &self,
+        acme: &AcmeClient,
+        resolver: Arc<GatewayCertResolver>,
+        creds: AcmeCredentials<'_>,
+    ) -> ChainAndPrivateKey {
+        let tls_path = self.state_location.join("ssl.pem");
+        match ChainAndPrivateKey::load_pem(&tls_path) {
+            Ok(valid) => valid,
+            Err(_) => {
+                warn!(
+                    "no valid certificate found at {}, creating one...",
+                    tls_path.display()
+                );
+
+                let creds = match creds {
+                    AcmeCredentials::InMemory(creds) => creds,
+                    AcmeCredentials::GatewayState => {
+                        let creds_path = self.state_location.join("acme.json");
+                        if !creds_path.exists() {
+                            panic!(
+                                "no ACME credentials found at {}, cannot continue with certificate creation",
+                                creds_path.display()
+                            );
+                        }
+
+                        let creds =
+                            std::fs::File::open(creds_path).expect("Invalid credentials path");
+                        serde_json::from_reader(&creds)
+                            .expect("Can not parse admin credentials from path")
+                    }
+                };
+
+                let certs = self.create_certificate(acme, resolver, creds).await;
+                certs.clone().save_pem(&tls_path).unwrap();
+                certs
+            }
+        }
+    }
+
+    /// Renew the gateway certificate if there less than 30 days until the current
+    /// certificate expiration.
+    pub(crate) async fn renew_certificate(
+        &self,
+        acme: &AcmeClient,
+        resolver: Arc<GatewayCertResolver>,
+        creds: AccountCredentials<'_>,
+    ) {
+        let account = AccountWrapper::from(creds).0;
+        let certs = self
+            .fetch_certificate(
+                acme,
+                resolver.clone(),
+                AcmeCredentials::InMemory(account.credentials()),
+            )
+            .await;
+        // Safe to unwrap because a 'ChainAndPrivateKey' is built from a PEM.
+        let chain_and_pk = certs.into_pem().unwrap();
+
+        let (_, x509_cert) = parse_x509_certificate(chain_and_pk.as_bytes()).unwrap();
+        let diff = x509_cert.validity().not_after.sub(ASN1Time::now()).unwrap();
+
+        if diff.whole_days() <= 30 {
+            let tls_path = self.state_location.join("ssl.pem");
+            let certs = self
+                .create_certificate(acme, resolver.clone(), account.credentials())
+                .await;
+            certs.save_pem(&tls_path).unwrap();
+        }
+    }
+
     pub fn context(&self) -> GatewayContext {
         self.provider.context()
     }
@@ -604,6 +743,7 @@ pub mod tests {
     use fqdn::FQDN;
 
     use super::*;
+
     use crate::task::{self, TaskResult};
     use crate::tests::{assert_err_kind, World};
     use crate::{Error, ErrorKind};
@@ -611,7 +751,7 @@ pub mod tests {
     #[tokio::test]
     async fn service_create_find_delete_project() -> anyhow::Result<()> {
         let world = World::new().await;
-        let svc = Arc::new(GatewayService::init(world.args(), world.pool()).await);
+        let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await);
 
         let neo: AccountName = "neo".parse().unwrap();
         let trinity: AccountName = "trinity".parse().unwrap();
@@ -727,7 +867,7 @@ pub mod tests {
     #[tokio::test]
     async fn service_create_ready_kill_restart_docker() -> anyhow::Result<()> {
         let world = World::new().await;
-        let svc = Arc::new(GatewayService::init(world.args(), world.pool()).await);
+        let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await);
 
         let neo: AccountName = "neo".parse().unwrap();
         let matrix: ProjectName = "matrix".parse().unwrap();
@@ -783,7 +923,7 @@ pub mod tests {
     #[tokio::test]
     async fn service_create_find_custom_domain() -> anyhow::Result<()> {
         let world = World::new().await;
-        let svc = Arc::new(GatewayService::init(world.args(), world.pool()).await);
+        let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await);
 
         let account: AccountName = "neo".parse().unwrap();
         let project_name: ProjectName = "matrix".parse().unwrap();
@@ -801,7 +941,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        svc.create_custom_domain(project_name.clone(), &domain, certificate, private_key)
+        svc.create_custom_domain(&project_name, &domain, certificate, private_key)
             .await
             .unwrap();
 
@@ -818,7 +958,7 @@ pub mod tests {
         let certificate = "dummy certificate update";
         let private_key = "dummy private key update";
 
-        svc.create_custom_domain(project_name.clone(), &domain, certificate, private_key)
+        svc.create_custom_domain(&project_name, &domain, certificate, private_key)
             .await
             .unwrap();
 
@@ -837,7 +977,7 @@ pub mod tests {
     #[tokio::test]
     async fn service_create_custom_domain_destroy_recreate_project() -> anyhow::Result<()> {
         let world = World::new().await;
-        let svc = Arc::new(GatewayService::init(world.args(), world.pool()).await);
+        let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await);
 
         let account: AccountName = "neo".parse().unwrap();
         let project_name: ProjectName = "matrix".parse().unwrap();
@@ -855,7 +995,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        svc.create_custom_domain(project_name.clone(), &domain, certificate, private_key)
+        svc.create_custom_domain(&project_name, &domain, certificate, private_key)
             .await
             .unwrap();
 

--- a/gateway/src/tls.rs
+++ b/gateway/src/tls.rs
@@ -18,6 +18,9 @@ use tokio::sync::RwLock;
 
 use crate::Error;
 
+/// LetsEncrypt recommends to renew a certificate when its close to 30 days validity window.
+pub const RENEWAL_VALIDITY_THRESHOLD_IN_DAYS: i64 = 30;
+
 #[derive(Clone)]
 pub struct ChainAndPrivateKey {
     chain: Vec<Certificate>,


### PR DESCRIPTION
Closes #621 .

## Description

This PR adds functionality that enables the periodical renewal of  `LetsEncrypt` certificates. These certificates have a validity window of 90 days and is recommended to be renewed 30 days before expiration. The functionality will cover renewal for:

1) certificates emitted for a custom domain project when requested through the admin gateway API `"/admin/acme/request/:project_name/:fqdn"` or through `shuttle-admin` CLI.
2) the gateway certificate, which is loaded when starting the gateway service or created based on a set of ACME credentials present on the local filesystem.

## WIP testing

1) End-to-end manual test of the certificate renewal with all shuttle components deployed locally. I have some issues with the shuttle local deployment that blocks me while testing. I need some more time to understand how to enable shuttle locally, with pebble deployed locally as CA.

2) Unit testing for the introduced business logic where it makes sense and is possible. Spent lots of time on 1) and I'll need to come back at this.

I welcome any suggestions on steps/guides/docs for how to enable the shuttle components locally to test the certificates renewal.

## Documentation

Haven't seen much documentation on how to test the admin functionality related to the certificates requesting, so I hope I'll be able to compile something worth mentioning after finishing this.

## Review wise

Besides code review, I am curious at the beginning to understand if this PR covers what's asked from #621 functionality-wise. I would be happy to follow up with adjustments code-wise if there are suggestions for improvement. Also, in parallel, I'll try to come back with information on the testing aspect.
