### PR TITLE
bug: idle static folder

### DIFF
--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["shuttle-service", "static-folder"]
 async-trait = "0.1.56"
 shuttle-service = { path = "../../service", version = "0.11.0", default-features = false }
 tokio = { version = "1.19.2", features = ["rt"] }
+tracing = "0.1.37"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["shuttle-service", "static-folder"]
 
 [dependencies]
 async-trait = "0.1.56"
+fs_extra = "1.3.0"
 shuttle-service = { path = "../../service", version = "0.11.0", default-features = false }
 tokio = { version = "1.19.2", features = ["rt"] }
 tracing = "0.1.37"

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -4,7 +4,6 @@ use shuttle_service::{
     error::{CustomError, Error as ShuttleError},
     Factory, ResourceBuilder,
 };
-use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use tokio::runtime::Runtime;
 use tracing::{error, trace};
@@ -67,15 +66,13 @@ impl<'a> ResourceBuilder<PathBuf> for StaticFolder<'a> {
             }
         }
 
-        let output_dir = factory.get_storage_path()?.join(self.folder);
+        let output_dir = factory.get_storage_path()?;
 
         trace!(output_directory = ?output_dir, "got output directory");
 
-        create_dir_all(&output_dir)?;
-
         let copy_options = CopyOptions::new().overwrite(true);
         match copy(&input_dir, &output_dir, &copy_options) {
-            Ok(_) => Ok(output_dir),
+            Ok(_) => Ok(output_dir.join(self.folder)),
             Err(error) => {
                 error!(
                     error = &error as &dyn std::error::Error,


### PR DESCRIPTION
## Description of change

This fixes static folder projects not starting up correctly after they went into idle mode. This would happen because the static folder resource would move the folder and therefore could not move it a second time when an idle project is woken up.

This change causes the static folder resource to rather copy the folder.

Closes issue #689 

## How Has This Been Tested (if applicable)?
Locally, with a full running setup and the axum websocket example
