### PR TITLE
fix: static folder local run clearing file contents, add missing tests in cargo-shuttle

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -136,7 +136,7 @@ impl Shuttle {
                 println!("First, let's log in to your Shuttle account.");
                 self.login(args.login_args.clone()).await?;
                 println!();
-            } else if args.new && args.login_args.api_key.is_some() {
+            } else if args.login_args.api_key.is_some() {
                 self.login(args.login_args.clone()).await?;
             } else {
                 bail!("Tried to login to create a Shuttle environment, but no API key was set.")

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -138,7 +138,7 @@ impl Shuttle {
                 println!();
             } else if args.login_args.api_key.is_some() {
                 self.login(args.login_args.clone()).await?;
-            } else {
+            } else if args.new {
                 bail!("Tried to login to create a Shuttle environment, but no API key was set.")
             }
         }

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -33,8 +33,6 @@ async fn non_interactive_basic_init() {
     assert!(cargo_toml.contains("shuttle-runtime = "));
 }
 
-// TODO: unignore when shuttle-rocket is published
-#[ignore]
 #[tokio::test]
 async fn non_interactive_rocket_init() {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -57,8 +55,6 @@ async fn non_interactive_rocket_init() {
     assert_valid_rocket_project(temp_dir_path.as_path(), "rocket-init");
 }
 
-// TODO: unignore when shuttle-rocket is published
-#[ignore]
 #[test]
 fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -98,8 +94,6 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-// TODO: unignore when shuttle-rocket is published
-#[ignore]
 #[test]
 fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -135,8 +129,6 @@ fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-// TODO: unignore when shuttle-rocket is published
-#[ignore]
 #[test]
 fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
@@ -176,11 +168,10 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
 fn assert_valid_rocket_project(path: &Path, name_prefix: &str) {
     let cargo_toml = read_to_string(path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains(&format!("name = \"{name_prefix}")));
-    assert!(cargo_toml.contains("shuttle-service = { version = "));
-    assert!(cargo_toml.contains("features = [\"web-rocket\"]"));
-    assert!(cargo_toml.contains("rocket = "));
+    assert!(cargo_toml.contains("shuttle-runtime = "));
+    assert!(cargo_toml.contains("shuttle-rocket = "));
 
-    let lib_file = read_to_string(path.join("src").join("lib.rs")).unwrap();
+    let main_file = read_to_string(path.join("src").join("main.rs")).unwrap();
     let expected = indoc! {r#"
     #[macro_use]
     extern crate rocket;
@@ -190,12 +181,12 @@ fn assert_valid_rocket_project(path: &Path, name_prefix: &str) {
         "Hello, world!"
     }
 
-    #[shuttle_service::main]
-    async fn rocket() -> shuttle_service::ShuttleRocket {
+    #[shuttle_runtime::main]
+    async fn rocket() -> shuttle_rocket::ShuttleRocket {
         let rocket = rocket::build().mount("/hello", routes![index]);
 
-        Ok(rocket)
+        Ok(rocket.into())
     }"#};
 
-    assert_eq!(lib_file, expected);
+    assert_eq!(main_file, expected);
 }

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -136,14 +136,7 @@ async fn axum_static_files() {
 
     assert_eq!(request_text, "Hello, world!");
 
-    let request_text = client
-        .get(format!("{url}"))
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
+    let request_text = client.get(url).send().await.unwrap().text().await.unwrap();
 
     assert!(
         request_text.contains("This is an example of serving static files with axum and shuttle.")

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -121,6 +121,65 @@ async fn rocket_postgres() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn axum_static_files() {
+    let url = cargo_shuttle_run("../examples/axum/static-files", false).await;
+    let client = reqwest::Client::new();
+
+    let request_text = client
+        .get(format!("{url}/hello"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(request_text, "Hello, world!");
+
+    let request_text = client
+        .get(format!("{url}"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert!(
+        request_text.contains("This is an example of serving static files with axum and shuttle.")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn shuttle_next() {
+    let url = cargo_shuttle_run("../examples/next/hello-world", false).await;
+    let client = reqwest::Client::new();
+
+    let request_text = client
+        .get(format!("{url}/hello"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(request_text, "Hello, World!");
+
+    let post_text = client
+        .post(format!("{url}/uppercase"))
+        .body("uppercase this")
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert_eq!(post_text, "UPPERCASE THIS");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore]
 async fn rocket_authentication() {
     let url = cargo_shuttle_run("../examples/rocket/authentication", false).await;

--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -391,7 +391,7 @@ mod tests {
             ) -> ShuttleComplex {
                 use shuttle_runtime::Context;
                 use shuttle_runtime::tracing_subscriber::prelude::*;
-                use shuttle_runtime::ResourceBuilder;
+                use shuttle_runtime::{Factory, ResourceBuilder};
 
                 let filter_layer =
                     shuttle_runtime::tracing_subscriber::EnvFilter::try_from_default_env()
@@ -506,7 +506,7 @@ mod tests {
             ) -> ShuttleComplex {
                 use shuttle_runtime::Context;
                 use shuttle_runtime::tracing_subscriber::prelude::*;
-                use shuttle_runtime::ResourceBuilder;
+                use shuttle_runtime::{Factory, ResourceBuilder};
 
                 let filter_layer =
                     shuttle_runtime::tracing_subscriber::EnvFilter::try_from_default_env()

--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -232,7 +232,7 @@ impl ToTokens for Loader {
             None
         } else {
             Some(parse_quote!(
-                use shuttle_runtime::ResourceBuilder;
+                use shuttle_runtime::{Factory, ResourceBuilder};
             ))
         };
 

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -65,6 +65,10 @@ impl<'a> ResourceBuilder<PathBuf> for StaticFolder<'a> {
 
         trace!(output_directory = ?output_dir, "got output directory");
 
+        if output_dir.join(self.folder) == input_dir {
+            return Ok(output_dir.join(self.folder));
+        }
+
         let copy_options = CopyOptions::new().overwrite(true);
         match copy(&input_dir, &output_dir, &copy_options) {
             Ok(_) => Ok(output_dir.join(self.folder)),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -227,7 +227,7 @@ pub use logger::Logger;
 pub use next::{AxumWasm, NextArgs};
 pub use provisioner_factory::ProvisionerFactory;
 pub use shuttle_common::storage_manager::StorageManager;
-pub use shuttle_service::{main, CustomError, Error, ResourceBuilder, Service};
+pub use shuttle_service::{main, CustomError, Error, Factory, ResourceBuilder, Service};
 
 // Dependencies required by the codegen
 pub use anyhow::Context;


### PR DESCRIPTION
## Description of change

This fixes the bug where `cargo shuttle run` deletes the contents of files in the static assets folder. I also added tests to cargo shuttle for static folder and shuttle-next projects.

Additionally this PR exports `Factory` from `shuttle_runtime` and imports it in the codegen in the `extra_imports` variable, to fix a bug where the codegen was missing the `Factory` trait for static file projects.

## How Has This Been Tested (if applicable)?

Tested with local run, and added a test that runs `axum/static-files` locally.
