### PR TITLE
Feature/eng 477 make wasm dependencies optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
       - run: |
           cargo clippy --tests \
                        --all-targets \
-                       --features="codegen,loader,<< parameters.framework >>" \
+                       --features="codegen,builder,<< parameters.framework >>" \
                        --no-deps -- \
                        --D warnings \
                        -A clippy::let-unit-value \
@@ -210,10 +210,10 @@ jobs:
       - restore-cargo-cache
       - run:
           name: Run unit tests
-          command: cargo test --package shuttle-service --features="codegen,loader" --lib -- --nocapture
+          command: cargo test --package shuttle-service --features="codegen,builder" --lib -- --nocapture
       - run:
           name: Run integration tests
-          command: cargo test --package shuttle-service --features="codegen,loader" --test '*' -- --nocapture
+          command: cargo test --package shuttle-service --features="codegen,builder" --test '*' -- --nocapture
       - save-cargo-cache
   platform-test:
     parameters:

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -28,7 +28,7 @@ uuid = { workspace = true, features = ["v4"] }
 # TODO: bump these crates to 6.0 when we bump rust to >= 1.66
 cap-std = { version = "1.0.2", optional = true }
 futures = { version = "0.3.25", optional = true }
-hyper = { version = "0.14.23", features = ["server"], optional = true }
+hyper = { version = "0.14.23", optional = true }
 rmp-serde = { version = "1.1.1", optional = true }
 wasi-common = { version = "4.0.0", optional = true }
 wasmtime = { version = "4.0.0", optional = true }
@@ -54,7 +54,7 @@ features = ["builder", "web-rocket"] # TODO: remove web-rocket
 next = [
     "cap-std", 
     "futures", 
-    "hyper", 
+    "hyper/server", 
     "rmp-serde", 
     "futures", 
     "wasi-common", 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,7 +41,7 @@ rocket = "0.5.0-rc.2"
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["wasm", "service"]
+features = ["service"]
 
 [dependencies.shuttle-proto]
 workspace = true
@@ -59,5 +59,6 @@ next = [
     "futures", 
     "wasi-common", 
     "wasmtime", 
-    "wasmtime-wasi"
+    "wasmtime-wasi",
+    "shuttle-common/wasm"
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,14 +11,12 @@ name = "rocket"
 
 [[bin]]
 name = "next"
+required-features = ["next"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-cap-std = "1.0.2"
 clap ={ version = "4.0.18", features = ["derive"] }
-hyper = { version = "0.14.23", features = ["server"] }
-rmp-serde = { version = "1.1.1" }
 thiserror = { workspace = true }
 tokio = { version = "1.22.0", features = ["full"] }
 tokio-stream = "0.1.11"
@@ -26,11 +24,15 @@ tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 uuid = { workspace = true, features = ["v4"] }
+
 # TODO: bump these crates to 6.0 when we bump rust to >= 1.66
-wasi-common = "4.0.0"
-wasmtime = "4.0.0"
-wasmtime-wasi = "4.0.0"
-futures = "0.3.25"
+cap-std = { version = "1.0.2", optional = true }
+futures = { version = "0.3.25", optional = true }
+hyper = { version = "0.14.23", features = ["server"], optional = true }
+rmp-serde = { version = "1.1.1", optional = true }
+wasi-common = { version = "4.0.0", optional = true }
+wasmtime = { version = "4.0.0", optional = true }
+wasmtime-wasi = { version = "4.0.0", optional = true }
 
 # For rocket.rs
 # TODO: remove
@@ -47,3 +49,15 @@ workspace = true
 [dependencies.shuttle-service]
 workspace = true
 features = ["builder", "web-rocket"] # TODO: remove web-rocket
+
+[features]
+next = [
+    "cap-std", 
+    "futures", 
+    "hyper", 
+    "rmp-serde", 
+    "futures", 
+    "wasi-common", 
+    "wasmtime", 
+    "wasmtime-wasi"
+]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -21,7 +21,7 @@ make axum
 Run the test:
 
 ```bash
-cargo test axum -- --nocapture
+cargo test --features next axum -- --nocapture
 
 # or, run tests
 make test
@@ -30,7 +30,7 @@ make test
 Load and run:
 
 ```bash
-cargo run --bin next -- --port 6001
+cargo run --features next --bin next -- --port 6001
 ```
 
 In another terminal:

--- a/runtime/src/legacy/mod.rs
+++ b/runtime/src/legacy/mod.rs
@@ -11,7 +11,7 @@ use std::{
 use anyhow::Context;
 use async_trait::async_trait;
 use clap::Parser;
-use futures::Future;
+use core::future::Future;
 use shuttle_common::{
     storage_manager::{StorageManager, WorkingDirStorageManager},
     LogItem,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,8 +1,9 @@
 mod legacy;
+#[cfg(feature = "next")]
 mod next;
 mod provisioner_factory;
 
 pub use legacy::{start, Legacy};
-pub use next::AxumWasm;
-pub use next::NextArgs;
+#[cfg(feature = "next")]
+pub use next::{AxumWasm, NextArgs};
 pub use provisioner_factory::ProvisionerFactory;


### PR DESCRIPTION
## Description of change

The WASI dependencies for shuttle-next are quite heavy. This PR makes them optional, and the next-runtime bin dependent on the `next` feature.

## How Has This Been Tested (if applicable)?

Ran legacy and next, they still work as expected, but legacy has fewer dependencies.
