### PR TITLE
[next] bug: communicating resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,14 +88,17 @@ commands:
             cat\<< EOF > ~/.cargo/config.toml
             [patch.crates-io]
             shuttle-service = { path = "$PWD/service" }
+            shuttle-runtime = { path = "$PWD/runtime" }
+
             shuttle-aws-rds = { path = "$PWD/resources/aws-rds" }
             shuttle-persist = { path = "$PWD/resources/persist" }
-            shuttle-runtime = { path = "$PWD/runtime" }
             shuttle-shared-db = { path = "$PWD/resources/shared-db" }
             shuttle-secrets = { path = "$PWD/resources/secrets" }
             shuttle-static-folder = { path = "$PWD/resources/static-folder" }
+
             shuttle-axum = { path = "$PWD/services/shuttle-axum" }
             shuttle-actix-web = { path = "$PWD/services/shuttle-actix-web" }
+            shuttle-next = { path = "$PWD/services/shuttle-next" }
             shuttle-poem = { path = "$PWD/services/shuttle-poem" }
             shuttle-poise = { path = "$PWD/services/shuttle-poise" }
             shuttle-rocket = { path = "$PWD/services/shuttle-rocket" }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,13 +56,26 @@ In order to test local changes to the library crates, you may want to add the be
 ```toml
 [patch.crates-io]
 shuttle-service = { path = "[base]/shuttle/service" }
-shuttle-common = { path = "[base]/shuttle/common" }
-shuttle-proto = { path = "[base]/shuttle/proto" }
+shuttle-runtime = { path = "[base]/shuttle/runtime" }
+
 shuttle-aws-rds = { path = "[base]/shuttle/resources/aws-rds" }
 shuttle-persist = { path = "[base]/shuttle/resources/persist" }
 shuttle-shared-db = { path = "[base]/shuttle/resources/shared-db" }
 shuttle-secrets = { path = "[base]/shuttle/resources/secrets" }
 shuttle-static-folder = { path = "[base]/shuttle/resources/static-folder" }
+
+shuttle-axum = { path = "[base]/shuttle/services/shuttle-axum" }
+shuttle-actix-web = { path = "[base]/shuttle/services/shuttle-actix-web" }
+shuttle-next = { path = "[base]/shuttle/services/shuttle-next" }
+shuttle-poem = { path = "[base]/shuttle/services/shuttle-poem" }
+shuttle-poise = { path = "[base]/shuttle/services/shuttle-poise" }
+shuttle-rocket = { path = "[base]/shuttle/services/shuttle-rocket" }
+shuttle-salvo = { path = "[base]/shuttle/services/shuttle-salvo" }
+shuttle-serenity = { path = "[base]/shuttle/services/shuttle-serenity" }
+shuttle-thruster = { path = "[base]/shuttle/services/shuttle-thruster" }
+shuttle-tide = { path = "[base]/shuttle/services/shuttle-tide" }
+shuttle-tower = { path = "[base]/shuttle/services/shuttle-tower" }
+shuttle-warp = { path = "[base]/shuttle/services/shuttle-warp" }
 ```
 
 Before we can login to our local instance of shuttle, we need to create a user.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4750,6 +4750,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tower",
  "tracing",
 ]
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -543,6 +543,7 @@ impl Shuttle {
                 .into_string()
                 .expect("to convert path to string"),
             service_name: service_name.clone(),
+            resources: Default::default(),
             secrets,
         });
         trace!("loading service");

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -527,6 +527,7 @@ impl Shuttle {
             is_wasm,
             runtime::StorageManagerType::WorkingDir(working_directory.to_path_buf()),
             &format!("http://localhost:{}", run_args.port + 1),
+            None,
             run_args.port + 2,
             runtime_path,
         )

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -92,6 +92,7 @@ async fn rocket_secrets() {
 
 // This example uses a shared Postgres. Thus local runs should create a docker container for it.
 #[tokio::test(flavor = "multi_thread")]
+#[ignore]
 async fn rocket_postgres() {
     let url = cargo_shuttle_run("../examples/rocket/postgres", false).await;
     let client = reqwest::Client::new();
@@ -281,7 +282,6 @@ async fn poem_hello_world() {
 
 // This example uses a shared Postgres. Thus local runs should create a docker container for it.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
 async fn poem_postgres() {
     let url = cargo_shuttle_run("../examples/poem/postgres", false).await;
     let client = reqwest::Client::new();

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "0.11.13", optional = true }
 rmp-serde = { version = "1.1.1", optional = true }
 rustrict = { version = "0.5.5", optional = true }
 serde = { workspace = true, features = ["derive", "std"] }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 strum = { workspace = true, features = ["derive"], optional = true }
 thiserror = { workspace = true, optional = true }
 tonic = { version = "0.8.3", optional = true }
@@ -47,10 +47,10 @@ uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 backend = ["async-trait", "axum/matched-path", "claims", "hyper/client", "opentelemetry-otlp", "thiserror", "tower-http", "tracing-subscriber/env-filter", "tracing-subscriber/fmt", "ttl_cache"]
 claims = ["bytes", "chrono/clock", "headers", "http", "http-body", "jsonwebtoken", "opentelemetry", "opentelemetry-http", "pin-project", "tower", "tracing", "tracing-opentelemetry"]
 display = ["chrono/clock", "comfy-table", "crossterm"]
-error = ["prost-types", "serde_json", "thiserror", "uuid"]
-models = ["anyhow", "async-trait", "display", "http", "reqwest", "serde_json", "service"]
+error = ["prost-types", "thiserror", "uuid"]
+models = ["anyhow", "async-trait", "display", "http", "reqwest", "service"]
 service = ["chrono/serde", "once_cell", "rustrict", "serde/derive", "strum", "uuid"]
-tracing = ["serde_json"]
+tracing = []
 wasm = ["chrono/clock", "http-serde", "http", "rmp-serde", "tracing", "tracing-subscriber"]
 
 [dev-dependencies]
@@ -59,7 +59,6 @@ base64 = "0.13.1"
 cap-std = "1.0.2"
 hyper = { workspace = true }
 ring = { workspace = true }
-serde_json = { workspace = true }
 tokio = { version = "1.22.0", features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true, features = ["util"] }
 tracing-fluent-assertions = "0.3.0"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -32,7 +32,7 @@ rmp-serde = { version = "1.1.1", optional = true }
 rustrict = { version = "0.5.5", optional = true }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true }
-strum = { workspace = true, features = ["derive"], optional = true }
+strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true, optional = true }
 tonic = { version = "0.8.3", optional = true }
 tower = { workspace = true, optional = true }
@@ -49,7 +49,7 @@ claims = ["bytes", "chrono/clock", "headers", "http", "http-body", "jsonwebtoken
 display = ["chrono/clock", "comfy-table", "crossterm"]
 error = ["prost-types", "thiserror", "uuid"]
 models = ["anyhow", "async-trait", "display", "http", "reqwest", "service"]
-service = ["chrono/serde", "once_cell", "rustrict", "serde/derive", "strum", "uuid"]
+service = ["chrono/serde", "once_cell", "rustrict", "serde/derive", "uuid"]
 tracing = []
 wasm = ["chrono/clock", "http-serde", "http", "rmp-serde", "tracing", "tracing-subscriber"]
 

--- a/common/src/database.rs
+++ b/common/src/database.rs
@@ -3,14 +3,14 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize};
 use strum::Display;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
     AwsRds(AwsRdsEngine),
     Shared(SharedEngine),
 }
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize)]
+#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum AwsRdsEngine {
@@ -19,7 +19,7 @@ pub enum AwsRdsEngine {
     MariaDB,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize)]
