### PR TITLE
Feature: eng 484 update init with codegen changes

### DIFF
--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -492,15 +492,6 @@ impl ShuttleInit for ShuttleInitSerenity {
         );
 
         set_key_value_dependency_version(
-            "shuttle-serenity",
-            dependencies,
-            manifest_path,
-            url,
-            true,
-            get_dependency_version_fn,
-        );
-
-        set_key_value_dependency_version(
             "shuttle-runtime",
             dependencies,
             manifest_path,
@@ -515,6 +506,15 @@ impl ShuttleInit for ShuttleInitSerenity {
             manifest_path,
             url,
             false,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-serenity",
+            dependencies,
+            manifest_path,
+            url,
+            true,
             get_dependency_version_fn,
         );
 
@@ -881,7 +881,7 @@ impl ShuttleInit for ShuttleInitThruster {
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
         set_key_value_dependency_version(
-            "shuttle-thruster",
+            "shuttle-runtime",
             dependencies,
             manifest_path,
             url,
@@ -890,7 +890,7 @@ impl ShuttleInit for ShuttleInitThruster {
         );
 
         set_key_value_dependency_version(
-            "shuttle-runtime",
+            "shuttle-thruster",
             dependencies,
             manifest_path,
             url,
@@ -1135,12 +1135,12 @@ mod shuttle_init_tests {
         set_inline_table_dependency_features(
             "shuttle-service",
             dependencies,
-            vec!["test-feature".to_string()],
+            vec!["builder".to_string()],
         );
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { features = ["test-feature"] }
+            shuttle-service = { features = ["builder"] }
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1200,15 +1200,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitActixWeb.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1218,8 +1209,10 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-actix-web"] }
             actix-web = "1.0"
+            shuttle-actix-web = "1.0"
+            shuttle-runtime = "1.0"
+            tokio = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1232,15 +1225,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitAxum.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1250,9 +1234,10 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-axum"] }
             axum = "1.0"
-            sync_wrapper = "1.0"
+            shuttle-axum = "1.0"
+            shuttle-runtime = "1.0"
+            tokio = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1265,15 +1250,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitRocket.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1283,8 +1259,10 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-rocket"] }
             rocket = "1.0"
+            shuttle-rocket = "1.0"
+            shuttle-runtime = "1.0"
+            tokio = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1297,15 +1275,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitTide.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1315,7 +1284,9 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-tide"] }
+            shuttle-tide = "1.0"
+            shuttle-runtime = "1.0"
+            tokio = "1.0"
             tide = "1.0"
         "#};
 
@@ -1329,15 +1300,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitTower.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1347,9 +1309,11 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-tower"] }
-            tower = { version = "1.0", features = ["full"] }
             hyper = { version = "1.0", features = ["full"] }
+            shuttle-runtime = "1.0"
+            shuttle-tower = "1.0"
+            tokio = "1.0"
+            tower = { version = "1.0", features = ["full"] }
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1362,15 +1326,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitPoem.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1380,8 +1335,10 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-poem"] }
             poem = "1.0"
+            shuttle-poem = "1.0"
+            shuttle-runtime = "1.0"
+            tokio = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1394,15 +1351,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitSalvo.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1412,8 +1360,10 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-salvo"] }
             salvo = "1.0"
+            shuttle-salvo = "1.0"
+            shuttle-runtime = "1.0"
+            tokio = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1426,15 +1376,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitSerenity.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1444,10 +1385,12 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["bot-serenity"] }
             anyhow = "1.0"
             serenity = { version = "1.0", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
+            shuttle-runtime = "1.0"
             shuttle-secrets = "1.0"
+            shuttle-serenity = "1.0"
+            tokio = "1.0"
             tracing = "1.0"
         "#};
 
@@ -1461,15 +1404,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitPoise.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1478,12 +1412,14 @@ mod shuttle_init_tests {
         );
 
         let expected = indoc! {r#"
-			[dependencies]
-			shuttle-service = { version = "1.0", features = ["bot-poise"] }
-			anyhow = "1.0"
-			poise = "1.0"
-			shuttle-secrets = "1.0"
-			tracing = "1.0"
+            [dependencies]
+            anyhow = "1.0"
+            poise = "1.0"
+            shuttle-poise = "1.0"
+            shuttle-runtime = "1.0"
+            shuttle-secrets = "1.0"
+            tokio = "1.0"
+            tracing = "1.0"
 		"#};
 
         assert_eq!(cargo_toml.to_string(), expected);
@@ -1496,15 +1432,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitWarp.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1514,7 +1441,9 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-warp"] }
+            shuttle-runtime = "1.0"
+            shuttle-warp = "1.0"
+            tokio = "1.0"
             warp = "1.0"
         "#};
 
@@ -1528,15 +1457,6 @@ mod shuttle_init_tests {
         let manifest_path = PathBuf::new();
         let url = Url::parse("https://shuttle.rs").unwrap();
 
-        set_inline_table_dependency_version(
-            "shuttle-service",
-            dependencies,
-            &manifest_path,
-            &url,
-            false,
-            mock_get_latest_dependency_version,
-        );
-
         ShuttleInitThruster.set_cargo_dependencies(
             dependencies,
             &manifest_path,
@@ -1546,13 +1466,17 @@ mod shuttle_init_tests {
 
         let expected = indoc! {r#"
             [dependencies]
-            shuttle-service = { version = "1.0", features = ["web-thruster"] }
+            shuttle-runtime = "1.0"
+            shuttle-thruster = "1.0"
             thruster = { version = "1.0", features = ["hyper_server"] }
+            tokio = "1.0"
         "#};
 
         assert_eq!(cargo_toml.to_string(), expected);
     }
 
+    // TODO: unignore this test when we publish shuttle-rocket
+    #[ignore]
     #[test]
     /// Makes sure that Rocket uses allow_prerelease flag when fetching the latest version
     fn test_get_latest_dependency_version_rocket() {

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -78,29 +78,52 @@ impl ShuttleInit for ShuttleInitActixWeb {
             get_dependency_version_fn,
         );
 
-        set_inline_table_dependency_features(
-            "shuttle-service",
+        set_key_value_dependency_version(
+            "shuttle-actix-web",
             dependencies,
-            vec!["web-actix-web".to_string()],
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
         );
     }
 
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
         use actix_web::{get, web::ServiceConfig};
-        use shuttle_service::ShuttleActixWeb;
+        use shuttle_actix_web::ShuttleActixWeb;
 
         #[get("/hello")]
         async fn hello_world() -> &'static str {
             "Hello World!"
         }
 
-        #[shuttle_service::main]
+        #[shuttle_runtime::main]
         async fn actix_web(
-        ) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Sync + Send + Clone + 'static> {
-            Ok(move |cfg: &mut ServiceConfig| {
+        ) -> ShuttleActixWeb<impl FnOnce(&mut ServiceConfig) + Send + Clone + 'static> {
+            let config = move |cfg: &mut ServiceConfig| {
                 cfg.service(hello_world);
-            })
+            };
+
+            Ok(config.into())
         }"#}
     }
 }
@@ -124,17 +147,30 @@ impl ShuttleInit for ShuttleInitAxum {
             get_dependency_version_fn,
         );
 
-        set_inline_table_dependency_features(
-            "shuttle-service",
-            dependencies,
-            vec!["web-axum".to_string()],
-        );
         set_key_value_dependency_version(
-            "sync_wrapper",
+            "shuttle-axum",
             dependencies,
             manifest_path,
             url,
-            false,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
             get_dependency_version_fn,
         );
     }
@@ -142,18 +178,16 @@ impl ShuttleInit for ShuttleInitAxum {
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
         use axum::{routing::get, Router};
-        use sync_wrapper::SyncWrapper;
 
         async fn hello_world() -> &'static str {
             "Hello, world!"
         }
 
-        #[shuttle_service::main]
-        async fn axum() -> shuttle_service::ShuttleAxum {
+        #[shuttle_runtime::main]
+        async fn axum() -> shuttle_axum::ShuttleAxum {
             let router = Router::new().route("/hello", get(hello_world));
-            let sync_wrapper = SyncWrapper::new(router);
 
-            Ok(sync_wrapper)
+            Ok(router.into())
         }"#}
     }
 }
@@ -177,10 +211,31 @@ impl ShuttleInit for ShuttleInitRocket {
             get_dependency_version_fn,
         );
 
-        set_inline_table_dependency_features(
-            "shuttle-service",
+        set_key_value_dependency_version(
+            "shuttle-rocket",
             dependencies,
-            vec!["web-rocket".to_string()],
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
         );
     }
 
@@ -194,11 +249,11 @@ impl ShuttleInit for ShuttleInitRocket {
             "Hello, world!"
         }
 
-        #[shuttle_service::main]
-        async fn rocket() -> shuttle_service::ShuttleRocket {
+        #[shuttle_runtime::main]
+        async fn rocket() -> shuttle_rocket::ShuttleRocket {
             let rocket = rocket::build().mount("/hello", routes![index]);
 
-            Ok(rocket)
+            Ok(rocket.into())
         }"#}
     }
 }
@@ -213,10 +268,31 @@ impl ShuttleInit for ShuttleInitTide {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
+        set_key_value_dependency_version(
+            "shuttle-tide",
             dependencies,
-            vec!["web-tide".to_string()],
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
         );
 
         set_key_value_dependency_version(
@@ -231,14 +307,14 @@ impl ShuttleInit for ShuttleInitTide {
 
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
-        #[shuttle_service::main]
-        async fn tide() -> shuttle_service::ShuttleTide<()> {
+        #[shuttle_runtime::main]
+        async fn tide() -> shuttle_tide::ShuttleTide<()> {
             let mut app = tide::new();
             app.with(tide::log::LogMiddleware::new());
 
             app.at("/hello").get(|_| async { Ok("Hello, world!") });
 
-            Ok(app)
+            Ok(app.into())
         }"#}
     }
 }
@@ -253,12 +329,6 @@ impl ShuttleInit for ShuttleInitPoem {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
-            dependencies,
-            vec!["web-poem".to_string()],
-        );
-
         set_key_value_dependency_version(
             "poem",
             dependencies,
@@ -267,22 +337,50 @@ impl ShuttleInit for ShuttleInitPoem {
             false,
             get_dependency_version_fn,
         );
+
+        set_key_value_dependency_version(
+            "shuttle-poem",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
     }
 
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
         use poem::{get, handler, Route};
+        use shuttle_poem::ShuttlePoem;
 
         #[handler]
         fn hello_world() -> &'static str {
             "Hello, world!"
         }
 
-        #[shuttle_service::main]
-        async fn poem() -> shuttle_service::ShuttlePoem<impl poem::Endpoint> {
+        #[shuttle_runtime::main]
+        async fn poem() -> ShuttlePoem<impl poem::Endpoint> {
             let app = Route::new().at("/hello", get(hello_world));
 
-            Ok(app)
+            Ok(app.into())
         }"#}
     }
 }
@@ -297,18 +395,39 @@ impl ShuttleInit for ShuttleInitSalvo {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
-            dependencies,
-            vec!["web-salvo".to_string()],
-        );
-
         set_key_value_dependency_version(
             "salvo",
             dependencies,
             manifest_path,
             url,
             false,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-salvo",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
             get_dependency_version_fn,
         );
     }
@@ -319,14 +438,14 @@ impl ShuttleInit for ShuttleInitSalvo {
 
         #[handler]
         async fn hello_world(res: &mut Response) {
-            res.render(Text::Plain("Hello, World!"));
+            res.render(Text::Plain("Hello, world!"));
         }
 
-        #[shuttle_service::main]
-        async fn salvo() -> shuttle_service::ShuttleSalvo {
-            let router = Router::new().get(hello_world);
+        #[shuttle_runtime::main]
+        async fn salvo() -> shuttle_salvo::ShuttleSalvo {
+            let router = Router::with_path("hello").get(hello_world);
 
-            Ok(router)
+            Ok(router.into())
         }"#}
     }
 }
@@ -341,12 +460,6 @@ impl ShuttleInit for ShuttleInitSerenity {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
-            dependencies,
-            vec!["bot-serenity".to_string()],
-        );
-
         set_key_value_dependency_version(
             "anyhow",
             dependencies,
@@ -379,11 +492,38 @@ impl ShuttleInit for ShuttleInitSerenity {
         );
 
         set_key_value_dependency_version(
+            "shuttle-serenity",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
             "shuttle-secrets",
             dependencies,
             manifest_path,
             url,
             false,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
             get_dependency_version_fn,
         );
 
@@ -424,10 +564,10 @@ impl ShuttleInit for ShuttleInitSerenity {
             }
         }
 
-        #[shuttle_service::main]
+        #[shuttle_runtime::main]
         async fn serenity(
             #[shuttle_secrets::Secrets] secret_store: SecretStore,
-        ) -> shuttle_service::ShuttleSerenity {
+        ) -> shuttle_serenity::ShuttleSerenity {
             // Get the discord token set in `Secrets.toml`
             let token = if let Some(token) = secret_store.get("DISCORD_TOKEN") {
                 token
@@ -443,7 +583,7 @@ impl ShuttleInit for ShuttleInitSerenity {
                 .await
                 .expect("Err creating client");
 
-            Ok(client)
+            Ok(client.into())
         }"#}
     }
 }
@@ -458,12 +598,6 @@ impl ShuttleInit for ShuttleInitPoise {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
-            dependencies,
-            vec!["bot-poise".to_string()],
-        );
-
         set_key_value_dependency_version(
             "anyhow",
             dependencies,
@@ -483,11 +617,38 @@ impl ShuttleInit for ShuttleInitPoise {
         );
 
         set_key_value_dependency_version(
+            "shuttle-poise",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
             "shuttle-secrets",
             dependencies,
             manifest_path,
             url,
             false,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
             get_dependency_version_fn,
         );
 
@@ -504,47 +665,47 @@ impl ShuttleInit for ShuttleInitPoise {
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
         use anyhow::Context as _;
-	use poise::serenity_prelude as serenity;
-	use shuttle_secrets::SecretStore;
-	use shuttle_service::ShuttlePoise;
+        use poise::serenity_prelude as serenity;
+        use shuttle_secrets::SecretStore;
+        use shuttle_poise::ShuttlePoise;
 
-	struct Data {} // User data, which is stored and accessible in all command invocations
-	type Error = Box<dyn std::error::Error + Send + Sync>;
-	type Context<'a> = poise::Context<'a, Data, Error>;
+        struct Data {} // User data, which is stored and accessible in all command invocations
+        type Error = Box<dyn std::error::Error + Send + Sync>;
+        type Context<'a> = poise::Context<'a, Data, Error>;
 
-	/// Responds with "world!"
-	#[poise::command(slash_command)]
-	async fn hello(ctx: Context<'_>) -> Result<(), Error> {
-		ctx.say("world!").await?;
-		Ok(())
-	}
+        /// Responds with "world!"
+        #[poise::command(slash_command)]
+        async fn hello(ctx: Context<'_>) -> Result<(), Error> {
+            ctx.say("world!").await?;
+            Ok(())
+        }
 
-	#[shuttle_service::main]
-	async fn poise(#[shuttle_secrets::Secrets] secret_store: SecretStore) -> ShuttlePoise<Data, Error> {
-		// Get the discord token set in `Secrets.toml`
-		let discord_token = secret_store
-			.get("DISCORD_TOKEN")
-			.context("'DISCORD_TOKEN' was not found")?;
+        #[shuttle_runtime::main]
+        async fn poise(#[shuttle_secrets::Secrets] secret_store: SecretStore) -> ShuttlePoise<Data, Error> {
+            // Get the discord token set in `Secrets.toml`
+            let discord_token = secret_store
+                .get("DISCORD_TOKEN")
+                .context("'DISCORD_TOKEN' was not found")?;
 
-		let framework = poise::Framework::builder()
-			.options(poise::FrameworkOptions {
-				commands: vec![hello()],
-				..Default::default()
-			})
-			.token(discord_token)
-			.intents(serenity::GatewayIntents::non_privileged())
-			.setup(|ctx, _ready, framework| {
-				Box::pin(async move {
-					poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-					Ok(Data {})
-				})
-			})
-			.build()
-			.await
-			.map_err(shuttle_service::error::CustomError::new)?;
+            let framework = poise::Framework::builder()
+                .options(poise::FrameworkOptions {
+                    commands: vec![hello()],
+                    ..Default::default()
+                })
+                .token(discord_token)
+                .intents(serenity::GatewayIntents::non_privileged())
+                .setup(|ctx, _ready, framework| {
+                    Box::pin(async move {
+                        poise::builtins::register_globally(ctx, &framework.options().commands).await?;
+                        Ok(Data {})
+                    })
+                })
+                .build()
+                .await
+                .map_err(shuttle_runtime::CustomError::new)?;
 
-		Ok(framework)
-	}"#}
+            Ok(framework.into())
+        }"#}
     }
 }
 
@@ -558,10 +719,42 @@ impl ShuttleInit for ShuttleInitTower {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
+        set_inline_table_dependency_version(
+            "hyper",
             dependencies,
-            vec!["web-tower".to_string()],
+            manifest_path,
+            url,
+            false,
+            get_dependency_version_fn,
+        );
+
+        set_inline_table_dependency_features("hyper", dependencies, vec!["full".to_string()]);
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-tower",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
         );
 
         set_inline_table_dependency_version(
@@ -574,17 +767,6 @@ impl ShuttleInit for ShuttleInitTower {
         );
 
         set_inline_table_dependency_features("tower", dependencies, vec!["full".to_string()]);
-
-        set_inline_table_dependency_version(
-            "hyper",
-            dependencies,
-            manifest_path,
-            url,
-            false,
-            get_dependency_version_fn,
-        );
-
-        set_inline_table_dependency_features("hyper", dependencies, vec!["full".to_string()]);
     }
 
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
@@ -619,9 +801,11 @@ impl ShuttleInit for ShuttleInitTower {
             }
         }
 
-        #[shuttle_service::main]
-        async fn tower() -> Result<HelloWorld, shuttle_service::Error> {
-            Ok(HelloWorld)
+        #[shuttle_runtime::main]
+        async fn tower() -> shuttle_tower::ShuttleTower<HelloWorld> {
+            let service = HelloWorld;
+
+            Ok(service.into())
         }"#}
     }
 }
