### PR TITLE
chore: v0.11.3

### DIFF
--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-static-folder"
-version = "0.11.0"
+version = "0.11.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to get a static folder at runtime on shuttle"


### PR DESCRIPTION
## Description of change

We are bumping static folder and publishing a release of that, as well as redeploying gateway and deployer so the gateway uses the new deployer, the new deployer is necessary since it uses patched local versions of the resource libraries.
