### PR TITLE
Feature: emit error when shuttle::main function is named main

### DIFF
--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -91,6 +91,16 @@ impl Parse for BuilderOption {
 
 impl Loader {
     pub(crate) fn from_item_fn(item_fn: &mut ItemFn) -> Option<Self> {
+        let fn_ident = item_fn.sig.ident.clone();
+
+        if fn_ident.clone().to_string() == "main".to_string() {
+            emit_error!(
+                fn_ident,
+                "shuttle_runtime::main functions cannot be named `main`"
+            );
+            return None;
+        }
+
         let inputs: Vec<_> = item_fn
             .sig
             .inputs
@@ -119,7 +129,7 @@ impl Loader {
 
         if let Some(type_path) = check_return_type(item_fn.sig.clone()) {
             Some(Self {
-                fn_ident: item_fn.sig.ident.clone(),
+                fn_ident: fn_ident.clone(),
                 fn_inputs: inputs,
                 fn_return: type_path,
             })

--- a/codegen/tests/ui/main/duplicate-main-fn.rs
+++ b/codegen/tests/ui/main/duplicate-main-fn.rs
@@ -1,0 +1,2 @@
+#[shuttle_codegen::main]
+async fn main() -> ShuttleRocket {}

--- a/codegen/tests/ui/main/duplicate-main-fn.stderr
+++ b/codegen/tests/ui/main/duplicate-main-fn.stderr
@@ -1,0 +1,11 @@
+error: shuttle_runtime::main functions cannot be named `main`
+ --> tests/ui/main/duplicate-main-fn.rs:2:10
+  |
+2 | async fn main() -> ShuttleRocket {}
+  |          ^^^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+ --> tests/ui/main/duplicate-main-fn.rs:2:36
+  |
+2 | async fn main() -> ShuttleRocket {}
+  |                                    ^ consider adding a `main` function to `$DIR/tests/ui/main/duplicate-main-fn.rs`


### PR DESCRIPTION
## Description of change

Emit a clear error when a shuttle_runtime::main function is named `main`, which does not work since the codegen generates a main function.

## How Has This Been Tested (if applicable)?

I added a test and I tested a modified example manually.
