### PR TITLE
fix: Respect `Cargo.lock` when building containers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,7 @@ WORKDIR /build
 FROM shuttle-build as cache
 WORKDIR /src
 COPY . .
-RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "README.md" -or -name "*.sql" \) -type f -exec install -D \{\} /build/\{\} \;
+RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" \) -type f -exec install -D \{\} /build/\{\} \;
 
 FROM shuttle-build AS planner
 COPY --from=cache /build .


### PR DESCRIPTION
Building the shuttle containers was failing during the `cargo chef cook` step because of a cyclic dependency introduced by an upstream crate. This did not happen when building outside of a container, because the versions pinned by `Cargo.lock` did not contain any cycles.

See https://github.com/tkaitchuck/aHash/issues/95