### PR TITLE
feat: add bug report and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,68 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of `cargo-shuttle` are you running (`cargo shuttle --version`)?
+      placeholder: "v0.11.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Which operating systems are you seeing the problem on?
+      multiple: true
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+  - type: dropdown
+    id: architecture
+    attributes:
+      label: Which CPU architectures are you seeing the problem on?
+      multiple: true
+      options:
+        - x86_64
+        - ARM64
+        - Other
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: sh
+  - type: checkboxes
+    id: duplicate
+    attributes:
+      label: Duplicate declaration
+      description: Please confirm that you are not creating a duplicate issue.
+      options:
+        - label: I have searched the issues and there are none like this.
+          required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/shuttle-hq/shuttle/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow shuttle's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -58,11 +58,4 @@ body:
       options:
         - label: I have searched the issues and there are none like this.
           required: true
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/shuttle-hq/shuttle/blob/main/CODE_OF_CONDUCT.md)
-      options:
-        - label: I agree to follow shuttle's Code of Conduct
-          required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discord
+    url: https://discord.gg/shuttle
+    about: Feel free to reach out on our Discord should you have any questions!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+# Description of change
+
+Please write a summary of your changes and why you made them. 
+
+Be sure to reference any related issues by adding `closes issue #`.
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes.
+
+## Checklist:
+
+- [ ] I have followed the [commit guidelines](https://github.com/shuttle-hq/shuttle/blob/main/CONTRIBUTING.md#committing).
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,15 +4,6 @@ Please write a summary of your changes and why you made them.
 
 Be sure to reference any related issues by adding `closes issue #`.
 
-# How Has This Been Tested?
+# How Has This Been Tested (if applicable)?
 
 Please describe the tests that you ran to verify your changes.
-
-## Checklist:
-
-- [ ] I have followed the [commit guidelines](https://github.com/shuttle-hq/shuttle/blob/main/CONTRIBUTING.md#committing).
-- [ ] I have performed a self-review of my code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
This adds a bug report template that users can choose when opening an issue, that requires the user to include some information that is usually needed. To see how it looks rendered, click view file. Or see this link: https://github.com/shuttle-hq/shuttle/blob/f0a5066244b414cec93dabbacf2a4ab0c389dead/.github/ISSUE_TEMPLATE/BUG-REPORT.yml

The user will be able to choose the bug report template or a blank issue (when we add more templates we can disable blank templates), or they can choose to follow a link to our discord.

It also adds a PR template to encourage contributors to self-review and add docs/tests.

Closes #602 