### PR TITLE
bug: ws not getting logs from broadcast channel

### DIFF
--- a/deployer/src/handlers/error.rs
+++ b/deployer/src/handlers/error.rs
@@ -6,6 +6,7 @@ use axum::Json;
 
 use serde::{ser::SerializeMap, Serialize};
 use shuttle_common::models::error::ApiError;
+use tracing::error;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -40,6 +41,8 @@ impl Serialize for Error {
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
+        error!(error = &self as &dyn std::error::Error, "request error");
+
         let code = match self {
             Error::NotFound => StatusCode::NOT_FOUND,
             _ => StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
This fixes the WebSocket connection returning early which made it seem like deployments are done, when in reality they were not.

We have no idea why the sqlite setting is affecting the broadcast channel however. I suspect it is causing some panic inside the thread, which is in persistence, that would have send the log to the broadcast channel.