### PR TITLE
refactor: unboxing AdminSecret

### DIFF
--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -482,7 +482,7 @@ where
 
         let future = self.inner.call(req);
 
-        ResponseFuture { future }
+        ResponseFuture(future)
     }
 }
 

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -1,11 +1,4 @@
-use std::{
-    convert::Infallible,
-    future::Future,
-    ops::Add,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
+use std::{convert::Infallible, future::Future, ops::Add, pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -17,7 +10,6 @@ use hyper::{body, Body, Client};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header as JwtHeader, Validation};
 use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
-use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tower::{Layer, Service};
@@ -26,9 +18,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use super::{
     cache::{CacheManagement, CacheManager},
-    future::ResponseFuture,
+    future::{ResponseFuture, StatusCodeFuture},
     headers::XShuttleAdminSecret,
-    StatusCodeFuture,
 };
 
 pub const EXP_MINUTES: i64 = 5;

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -28,6 +28,7 @@ use super::{
     cache::{CacheManagement, CacheManager},
     future::ResponseFuture,
     headers::XShuttleAdminSecret,
+    ResponseState, StatusCodeFuture,
 };
 
 pub const EXP_MINUTES: i64 = 5;
@@ -528,51 +529,6 @@ impl<S> Layer<S> for ScopedLayer {
 pub struct Scoped<S> {
     inner: S,
     required: Vec<Scope>,
-}
-
-/// Future for layers that might return a different status code
-#[pin_project]
-pub struct StatusCodeFuture<F> {
-    #[pin]
-    state: ResponseState<F>,
-}
-
-#[pin_project(project = ResponseStateProj)]
-pub enum ResponseState<F> {
-    Called {
-        #[pin]
-        inner: F,
-    },
-    Unauthorized,
-    Forbidden,
-    BadRequest,
-}
-
-impl<F, Error> Future for StatusCodeFuture<F>
-where
-    F: Future<Output = Result<axum::response::Response, Error>>,
-{
-    type Output = Result<axum::response::Response, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        match this.state.project() {
-            ResponseStateProj::Called { inner } => inner.poll(cx),
-            ResponseStateProj::Unauthorized => Poll::Ready(Ok(Response::builder()
-                .status(StatusCode::UNAUTHORIZED)
-                .body(Default::default())
-                .unwrap())),
-            ResponseStateProj::Forbidden => Poll::Ready(Ok(Response::builder()
-                .status(StatusCode::FORBIDDEN)
-                .body(Default::default())
-                .unwrap())),
-            ResponseStateProj::BadRequest => Poll::Ready(Ok(Response::builder()
-                .status(StatusCode::BAD_REQUEST)
-                .body(Default::default())
-                .unwrap())),
-        }
-    }
 }
 
 impl<S> Service<Request<Body>> for Scoped<S>

--- a/common/src/backends/future.rs
+++ b/common/src/backends/future.rs
@@ -4,6 +4,8 @@ use std::{
     task::{Context, Poll},
 };
 
+use axum::response::Response;
+use http::StatusCode;
 use pin_project::pin_project;
 
 #[pin_project]
@@ -22,5 +24,34 @@ where
         let this = self.project();
 
         this.future.poll(cx)
+    }
+}
+
+/// Future for layers that might return a different status code
+#[pin_project(project = StatusCodeProj)]
+pub enum StatusCodeFuture<F> {
+    // A future that should be polled
+    Poll(#[pin] F),
+
+    // A status code to return
+    Code(StatusCode),
+}
+
+impl<F, Error> Future for StatusCodeFuture<F>
+where
+    F: Future<Output = Result<axum::response::Response, Error>>,
+{
+    type Output = Result<Response, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this {
+            StatusCodeProj::Poll(inner) => inner.poll(cx),
+            StatusCodeProj::Code(status_code) => Poll::Ready(Ok(Response::builder()
+                .status(*status_code)
+                .body(Default::default())
+                .unwrap())),
+        }
     }
 }

--- a/common/src/backends/future.rs
+++ b/common/src/backends/future.rs
@@ -8,11 +8,9 @@ use axum::response::Response;
 use http::StatusCode;
 use pin_project::pin_project;
 
+// Future for layers that just return the inner response
 #[pin_project]
-pub struct ResponseFuture<F> {
-    #[pin]
-    pub future: F,
-}
+pub struct ResponseFuture<F>(#[pin] pub F);
 
 impl<F, Response, Error> Future for ResponseFuture<F>
 where
@@ -23,7 +21,7 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 
-        this.future.poll(cx)
+        this.0.poll(cx)
     }
 }
 

--- a/common/src/backends/mod.rs
+++ b/common/src/backends/mod.rs
@@ -1,6 +1,61 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use axum::response::Response;
+use http::StatusCode;
+use pin_project::pin_project;
+
 pub mod auth;
 pub mod cache;
 pub mod future;
 pub mod headers;
 pub mod metrics;
 pub mod tracing;
+
+/// Future for layers that might return a different status code
+#[pin_project]
+pub struct StatusCodeFuture<F> {
+    #[pin]
+    state: ResponseState<F>,
+}
+
+#[pin_project(project = ResponseStateProj)]
+pub enum ResponseState<F> {
+    Called {
+        #[pin]
+        inner: F,
+    },
+    Unauthorized,
+    Forbidden,
+    BadRequest,
+}
+
+impl<F, Error> Future for StatusCodeFuture<F>
+where
+    F: Future<Output = Result<axum::response::Response, Error>>,
+{
+    type Output = Result<Response, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        match this.state.project() {
+            ResponseStateProj::Called { inner } => inner.poll(cx),
+            ResponseStateProj::Unauthorized => Poll::Ready(Ok(Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(Default::default())
+                .unwrap())),
+            ResponseStateProj::Forbidden => Poll::Ready(Ok(Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body(Default::default())
+                .unwrap())),
+            ResponseStateProj::BadRequest => Poll::Ready(Ok(Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Default::default())
+                .unwrap())),
+        }
+    }
+}

--- a/common/src/backends/mod.rs
+++ b/common/src/backends/mod.rs
@@ -1,45 +1,6 @@
-use std::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
-
-use axum::response::Response;
-use http::StatusCode;
-use pin_project::pin_project;
-
 pub mod auth;
 pub mod cache;
-pub mod future;
+mod future;
 pub mod headers;
 pub mod metrics;
 pub mod tracing;
-
-/// Future for layers that might return a different status code
-#[pin_project(project = StatusCodeProj)]
-pub enum StatusCodeFuture<F> {
-    // A future that should be polled
-    Poll(#[pin] F),
-
-    // A status code to return
-    Code(StatusCode),
-}
-
-impl<F, Error> Future for StatusCodeFuture<F>
-where
-    F: Future<Output = Result<axum::response::Response, Error>>,
-{
-    type Output = Result<Response, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        match this {
-            StatusCodeProj::Poll(inner) => inner.poll(cx),
-            StatusCodeProj::Code(status_code) => Poll::Ready(Ok(Response::builder()
-                .status(*status_code)
-                .body(Default::default())
-                .unwrap())),
-        }
-    }
-}

--- a/common/src/backends/tracing.rs
+++ b/common/src/backends/tracing.rs
@@ -182,6 +182,6 @@ where
 
         let future = self.inner.call(req);
 
-        ResponseFuture { future }
+        ResponseFuture(future)
     }
 }


### PR DESCRIPTION
Removes the `Box::pin` from the AdminSecret. Also allows more reuse of the future.