### PR TITLE
feat: embed protoc in shuttle-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ca8623e5633e298ad1f917d8be0a44bcf406bf3cde3b80e63003e49a3f27d"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb9fc9cce84c8694b6ea01cc6296617b288b703719b725b8c9c65f7c5874435"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d2a07dcf7173a04d49974930ccbfb7fd4d74df30ecfc8762cf2f895a094516"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54fef0b04fcacba64d1d80eed74a20356d96847da8497a59b0a0a436c9165b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8782f2ce7d43a9a5c74ea4936f001e9e8442205c244f7a3d4286bd4c37bc924"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5de656c7ee83f08e0ae5b81792ccfdc1d04e7876b1d9a38e6876a9e09e02537"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4746,6 +4796,7 @@ dependencies = [
  "home",
  "prost",
  "prost-types",
+ "protoc-bin-vendored",
  "shuttle-common",
  "tokio",
  "tonic",

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -22,4 +22,5 @@ workspace = true
 features = ["error", "service", "wasm"]
 
 [build-dependencies]
+protoc-bin-vendored = "3.0.0"
 tonic-build = "0.8.3"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,4 +1,10 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protoc = protoc_bin_vendored::protoc_bin_path().unwrap();
+    let protoc_include = protoc_bin_vendored::include_path().unwrap();
+
+    std::env::set_var("PROTOC", protoc);
+    std::env::set_var("PROTOC_INCLUDE", protoc_include);
+
     tonic_build::configure().compile(&["./provisioner.proto", "./runtime.proto"], &["./"])?;
 
     Ok(())

--- a/runtime/tests/resources/axum-wasm-expanded/Cargo.toml
+++ b/runtime/tests/resources/axum-wasm-expanded/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 futures = "0.3.25"
-shuttle-next = { path = "../../../../next" }
+shuttle-next = { path = "../../../../services/shuttle-next" }
 tracing = "0.1.37"


### PR DESCRIPTION
## Description of change

This embeds protoc in shuttle-proto, so it doesn't need to be installed by the user to install cargo-shuttle.

## How Has This Been Tested (if applicable)?

Seems to work on linux, about to test on windows.
