### PR TITLE
feat: remove box self from services, remove syncwrapper from axum service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6469,7 +6469,6 @@ dependencies = [
  "shuttle-codegen",
  "shuttle-common",
  "sqlx",
- "sync_wrapper",
  "thiserror",
  "thruster",
  "tide",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -31,7 +31,6 @@ salvo = { version = "0.37.5", optional = true }
 serde_json = { workspace = true }
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"], optional = true }
 poise = { version = "0.5.2", optional = true }
-sync_wrapper = { version = "0.1.1", optional = true }
 thiserror = { workspace = true }
 thruster = { version = "1.3.0", optional = true }
 tide = { version = "0.16.0", optional = true }
@@ -70,7 +69,7 @@ codegen = ["shuttle-codegen/frameworks"]
 loader = ["cargo", "libloading"]
 
 web-actix-web = ["actix-web", "num_cpus"]
-web-axum = ["axum", "sync_wrapper"]
+web-axum = ["axum"]
 web-rocket = ["rocket"]
 web-thruster = ["thruster"]
 web-tide = ["tide", "async-std"]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -540,18 +540,19 @@ pub type ShuttleWarp<T> = Result<warp::filters::BoxedFilter<T>, Error>;
 
 #[cfg(feature = "web-axum")]
 #[async_trait]
-impl Service for sync_wrapper::SyncWrapper<axum::Router> {
+impl Service for axum::Router {
     async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
-        let router = self.into_inner();
-
         axum::Server::bind(&addr)
-            .serve(router.into_make_service())
+            .serve(self.into_make_service())
             .await
             .map_err(error::CustomError::new)?;
 
         Ok(())
     }
 }
+
+#[cfg(feature = "web-axum")]
+pub type ShuttleAxum = Result<axum::Router, Error>;
 
 #[cfg(feature = "web-actix-web")]
 #[async_trait]
@@ -574,9 +575,6 @@ where
 }
 #[cfg(feature = "web-actix-web")]
 pub type ShuttleActixWeb<F> = Result<F, Error>;
-
-#[cfg(feature = "web-axum")]
-pub type ShuttleAxum = Result<sync_wrapper::SyncWrapper<axum::Router>, Error>;
 
 #[cfg(feature = "web-salvo")]
 #[async_trait]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -509,7 +509,7 @@ impl<T> Service for T
 where
     T: poem::Endpoint + Sync + Send + 'static,
 {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         poem::Server::new(poem::listener::TcpListener::bind(addr))
             .run(self)
             .await
@@ -529,7 +529,7 @@ where
     T: Send + Sync + Clone + 'static + warp::Filter,
     T::Extract: warp::reply::Reply,
 {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         warp::serve(*self).run(addr).await;
         Ok(())
     }
@@ -541,7 +541,7 @@ pub type ShuttleWarp<T> = Result<warp::filters::BoxedFilter<T>, Error>;
 #[cfg(feature = "web-axum")]
 #[async_trait]
 impl Service for sync_wrapper::SyncWrapper<axum::Router> {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         let router = self.into_inner();
 
         axum::Server::bind(&addr)
@@ -559,7 +559,7 @@ impl<F> Service for F
 where
     F: FnOnce(&mut actix_web::web::ServiceConfig) + Sync + Send + Clone + 'static,
 {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), Error> {
         // Start a worker for each cpu, but no more than 4.
         let worker_count = num_cpus::get().max(4);
 
@@ -581,7 +581,7 @@ pub type ShuttleAxum = Result<sync_wrapper::SyncWrapper<axum::Router>, Error>;
 #[cfg(feature = "web-salvo")]
 #[async_trait]
 impl Service for salvo::Router {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         salvo::Server::new(salvo::listener::TcpListener::bind(addr))
             .serve(self)
             .await;
@@ -599,7 +599,7 @@ impl<T> Service for T
 where
     T: thruster::ThrusterServer + Sync + Send + 'static,
 {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         self.build(&addr.ip().to_string(), addr.port()).await;
 
         Ok(())
@@ -615,7 +615,7 @@ impl<T> Service for tide::Server<T>
 where
     T: Clone + Send + Sync + 'static,
 {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         self.listen(addr).await.map_err(error::CustomError::new)?;
 
         Ok(())
@@ -637,7 +637,7 @@ where
     T::Error: std::error::Error + Send + Sync,
     T::Future: std::future::Future + Send + Sync,
 {
-    async fn bind(mut self: Box<Self>, addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, addr: SocketAddr) -> Result<(), error::Error> {
         let shared = tower::make::Shared::new(self);
         hyper::Server::bind(&addr)
             .serve(shared)
@@ -651,7 +651,7 @@ where
 #[cfg(feature = "bot-serenity")]
 #[async_trait]
 impl Service for serenity::Client {
-    async fn bind(mut self: Box<Self>, _addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, _addr: SocketAddr) -> Result<(), error::Error> {
         self.start().await.map_err(error::CustomError::new)?;
 
         Ok(())
@@ -668,7 +668,7 @@ where
     T: std::marker::Send + std::marker::Sync + 'static,
     E: std::marker::Send + std::marker::Sync + 'static,
 {
-    async fn bind(mut self: Box<Self>, _addr: SocketAddr) -> Result<(), error::Error> {
+    async fn bind(mut self, _addr: SocketAddr) -> Result<(), error::Error> {
         self.start().await.map_err(error::CustomError::new)?;
 
         Ok(())


### PR DESCRIPTION
## Description of change

Removes box self from services and syncwrapper from axum service since they are no longer needed.

This PR is based on https://github.com/shuttle-hq/shuttle/pull/675

## How Has This Been Tested (if applicable)?

Please describe the tests that you ran to verify your changes.
