### PR TITLE
[next] refactor: update runtime manager

### DIFF
--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -208,7 +208,7 @@ impl Built {
         let runtime_client = runtime_manager
             .lock()
             .await
-            .get_runtime_client(legacy_runtime_path.clone())
+            .get_runtime_client(self.id, legacy_runtime_path.clone())
             .await
             .map_err(Error::Runtime)?;
 

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -13,6 +13,8 @@ use crate::deployment::deploy_layer;
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
+/// Manager that can start up mutliple runtimes. This is needed so that two runtimes can be up when a new deployment is made:
+/// One runtime for the new deployment being loaded; another for the currently active deployment
 #[derive(Clone)]
 pub struct RuntimeManager {
     runtimes: Arc<std::sync::Mutex<HashMap<Uuid, (process::Child, RuntimeClient<Channel>)>>>,

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryInto, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, convert::TryInto, path::PathBuf, sync::Arc};
 
 use anyhow::Context;
 use shuttle_proto::runtime::{
@@ -6,7 +6,7 @@ use shuttle_proto::runtime::{
 };
 use tokio::{process, sync::Mutex};
 use tonic::transport::Channel;
-use tracing::{debug, info, instrument, trace};
+use tracing::{debug, info, trace};
 use uuid::Uuid;
 
 use crate::deployment::deploy_layer;
@@ -15,10 +15,7 @@ const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
 #[derive(Clone)]
 pub struct RuntimeManager {
-    legacy: Option<RuntimeClient<Channel>>,
-    legacy_process: Option<Arc<std::sync::Mutex<process::Child>>>,
-    next: Option<RuntimeClient<Channel>>,
-    next_process: Option<Arc<std::sync::Mutex<process::Child>>>,
+    runtimes: Arc<std::sync::Mutex<HashMap<Uuid, (process::Child, RuntimeClient<Channel>)>>>,
     artifacts_path: PathBuf,
     provisioner_address: String,
     log_sender: crossbeam_channel::Sender<deploy_layer::Log>,
@@ -31,10 +28,7 @@ impl RuntimeManager {
         log_sender: crossbeam_channel::Sender<deploy_layer::Log>,
     ) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
-            legacy: None,
-            legacy_process: None,
-            next: None,
-            next_process: None,
+            runtimes: Arc::new(std::sync::Mutex::new(HashMap::new())),
             artifacts_path,
             provisioner_address,
             log_sender,
@@ -43,157 +37,109 @@ impl RuntimeManager {
 
     pub async fn get_runtime_client(
         &mut self,
+        id: Uuid,
         legacy_runtime_path: Option<PathBuf>,
     ) -> anyhow::Result<RuntimeClient<Channel>> {
-        if legacy_runtime_path.is_none() {
-            debug!("Getting shuttle-next runtime client");
+        trace!("making new client");
 
-            Self::get_runtime_client_helper(
-                &mut self.next,
-                &mut self.next_process,
-                None,
-                self.artifacts_path.clone(),
-                &self.provisioner_address,
-                self.log_sender.clone(),
-            )
-            .await
-        } else {
-            debug!("Getting legacy runtime client");
+        let port = portpicker::pick_unused_port().context("failed to find available port")?;
+        let is_next = legacy_runtime_path.is_none();
 
-            Self::get_runtime_client_helper(
-                &mut self.legacy,
-                &mut self.legacy_process,
-                legacy_runtime_path,
-                self.artifacts_path.clone(),
-                &self.provisioner_address,
-                self.log_sender.clone(),
-            )
-            .await
-        }
-    }
-
-    /// Send a kill / stop signal for a deployment to any runtimes currently running
-    pub async fn kill(&mut self, id: &Uuid) -> bool {
-        let success_legacy = if let Some(legacy_client) = &mut self.legacy {
-            trace!(%id, "sending stop signal to legacy for deployment");
-
-            let stop_request = tonic::Request::new(StopRequest {});
-            let response = legacy_client.stop(stop_request).await.unwrap();
-
-            response.into_inner().success
-        } else {
-            trace!("no legacy client running");
-            true
-        };
-
-        let success_next = if let Some(next_client) = &mut self.next {
-            trace!(%id, "sending stop signal to next for deployment");
-
-            let stop_request = tonic::Request::new(StopRequest {});
-            let response = next_client.stop(stop_request).await.unwrap();
-
-            response.into_inner().success
-        } else {
-            trace!("no next client running");
-            true
-        };
-
-        success_legacy && success_next
-    }
-
-    #[instrument(skip(runtime_option, process_option, log_sender))]
-    async fn get_runtime_client_helper(
-        runtime_option: &mut Option<RuntimeClient<Channel>>,
-        process_option: &mut Option<Arc<std::sync::Mutex<process::Child>>>,
-        legacy_runtime_path: Option<PathBuf>,
-        artifacts_path: PathBuf,
-        provisioner_address: &str,
-        log_sender: crossbeam_channel::Sender<deploy_layer::Log>,
-    ) -> anyhow::Result<RuntimeClient<Channel>> {
-        if let Some(runtime_client) = runtime_option {
-            trace!("returning previous client");
-            Ok(runtime_client.clone())
-        } else {
-            trace!("making new client");
-
-            let port = portpicker::pick_unused_port().context("failed to find available port")?;
-            let is_next = legacy_runtime_path.is_none();
-
-            let get_runtime_executable = || {
-                if let Some(legacy_runtime) = legacy_runtime_path {
-                    debug!(
-                        "Starting legacy runtime at: {}",
-                        legacy_runtime
-                            .clone()
-                            .into_os_string()
-                            .into_string()
-                            .unwrap_or_default()
-                    );
+        let get_runtime_executable = || {
+            if let Some(legacy_runtime) = legacy_runtime_path {
+                debug!(
+                    "Starting legacy runtime at: {}",
                     legacy_runtime
-                } else {
-                    if cfg!(debug_assertions) {
-                        debug!("Installing shuttle-next runtime in debug mode from local source");
-                        // If we're running deployer natively, install shuttle-runtime using the
-                        // version of runtime from the calling repo.
-                        let path = std::fs::canonicalize(format!("{MANIFEST_DIR}/../runtime"));
+                        .clone()
+                        .into_os_string()
+                        .into_string()
+                        .unwrap_or_default()
+                );
+                legacy_runtime
+            } else {
+                if cfg!(debug_assertions) {
+                    debug!("Installing shuttle-next runtime in debug mode from local source");
+                    // If we're running deployer natively, install shuttle-runtime using the
+                    // version of runtime from the calling repo.
+                    let path = std::fs::canonicalize(format!("{MANIFEST_DIR}/../runtime"));
 
-                        // The path will not be valid if we are in a deployer container, in which
-                        // case we don't try to install and use the one installed in deploy.sh.
-                        if let Ok(path) = path {
-                            std::process::Command::new("cargo")
-                                .arg("install")
-                                .arg("shuttle-runtime")
-                                .arg("--path")
-                                .arg(path)
-                                .arg("--bin")
-                                .arg("shuttle-next")
-                                .arg("--features")
-                                .arg("next")
-                                .output()
-                                .expect("failed to install the local version of shuttle-runtime");
-                        }
+                    // The path will not be valid if we are in a deployer container, in which
+                    // case we don't try to install and use the one installed in deploy.sh.
+                    if let Ok(path) = path {
+                        std::process::Command::new("cargo")
+                            .arg("install")
+                            .arg("shuttle-runtime")
+                            .arg("--path")
+                            .arg(path)
+                            .arg("--bin")
+                            .arg("shuttle-next")
+                            .arg("--features")
+                            .arg("next")
+                            .output()
+                            .expect("failed to install the local version of shuttle-runtime");
                     }
-
-                    debug!("Returning path to shuttle-next runtime",);
-                    // If we're in a deployer built with the containerfile, the runtime will have
-                    // been installed in deploy.sh.
-                    home::cargo_home()
-                        .expect("failed to find path to cargo home")
-                        .join("bin/shuttle-next")
                 }
-            };
 
-            let (process, runtime_client) = runtime::start(
-                is_next,
-                runtime::StorageManagerType::Artifacts(artifacts_path),
-                provisioner_address,
-                port,
-                get_runtime_executable,
-            )
+                debug!("Returning path to shuttle-next runtime",);
+                // If we're in a deployer built with the containerfile, the runtime will have
+                // been installed in deploy.sh.
+                home::cargo_home()
+                    .expect("failed to find path to cargo home")
+                    .join("bin/shuttle-next")
+            }
+        };
+
+        let (process, runtime_client) = runtime::start(
+            is_next,
+            runtime::StorageManagerType::Artifacts(self.artifacts_path.clone()),
+            &self.provisioner_address,
+            port,
+            get_runtime_executable,
+        )
+        .await
+        .context("failed to start shuttle runtime")?;
+
+        let sender = self.log_sender.clone();
+        let mut stream = runtime_client
+            .clone()
+            .subscribe_logs(tonic::Request::new(SubscribeLogsRequest {}))
             .await
-            .context("failed to start shuttle runtime")?;
+            .context("subscribing to runtime logs stream")?
+            .into_inner();
 
-            let sender = log_sender;
-            let mut stream = runtime_client
-                .clone()
-                .subscribe_logs(tonic::Request::new(SubscribeLogsRequest {}))
-                .await
-                .context("subscribing to runtime logs stream")?
-                .into_inner();
-
-            tokio::spawn(async move {
-                while let Ok(Some(log)) = stream.message().await {
-                    if let Ok(log) = log.try_into() {
-                        sender.send(log).expect("to send log to persistence");
-                    }
+        tokio::spawn(async move {
+            while let Ok(Some(log)) = stream.message().await {
+                if let Ok(log) = log.try_into() {
+                    sender.send(log).expect("to send log to persistence");
                 }
-            });
+            }
+        });
 
-            *runtime_option = Some(runtime_client.clone());
-            *process_option = Some(Arc::new(std::sync::Mutex::new(process)));
+        self.runtimes
+            .lock()
+            .unwrap()
+            .insert(id, (process, runtime_client.clone()));
 
-            // Safe to unwrap as it was just set
-            Ok(runtime_client)
+        Ok(runtime_client)
+    }
+
+    /// Send a kill / stop signal for a deployment to its running runtime
+    pub async fn kill(&mut self, id: &Uuid) -> bool {
+        let value = self.runtimes.lock().unwrap().remove(id);
+
+        if let Some((mut process, mut runtime_client)) = value {
+            trace!(%id, "sending stop signal for deployment");
+
+            let stop_request = tonic::Request::new(StopRequest {});
+            let response = runtime_client.stop(stop_request).await.unwrap();
+
+            let result = response.into_inner().success;
+            let _ = process.start_kill();
+
+            result
+        } else {
+            trace!("no client running");
+            true
         }
     }
 }
@@ -202,12 +148,8 @@ impl Drop for RuntimeManager {
     fn drop(&mut self) {
         info!("runtime manager shutting down");
 
-        if let Some(ref process) = self.legacy_process.take() {
-            let _ = process.lock().unwrap().start_kill();
-        }
-
-        if let Some(ref process) = self.next_process.take() {
-            let _ = process.lock().unwrap().start_kill();
+        for (process, _runtime_client) in self.runtimes.lock().unwrap().values_mut() {
+            let _ = process.start_kill();
         }
     }
 }


### PR DESCRIPTION
## Description of change

Update the runtime manager to run multiple deploys at the same time. This is to allow a new deploy to be loaded while an old deploy stays up running

## How Has This Been Tested (if applicable)?
By running deloyer locally