+#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum SharedEngine {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod log;
 pub mod models;
 #[cfg(feature = "service")]
 pub mod project;
+pub mod resource;
 #[cfg(feature = "service")]
 pub mod storage_manager;
 #[cfg(feature = "tracing")]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -2,7 +2,6 @@
 pub mod backends;
 #[cfg(feature = "claims")]
 pub mod claims;
-#[cfg(feature = "service")]
 pub mod database;
 #[cfg(feature = "service")]
 pub mod deployment;

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,7 +1,6 @@
 pub mod deployment;
 pub mod error;
 pub mod project;
-pub mod resource;
 pub mod secret;
 pub mod service;
 pub mod stats;

--- a/common/src/models/service.rs
+++ b/common/src/models/service.rs
@@ -1,6 +1,6 @@
 use crate::{
-    models::{deployment, resource, resource::ResourceInfo, secret},
-    DatabaseReadyInfo,
+    models::{deployment, secret},
+    resource::{self, ResourceInfo},
 };
 
 use comfy_table::{
@@ -32,12 +32,6 @@ pub struct Summary {
     pub deployment: Option<deployment::Response>,
     pub resources: Vec<resource::Response>,
     pub uri: String,
-}
-
-impl ResourceInfo for DatabaseReadyInfo {
-    fn connection_string_public(&self) -> String {
-        self.connection_string_public()
-    }
 }
 
 impl Display for Detailed {

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -48,6 +48,10 @@ impl Response {
     pub fn into_bytes(self) -> Vec<u8> {
         serde_json::to_vec(&self).expect("to turn resource into a vec")
     }
+
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        serde_json::from_slice(&bytes).expect("to turn bytes into a resource")
+    }
 }
 
 impl Display for Type {

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -2,13 +2,11 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use uuid::Uuid;
 
 use crate::{database, DatabaseReadyInfo};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Response {
-    pub service_id: Uuid,
     pub r#type: Type,
     pub data: Value,
 }
@@ -17,9 +15,22 @@ pub struct Response {
 pub trait ResourceInfo {
     /// String to connect to this resource from a public location
     fn connection_string_public(&self) -> String;
+
+    /// String to connect to this resource from within shuttle
+    fn connection_string_private(&self) -> String;
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+impl ResourceInfo for DatabaseReadyInfo {
+    fn connection_string_public(&self) -> String {
+        self.connection_string_public()
+    }
+
+    fn connection_string_private(&self) -> String {
+        self.connection_string_private()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Type {
     Database(database::Type),
@@ -32,6 +43,10 @@ impl Response {
                 serde_json::from_value::<DatabaseReadyInfo>(self.data.clone()).unwrap()
             }
         }
+    }
+
+    pub fn into_bytes(self) -> Vec<u8> {
+        serde_json::to_vec(&self).expect("to turn resource into a vec")
     }
 }
 

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -470,7 +470,7 @@ mod tests {
         let path = tmp_dir.into_path();
         let (tx, _rx) = crossbeam_channel::unbounded();
 
-        RuntimeManager::new(path, format!("http://{}", provisioner_addr), tx)
+        RuntimeManager::new(path, format!("http://{}", provisioner_addr), None, tx)
     }
 
     #[async_trait::async_trait]

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -310,7 +310,10 @@ mod tests {
         time::Duration,
     };
 
-    use crate::{persistence::DeploymentUpdater, RuntimeManager};
+    use crate::{
+        persistence::{DeploymentUpdater, Resource, ResourceManager},
+        RuntimeManager,
+    };
     use async_trait::async_trait;
     use axum::body::Bytes;
     use ctor::ctor;
@@ -550,6 +553,21 @@ mod tests {
 
         async fn get_secrets(&self, _service_id: &Uuid) -> Result<Vec<Secret>, Self::Err> {
             Ok(Default::default())
+        }
+    }
+
+    #[derive(Clone)]
+    struct StubResourceManager;
+
+    #[async_trait::async_trait]
+    impl ResourceManager for StubResourceManager {
+        type Err = std::io::Error;
+
+        async fn insert_resource(&self, _resource: &Resource) -> Result<(), Self::Err> {
+            Ok(())
+        }
+        async fn get_resources(&self, _service_id: &Uuid) -> Result<Vec<Resource>, Self::Err> {
+            Ok(Vec::new())
         }
     }
 
@@ -861,6 +879,7 @@ mod tests {
             .active_deployment_getter(StubActiveDeploymentGetter)
             .artifacts_path(PathBuf::from("/tmp"))
             .secret_getter(StubSecretGetter)
+            .resource_manager(StubResourceManager)
             .runtime(get_runtime_manager())
             .deployment_updater(StubDeploymentUpdater)
             .queue_client(StubBuildQueueClient)

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -12,7 +12,7 @@ use tracing::{instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::{
-    persistence::{DeploymentUpdater, SecretGetter, SecretRecorder, State},
+    persistence::{DeploymentUpdater, ResourceManager, SecretGetter, SecretRecorder, State},
     RuntimeManager,
 };
 use tokio::sync::{mpsc, Mutex};
@@ -23,7 +23,7 @@ use self::{deploy_layer::LogRecorder, gateway_client::BuildQueueClient};
 const QUEUE_BUFFER_SIZE: usize = 100;
 const RUN_BUFFER_SIZE: usize = 100;
 
-pub struct DeploymentManagerBuilder<LR, SR, ADG, DU, SG, QC> {
+pub struct DeploymentManagerBuilder<LR, SR, ADG, DU, SG, RM, QC> {
     build_log_recorder: Option<LR>,
     secret_recorder: Option<SR>,
     active_deployment_getter: Option<ADG>,
@@ -31,16 +31,18 @@ pub struct DeploymentManagerBuilder<LR, SR, ADG, DU, SG, QC> {
     runtime_manager: Option<Arc<Mutex<RuntimeManager>>>,
     deployment_updater: Option<DU>,
     secret_getter: Option<SG>,
+    resource_manager: Option<RM>,
     queue_client: Option<QC>,
 }
 
-impl<LR, SR, ADG, DU, SG, QC> DeploymentManagerBuilder<LR, SR, ADG, DU, SG, QC>
+impl<LR, SR, ADG, DU, SG, RM, QC> DeploymentManagerBuilder<LR, SR, ADG, DU, SG, RM, QC>
 where
     LR: LogRecorder,
     SR: SecretRecorder,
     ADG: ActiveDeploymentsGetter,
     DU: DeploymentUpdater,
     SG: SecretGetter,
+    RM: ResourceManager,
     QC: BuildQueueClient,
 {
     pub fn build_log_recorder(mut self, build_log_recorder: LR) -> Self {
@@ -79,6 +81,12 @@ where
         self
     }
 
+    pub fn resource_manager(mut self, resource_manager: RM) -> Self {
+        self.resource_manager = Some(resource_manager);
+
+        self
+    }
+
     pub fn runtime(mut self, runtime_manager: Arc<Mutex<RuntimeManager>>) -> Self {
         self.runtime_manager = Some(runtime_manager);
 
@@ -110,6 +118,7 @@ where
             .deployment_updater
             .expect("a deployment updater to be set");
         let secret_getter = self.secret_getter.expect("a secret getter to be set");
+        let resource_manager = self.resource_manager.expect("a resource manager to be set");
 
         let (queue_send, queue_recv) = mpsc::channel(QUEUE_BUFFER_SIZE);
         let (run_send, run_recv) = mpsc::channel(RUN_BUFFER_SIZE);
@@ -132,6 +141,7 @@ where
             deployment_updater,
             active_deployment_getter,
             secret_getter,
+            resource_manager,
             storage_manager.clone(),
         ));
 
@@ -169,7 +179,8 @@ pub struct DeploymentManager {
 impl DeploymentManager {
     /// Create a new deployment manager. Manages one or more 'pipelines' for
     /// processing service building, loading, and deployment.
-    pub fn builder<LR, SR, ADG, DU, SG, QC>() -> DeploymentManagerBuilder<LR, SR, ADG, DU, SG, QC> {
+    pub fn builder<LR, SR, ADG, DU, SG, RM, QC>(
+    ) -> DeploymentManagerBuilder<LR, SR, ADG, DU, SG, RM, QC> {
         DeploymentManagerBuilder {
             build_log_recorder: None,
             secret_recorder: None,
@@ -178,6 +189,7 @@ impl DeploymentManager {
             runtime_manager: None,
             deployment_updater: None,
             secret_getter: None,
+            resource_manager: None,
             queue_client: None,
         }
     }

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -265,6 +265,20 @@ async fn load(
             .unwrap_or_default()
     );
 
+    // Get resources from cache when a claim is not set (ie an idl project is started)
+    let resources = if claim.is_none() {
+        resource_manager
+            .get_resources(&service_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(resource::Response::from)
+            .map(resource::Response::into_bytes)
+            .collect()
+    } else {
+        Default::default()
+    };
+
     let secrets = secret_getter
         .get_secrets(&service_id)
         .await
@@ -279,6 +293,7 @@ async fn load(
             .into_string()
             .unwrap_or_default(),
         service_name: service_name.clone(),
+        resources,
         secrets,
     });
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -480,7 +480,7 @@ mod tests {
             }
         });
 
-        RuntimeManager::new(path, format!("http://{}", provisioner_addr), tx)
+        RuntimeManager::new(path, format!("http://{}", provisioner_addr), None, tx)
     }
 
     #[derive(Clone)]

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -37,6 +37,7 @@ pub async fn start(
         .runtime(runtime_manager)
         .deployment_updater(persistence.clone())
         .secret_getter(persistence.clone())
+        .resource_manager(persistence.clone())
         .queue_client(GatewayClient::new(args.gateway_uri))
         .build();
 

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -24,6 +24,7 @@ async fn main() {
     let runtime_manager = RuntimeManager::new(
         args.artifacts_path.clone(),
         args.provisioner_address.uri().to_string(),
+        Some(args.auth_uri.to_string()),
         persistence.get_log_sender(),
     );
 

--- a/deployer/src/persistence/resource/mod.rs
+++ b/deployer/src/persistence/resource/mod.rs
@@ -25,10 +25,9 @@ pub struct Resource {
     pub data: serde_json::Value,
 }
 
-impl From<Resource> for shuttle_common::models::resource::Response {
+impl From<Resource> for shuttle_common::resource::Response {
     fn from(resource: Resource) -> Self {
-        shuttle_common::models::resource::Response {
-            service_id: resource.service_id,
+        shuttle_common::resource::Response {
             r#type: resource.r#type.into(),
             data: resource.data,
         }
@@ -40,10 +39,18 @@ pub enum Type {
     Database(DatabaseType),
 }
 
-impl From<Type> for shuttle_common::models::resource::Type {
+impl From<Type> for shuttle_common::resource::Type {
     fn from(r#type: Type) -> Self {
         match r#type {
             Type::Database(r#type) => Self::Database(r#type.into()),
+        }
+    }
+}
+
+impl From<shuttle_common::resource::Type> for Type {
+    fn from(r#type: shuttle_common::resource::Type) -> Self {
+        match r#type {
+            shuttle_common::resource::Type::Database(r#type) => Self::Database(r#type.into()),
         }
     }
 }

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -33,6 +33,7 @@ pub struct RuntimeManager {
     runtimes: Runtimes,
     artifacts_path: PathBuf,
     provisioner_address: String,
+    auth_uri: Option<String>,
     log_sender: crossbeam_channel::Sender<deploy_layer::Log>,
 }
 
@@ -40,12 +41,14 @@ impl RuntimeManager {
     pub fn new(
         artifacts_path: PathBuf,
         provisioner_address: String,
+        auth_uri: Option<String>,
         log_sender: crossbeam_channel::Sender<deploy_layer::Log>,
     ) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
             runtimes: Default::default(),
             artifacts_path,
             provisioner_address,
+            auth_uri,
             log_sender,
         }))
     }
@@ -108,6 +111,7 @@ impl RuntimeManager {
             is_next,
             runtime::StorageManagerType::Artifacts(self.artifacts_path.clone()),
             &self.provisioner_address,
+            self.auth_uri.as_ref(),
             port,
             get_runtime_executable,
         )

--- a/e2e/tests/integration/helpers/mod.rs
+++ b/e2e/tests/integration/helpers/mod.rs
@@ -38,13 +38,29 @@ impl TempCargoHome {
                 write!(
                     config,
                     r#"[patch.crates-io]
-shuttle-service = {{ path = "{}" }}
-shuttle-aws-rds = {{ path = "{}" }}
-shuttle-persist = {{ path = "{}" }}
-shuttle-shared-db = {{ path = "{}" }}
-shuttle-secrets = {{ path = "{}" }}
-shuttle-static-folder = {{ path = "{}" }}"#,
+shuttle-service = { path = "{}" }
+shuttle-runtime = { path = "{}" }
+
+shuttle-aws-rds = { path = "{}" }
+shuttle-persist = { path = "{}" }
+shuttle-shared-db = { path = "{}" }
+shuttle-secrets = { path = "{}" }
+shuttle-static-folder = { path = "{}" }
+
+shuttle-axum = { path = "{}" }
+shuttle-actix-web = { path = "{}" }
+shuttle-next = { path = "{}" }
+shuttle-poem = { path = "{}" }
+shuttle-poise = { path = "{}" }
+shuttle-rocket = { path = "{}" }
+shuttle-salvo = { path = "{}" }
+shuttle-serenity = { path = "{}" }
+shuttle-thruster = { path = "{}" }
+shuttle-tide = { path = "{}" }
+shuttle-tower = { path = "{}" }
+shuttle-warp = { path = "{}" }"#,
                     WORKSPACE_ROOT.join("service").display(),
+                    WORKSPACE_ROOT.join("runtime").display(),
                     WORKSPACE_ROOT.join("resources").join("aws-rds").display(),
                     WORKSPACE_ROOT.join("resources").join("persist").display(),
                     WORKSPACE_ROOT.join("resources").join("shared-db").display(),
@@ -52,6 +68,54 @@ shuttle-static-folder = {{ path = "{}" }}"#,
                     WORKSPACE_ROOT
                         .join("resources")
                         .join("static-folder")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-axum")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-actix-web")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-next")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-poem")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-poise")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-rocket")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-salvo")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-serenity")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-thruster")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-tide")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-tower")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("services")
+                        .join("shuttle-warp")
                         .display(),
                 )
                 .unwrap();

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -717,7 +717,7 @@ impl ProjectCreating {
                         auth_uri,
                     ],
                     "Env": [
-                        "RUST_LOG=debug,shuttle=trace",
+                        "RUST_LOG=debug,shuttle=trace,h2=warn",
                     ]
                 })
             });

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -15,11 +15,12 @@ prost = "0.11.2"
 prost-types = { workspace = true }
 tokio = { version = "1.22.0", features = ["process"] }
 tonic = { workspace = true }
+tower = { workspace = true }
 tracing = { workspace = true }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["error", "service", "wasm"]
+features = ["claims", "error", "service", "wasm"]
 
 [build-dependencies]
 tonic-build = "0.8.3"

--- a/proto/runtime.proto
+++ b/proto/runtime.proto
@@ -36,6 +36,8 @@ message LoadResponse {
   bool success = 1;
   // Error message if not successful
   string message = 2;
+  // Which resources where requested
+  repeated bytes resources = 10;
 }
 
 message StartRequest {

--- a/proto/runtime.proto
+++ b/proto/runtime.proto
@@ -27,8 +27,11 @@ message LoadRequest {
   // Path to compiled file to load for service
   string path = 2;
 
+  // A cache of resource details to use instead when asked
+  repeated bytes resources = 10;
+
   // Secrets that belong to this deployment
-  map<string, string> secrets = 10;
+  map<string, string> secrets = 20;
 }
 
 message LoadResponse {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -210,6 +210,7 @@ pub mod runtime {
         wasm: bool,
         storage_manager_type: StorageManagerType,
         provisioner_address: &str,
+        auth_uri: Option<&String>,
         port: u16,
         get_runtime_executable: impl FnOnce() -> PathBuf,
     ) -> anyhow::Result<(
@@ -228,7 +229,7 @@ pub mod runtime {
         let args = if wasm {
             vec!["--port", port]
         } else {
-            vec![
+            let mut args = vec![
                 "--port",
                 port,
                 "--provisioner-address",
@@ -237,7 +238,13 @@ pub mod runtime {
                 storage_manager_type,
                 "--storage-manager-path",
                 storage_manager_path,
-            ]
+            ];
+
+            if let Some(auth_uri) = auth_uri {
+                args.append(&mut vec!["--auth-uri", auth_uri]);
+            }
+
+            args
         };
 
         let runtime = process::Command::new(runtime_executable_path)

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -106,7 +106,7 @@ pub mod runtime {
     use prost_types::Timestamp;
     use shuttle_common::{
         claims::{ClaimLayer, ClaimService, InjectPropagation, InjectPropagationLayer},
-        database, ParseError,
+        ParseError,
     };
     use tokio::process;
     use tonic::transport::{Channel, Endpoint};

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -41,7 +41,7 @@ wasmtime-wasi = { version = "4.0.0", optional = true }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["claims"]
+features = ["claims", "backend"]
 
 [dependencies.shuttle-proto]
 workspace = true

--- a/runtime/src/alpha/args.rs
+++ b/runtime/src/alpha/args.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use tonic::transport::Endpoint;
+use tonic::transport::{Endpoint, Uri};
 
 #[derive(Parser, Debug)]
 #[command(version)]
@@ -21,6 +21,10 @@ pub struct Args {
     /// Path to use for storage manager
     #[arg(long)]
     pub storage_manager_path: PathBuf,
+
+    /// Address to reach the authentication service at
+    #[arg(long, default_value = "http://127.0.0.1:8008")]
+    pub auth_uri: Uri,
 }
 
 #[derive(Clone, Debug, ValueEnum)]

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -171,6 +171,7 @@ where
 
         let LoadRequest {
             path,
+            resources,
             secrets,
             service_name,
         } = request.into_inner();
@@ -195,7 +196,12 @@ where
         let service_name = ServiceName::from_str(service_name.as_str())
             .map_err(|err| Status::from_error(Box::new(err)))?;
 
-        let resources: Arc<tokio::sync::Mutex<Vec<resource::Response>>> = Default::default();
+        let resources = resources
+            .into_iter()
+            .map(resource::Response::from_bytes)
+            .collect();
+        let resources: Arc<tokio::sync::Mutex<Vec<resource::Response>>> =
+            Arc::new(tokio::sync::Mutex::new(resources));
 
         let factory = ProvisionerFactory::new(
             provisioner_client,

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -92,6 +92,7 @@ impl Runtime for AxumWasm {
         let message = LoadResponse {
             success: true,
             message: String::new(),
+            resources: Vec::new(),
         };
 
         Ok(tonic::Response::new(message))

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -6,6 +6,7 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
+use shuttle_common::claims::{ClaimService, InjectPropagation};
 use shuttle_proto::{
     provisioner::{
         provisioner_server::{Provisioner, ProvisionerServer},
@@ -20,7 +21,7 @@ use tonic::{
 };
 
 pub struct TestRuntime {
-    pub runtime_client: RuntimeClient<Channel>,
+    pub runtime_client: RuntimeClient<ClaimService<InjectPropagation<Channel>>>,
     pub bin_path: String,
     pub service_name: String,
     pub runtime_address: SocketAddr,

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -55,6 +55,7 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
         is_wasm,
         runtime::StorageManagerType::WorkingDir(PathBuf::from(project_path.clone())),
         &format!("http://{}", provisioner_address),
+        None,
         runtime_port,
         runtime_path,
     )

--- a/runtime/tests/integration/loader.rs
+++ b/runtime/tests/integration/loader.rs
@@ -17,6 +17,7 @@ async fn bind_panic() {
     let load_request = tonic::Request::new(LoadRequest {
         path: bin_path,
         service_name,
+        resources: Default::default(),
         secrets,
     });
 

--- a/runtime/tests/resources/axum-wasm-expanded/Cargo.toml
+++ b/runtime/tests/resources/axum-wasm-expanded/Cargo.toml
@@ -10,5 +10,5 @@ crate-type = [ "cdylib" ]
 
 [dependencies]
 futures = "0.3.25"
-shuttle-next = { path = "../../../../next" }
+shuttle-next = { path = "../../../../services/shuttle-next" }
 tracing = "0.1.37"


### PR DESCRIPTION
## Description of change
This makes a runtime use the resources given to it by deployer (when waking from idling). It also makes runtime communicate back to deployer which resources where provisioned.

Also closes ENG-252

## How Has This Been Tested (if applicable)?
Using local runners
