### PR TITLE
Feat: unbox the ClaimService and Scoped futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6088,6 +6088,7 @@ dependencies = [
  "opentelemetry-datadog",
  "opentelemetry-http",
  "pem",
+ "pin-project",
  "portpicker",
  "rand 0.8.5",
  "rcgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5994,6 +5994,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
+ "pin-project",
  "reqwest",
  "ring",
  "rustrict",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ once_cell = "1.16.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-datadog = { version = "0.6.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.7.0"
+pin-project = "1.0.12"
 rand = "0.8.5"
 ring = "0.16.20"
 serde = "1.0.148"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,6 +23,7 @@ jsonwebtoken = { workspace = true, optional = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
+pin-project = "1.0.12"
 reqwest = { version = "0.11.13", optional = true }
 rustrict = "0.5.5"
 serde = { workspace = true, features = ["derive"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,7 @@ jsonwebtoken = { workspace = true, optional = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
-pin-project = "1.0.12"
+pin-project = { workspace = true } 
 reqwest = { version = "0.11.13", optional = true }
 rustrict = "0.5.5"
 serde = { workspace = true, features = ["derive"] }

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -585,9 +585,9 @@ where
                 },
             }
         } else {
-            return ScopedFuture {
+            ScopedFuture {
                 state: ResponseState::Forbidden,
-            };
+            }
         }
     }
 }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -28,6 +28,7 @@ opentelemetry = { workspace = true }
 opentelemetry-datadog = { workspace = true }
 opentelemetry-http = { workspace = true }
 pem = "1.1.0"
+pin-project = { workspace = true }
 rand = { workspace = true }
 rcgen = "0.10.0"
 rustls = "0.20.7"


### PR DESCRIPTION
We can unbox the future type in tower layers if we implement future ourselves. For how I landed on the implementation for ClaimService, see: https://github.com/tower-rs/tower/blob/master/guides/building-a-middleware-from-scratch.md

For what inspired the enum solution for the Scoped future, see: https://github.com/tower-rs/tower/blob/master/tower/src/load_shed/future.rs#L13-L63