@@ -636,10 +820,31 @@ impl ShuttleInit for ShuttleInitWarp {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
+        set_key_value_dependency_version(
+            "shuttle-runtime",
             dependencies,
-            vec!["web-warp".to_string()],
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-warp",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
         );
 
         set_key_value_dependency_version(
@@ -654,13 +859,13 @@ impl ShuttleInit for ShuttleInitWarp {
 
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
         indoc! {r#"
-            use warp::Filter;
-            use warp::Reply;
-
-            #[shuttle_service::main]
-            async fn warp() -> shuttle_service::ShuttleWarp<(impl Reply,)> {
-                let route = warp::any().map(|| "Hello, World");
-                Ok(route.boxed())
+        use warp::Filter;
+        use warp::Reply;
+        
+        #[shuttle_runtime::main]
+        async fn warp() -> shuttle_warp::ShuttleWarp<(impl Reply,)> {
+            let route = warp::any().map(|| "Hello, World!");
+            Ok(route.boxed().into())
         }"#}
     }
 }
@@ -675,10 +880,22 @@ impl ShuttleInit for ShuttleInitThruster {
         url: &Url,
         get_dependency_version_fn: GetDependencyVersionFn,
     ) {
-        set_inline_table_dependency_features(
-            "shuttle-service",
+        set_key_value_dependency_version(
+            "shuttle-thruster",
             dependencies,
-            vec!["web-thruster".to_string()],
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
+
+        set_key_value_dependency_version(
+            "shuttle-runtime",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
         );
 
         set_inline_table_dependency_version(
@@ -695,6 +912,15 @@ impl ShuttleInit for ShuttleInitThruster {
             dependencies,
             vec!["hyper_server".to_string()],
         );
+
+        set_key_value_dependency_version(
+            "tokio",
+            dependencies,
+            manifest_path,
+            url,
+            true,
+            get_dependency_version_fn,
+        );
     }
 
     fn get_boilerplate_code_for_framework(&self) -> &'static str {
@@ -703,20 +929,21 @@ impl ShuttleInit for ShuttleInitThruster {
             context::basic_hyper_context::{generate_context, BasicHyperContext as Ctx, HyperRequest},
             m, middleware_fn, App, HyperServer, MiddlewareNext, MiddlewareResult, ThrusterServer,
         };
-
+        
         #[middleware_fn]
         async fn hello(mut context: Ctx, _next: MiddlewareNext<Ctx>) -> MiddlewareResult<Ctx> {
             context.body("Hello, World!");
             Ok(context)
         }
-
-        #[shuttle_service::main]
-        async fn thruster() -> shuttle_service::ShuttleThruster<HyperServer<Ctx, ()>> {
-            Ok(HyperServer::new(
+        
+        #[shuttle_runtime::main]
+        async fn thruster() -> shuttle_thruster::ShuttleThruster<HyperServer<Ctx, ()>> {
+            let server = HyperServer::new(
                 App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/hello", m![hello]),
-            ))
-        }
-        "#}
+            );
+            
+            Ok(server.into())
+        }"#}
     }
 }
 

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -32,6 +32,8 @@ async fn non_interactive_basic_init() {
     assert!(cargo_toml.contains("shuttle-service = { version = "));
 }
 
+// TODO: unignore when shuttle-rocket is published
+#[ignore]
 #[tokio::test]
 async fn non_interactive_rocket_init() {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -54,6 +56,8 @@ async fn non_interactive_rocket_init() {
     assert_valid_rocket_project(temp_dir_path.as_path(), "rocket-init");
 }
 
+// TODO: unignore when shuttle-rocket is published
+#[ignore]
 #[test]
 fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -93,6 +97,8 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+// TODO: unignore when shuttle-rocket is published
+#[ignore]
 #[test]
 fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -128,6 +134,8 @@ fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::er
     Ok(())
 }
 
+// TODO: unignore when shuttle-rocket is published
+#[ignore]
 #[test]
 fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();


### PR DESCRIPTION
## Description of change

This updates init with the shuttle-next changes, copied from the updated examples that have been tested with local run. I ended up ignoring 5 tests since they try to fetch `shuttle-rocket` from crates.io and that hasn't been published yet, but I added a `TODO` to each.

## How Has This Been Tested (if applicable)?

Updated and made sure all tests that can pass do pass. See above for ignored tests. We will also test init as part of the pre-release QA.
