### PR TITLE
fix: windows local run path bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "crossterm",
  "dialoguer",
  "dirs",
+ "dunce",
  "flate2",
  "futures",
  "git2",

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -22,6 +22,7 @@ crossbeam-channel = "0.5.6"
 crossterm = "0.25.0"
 dialoguer = { version = "0.10.2", features = ["fuzzy-select"] }
 dirs = "4.0.0"
+dunce = "1.0.3"
 flate2 = "1.0.25"
 futures = "0.3.25"
 git2 = "0.14.2"

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -1,6 +1,6 @@
 use std::{
     ffi::OsString,
-    fs::{canonicalize, create_dir_all},
+    fs::create_dir_all,
     io::{self, ErrorKind},
     path::PathBuf,
 };
@@ -241,7 +241,7 @@ impl InitArgs {
 
 // Helper function to parse and return the absolute path
 fn parse_path(path: OsString) -> Result<PathBuf, String> {
-    canonicalize(&path).map_err(|e| format!("could not turn {path:?} into a real path: {e}"))
+    dunce::canonicalize(&path).map_err(|e| format!("could not turn {path:?} into a real path: {e}"))
 }
 
 // Helper function to parse, create if not exists, and return the absolute path


### PR DESCRIPTION
## Description of change

Cargo has a long-lived problem with [windows paths](https://github.com/rust-lang/cargo/issues/9770), which has affected our users on windows when doing local runs. We have dealt with this by having users `cargo build` before `cargo shuttle run`. This PR uses [dunce](https://crates.io/crates/dunce) to not use UNC paths when canonicalizing paths on windows, while it uses `std::fs::canonicalize` on other platforms.

## How Has This Been Tested (if applicable)?

Local runs with and without this fix on windows, it worked every time.
