### PR TITLE
Fix/move docker profiles to dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ test:
 	cd e2e; POSTGRES_PASSWORD=$(POSTGRES_PASSWORD) APPS_FQDN=$(APPS_FQDN) cargo test $(CARGO_TEST_FLAGS) -- --nocapture
 
 # Start the containers locally. This does not start panamax by default,
-# to start panamax locally run this command with the COMPOSE_PROFILES=panamax 
-# environment variable.
+# to start panamax locally run this command with an override for the profiles:
+# `make COMPOSE_PROFILES=panamax up`
 up: docker-compose.rendered.yml
 	CONTAINER_REGISTRY=$(CONTAINER_REGISTRY) $(DOCKER_COMPOSE) -f $< -p $(STACK) up -d $(DOCKER_COMPOSE_FLAGS)
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,3 +23,9 @@ services:
         exec /usr/local/bin/service "$${@:0}"
     ports:
       - 5000:8000
+  panamax:
+    profiles:
+      - panamax
+  deck-chores:
+    profiles:
+      - panamax

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,8 +173,6 @@ services:
         constraints:
           - node.hostname==controller
   panamax:
-    profiles:
-      - panamax
     image: "${CONTAINER_REGISTRY}/panamax:${PANAMAX_TAG}"
     restart: always
     networks:
@@ -191,8 +189,6 @@ services:
         constraints:
           - node.hostname==controller
   deck-chores:
-    profiles:
-      - panamax
     image: funkyfuture/deck-chores:1
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Description of change

Docker swarm does not support docker profiles, so to be able to run the deploy command we had to remove these from `docker-compose.yml`. We fix this by moving them into `docker-compose.dev.yml` so they are only applied to the local runs.

## How Has This Been Tested (if applicable)?

Verified that the local behavior is the same, and we deployed yesterday after removing the profiles from the main compose file.
