### PR TITLE
feat: bump panamax, remove docker stats receiver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ POSTGRES_EXTRA_PATH?=./extras/postgres
 POSTGRES_TAG?=14
 
 PANAMAX_EXTRA_PATH?=./extras/panamax
-PANAMAX_TAG?=1.0.6
+PANAMAX_TAG?=1.0.12
 
 OTEL_EXTRA_PATH?=./extras/otel
 OTEL_TAG?=0.72.0

--- a/extras/otel/otel-collector-config.yaml
+++ b/extras/otel/otel-collector-config.yaml
@@ -65,6 +65,6 @@ service:
       processors: [attributes, batch]
       exporters: [datadog]
     metrics:
-      receivers: [hostmetrics, prometheus/otel, docker_stats, otlp]
+      receivers: [hostmetrics, prometheus/otel, otlp]
       processors: [batch]
       exporters: [datadog]


### PR DESCRIPTION
We applied these changes after the release, they are live on production.