### PR TITLE
Fix: remove target from bin build name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,78 +388,78 @@ jobs:
 workflows:
   ci:
     jobs:
-      #  - workspace-fmt
-      #  - workspace-clippy:
-      #      name: workspace-clippy-<< matrix.framework >>
-      #      requires:
-      #        - workspace-fmt
-      #      matrix:
-      #        parameters:
-      #          framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
-      #  - check-standalone:
-      #      matrix:
-      #        parameters:
-      #          path:
-      #            - resources/aws-rds
-      #            - resources/persist
-      #            - resources/secrets
-      #            - resources/shared-db
-      #            - resources/static-folder
-      #  - service-test:
-      #      requires:
-      #        - workspace-clippy
-      #  - platform-test:
-      #      requires:
-      #        - workspace-clippy
-      #      matrix:
-      #        parameters:
-      #          crate: ["shuttle-auth", "shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
-      #  - e2e-test:
-      #      requires:
-      #        - service-test
-      #        - platform-test
-      #        - check-standalone
-      #      filters:
-      #        branches:
-      #          only: production
-      #  - build-and-push:
-      #      requires:
-      #        - e2e-test
-      #      filters:
-      #        branches:
-      #          only: production
+       - workspace-fmt
+       - workspace-clippy:
+           name: workspace-clippy-<< matrix.framework >>
+           requires:
+             - workspace-fmt
+           matrix:
+             parameters:
+               framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
+       - check-standalone:
+           matrix:
+             parameters:
+               path:
+                 - resources/aws-rds
+                 - resources/persist
+                 - resources/secrets
+                 - resources/shared-db
+                 - resources/static-folder
+       - service-test:
+           requires:
+             - workspace-clippy
+       - platform-test:
+           requires:
+             - workspace-clippy
+           matrix:
+             parameters:
+               crate: ["shuttle-auth", "shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
+       - e2e-test:
+           requires:
+             - service-test
+             - platform-test
+             - check-standalone
+           filters:
+             branches:
+               only: production
+       - build-and-push:
+           requires:
+             - e2e-test
+           filters:
+             branches:
+               only: production
        - build-binaries-linux:
            name: build-binaries-x86_64-gnu
            image: ubuntu-2204:2022.04.1
            target: x86_64-unknown-linux-gnu
            resource_class: medium
-          #  filters:
-          #    branches:
-          #      only: production
+           filters:
+             branches:
+               only: production
        - build-binaries-linux:
            name: build-binaries-x86_64-musl
            image: ubuntu-2204:2022.04.1
            target: x86_64-unknown-linux-musl
            resource_class: medium
-          #  filters:
-          #    branches:
-          #      only: production
+           filters:
+             branches:
+               only: production
        - build-binaries-linux:
            name: build-binaries-aarch64
            image: ubuntu-2004:202101-01
            target: aarch64-unknown-linux-musl
            resource_class: arm.medium
-          #  filters:
-          #    branches:
-          #      only: production
-       - build-binaries-windows
-          # filters:
-          #   branches:
-          #     only: production
-       - build-binaries-mac
-          # filters:
-          #   branches:
-          #    only: production
+           filters:
+             branches:
+               only: production
+       - build-binaries-windows:
+          filters:
+            branches:
+              only: production
+       - build-binaries-mac:
+          filters:
+            branches:
+             only: production
        - publish-github-release:
           requires:
             - build-binaries-x86_64-gnu
@@ -467,6 +467,6 @@ workflows:
             - build-binaries-aarch64
             - build-binaries-windows
             - build-binaries-mac
-          # filters:
-          #   branches:
-          #    only: production
+          filters:
+            branches:
+             only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ commands:
       - run:
           name: Set git tag in the environment
           command: |
-            echo TAG=$(git describe --tags) >> $BASH_ENV
+            echo TAG=$(git describe --tags --abbrev=0) >> $BASH_ENV
       - run:
           name: Set binary directory in the environment
           command: |
@@ -130,7 +130,7 @@ commands:
           name: Make artifact
           command: |
             mkdir $BIN_DIR
-            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> $BIN_DIR/cargo-shuttle-<< parameters.target >><< parameters.suffix >>
+            mv target/<< parameters.target >>/release/cargo-shuttle<< parameters.suffix >> $BIN_DIR/cargo-shuttle<< parameters.suffix >>
             mv LICENSE $BIN_DIR/
             mv README.md $BIN_DIR/
             mkdir -p artifacts/<< parameters.target >>
@@ -388,78 +388,78 @@ jobs:
 workflows:
   ci:
     jobs:
-       - workspace-fmt
-       - workspace-clippy:
-           name: workspace-clippy-<< matrix.framework >>
-           requires:
-             - workspace-fmt
-           matrix:
-             parameters:
-               framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
-       - check-standalone:
-           matrix:
-             parameters:
-               path:
-                 - resources/aws-rds
-                 - resources/persist
-                 - resources/secrets
-                 - resources/shared-db
-                 - resources/static-folder
-       - service-test:
-           requires:
-             - workspace-clippy
-       - platform-test:
-           requires:
-             - workspace-clippy
-           matrix:
-             parameters:
-               crate: ["shuttle-auth", "shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
-       - e2e-test:
-           requires:
-             - service-test
-             - platform-test
-             - check-standalone
-           filters:
-             branches:
-               only: production
-       - build-and-push:
-           requires:
-             - e2e-test
-           filters:
-             branches:
-               only: production
+      #  - workspace-fmt
+      #  - workspace-clippy:
+      #      name: workspace-clippy-<< matrix.framework >>
+      #      requires:
+      #        - workspace-fmt
+      #      matrix:
+      #        parameters:
+      #          framework: ["web-actix-web", "web-axum", "web-rocket", "web-poem", "web-thruster", "web-tide", "web-tower","web-warp", "web-salvo", "bot-serenity", "bot-poise"]
+      #  - check-standalone:
+      #      matrix:
+      #        parameters:
+      #          path:
+      #            - resources/aws-rds
+      #            - resources/persist
+      #            - resources/secrets
+      #            - resources/shared-db
+      #            - resources/static-folder
+      #  - service-test:
+      #      requires:
+      #        - workspace-clippy
+      #  - platform-test:
+      #      requires:
+      #        - workspace-clippy
+      #      matrix:
+      #        parameters:
+      #          crate: ["shuttle-auth", "shuttle-deployer", "cargo-shuttle", "shuttle-codegen", "shuttle-common", "shuttle-proto", "shuttle-provisioner"]
+      #  - e2e-test:
+      #      requires:
+      #        - service-test
+      #        - platform-test
+      #        - check-standalone
+      #      filters:
+      #        branches:
+      #          only: production
+      #  - build-and-push:
+      #      requires:
+      #        - e2e-test
+      #      filters:
+      #        branches:
+      #          only: production
        - build-binaries-linux:
            name: build-binaries-x86_64-gnu
            image: ubuntu-2204:2022.04.1
            target: x86_64-unknown-linux-gnu
            resource_class: medium
-           filters:
-             branches:
-               only: production
+          #  filters:
+          #    branches:
+          #      only: production
        - build-binaries-linux:
            name: build-binaries-x86_64-musl
            image: ubuntu-2204:2022.04.1
            target: x86_64-unknown-linux-musl
            resource_class: medium
-           filters:
-             branches:
-               only: production
+          #  filters:
+          #    branches:
+          #      only: production
        - build-binaries-linux:
            name: build-binaries-aarch64
            image: ubuntu-2004:202101-01
            target: aarch64-unknown-linux-musl
            resource_class: arm.medium
-           filters:
-             branches:
-               only: production
-       - build-binaries-windows:
-          filters:
-            branches:
-              only: production
-       - build-binaries-mac:
-          filters:
-            branches:
-             only: production
+          #  filters:
+          #    branches:
+          #      only: production
+       - build-binaries-windows
+          # filters:
+          #   branches:
+          #     only: production
+       - build-binaries-mac
+          # filters:
+          #   branches:
+          #    only: production
        - publish-github-release:
           requires:
             - build-binaries-x86_64-gnu
@@ -467,6 +467,6 @@ workflows:
             - build-binaries-aarch64
             - build-binaries-windows
             - build-binaries-mac
-          filters:
-            branches:
-             only: production
+          # filters:
+          #   branches:
+          #    only: production


### PR DESCRIPTION
Remove the target from the binary name to be compatible with binstall, and also switch to using only the short-form git tag.

See first commit's workflow run for successful run, and see the new draft release in releases for a preview of the binaries.