### PR TITLE
Reference container images by full name

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile-upstream:1.4.0-rc1
 ARG RUSTUP_TOOLCHAIN
-FROM rust:${RUSTUP_TOOLCHAIN}-buster as shuttle-build
+FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-buster as shuttle-build
 RUN apt-get update &&\
     apt-get install -y curl
 

--- a/cargo-shuttle/src/provisioner_server.rs
+++ b/cargo-shuttle/src/provisioner_server.rs
@@ -328,7 +328,7 @@ fn db_type_to_config(db_type: Type) -> EngineConfig {
     match db_type {
         Type::Shared(SharedEngine::Postgres) => EngineConfig {
             r#type: "shared_postgres".to_string(),
-            image: "postgres:11".to_string(),
+            image: "docker.io/library/postgres:11".to_string(),
             engine: "postgres".to_string(),
             username: "postgres".to_string(),
             password: "postgres".to_string(),
@@ -343,7 +343,7 @@ fn db_type_to_config(db_type: Type) -> EngineConfig {
         },
         Type::Shared(SharedEngine::MongoDb) => EngineConfig {
             r#type: "shared_mongodb".to_string(),
-            image: "mongo:5.0.10".to_string(),
+            image: "docker.io/library/mongo:5.0.10".to_string(),
             engine: "mongodb".to_string(),
             username: "mongodb".to_string(),
             password: "password".to_string(),
@@ -362,7 +362,7 @@ fn db_type_to_config(db_type: Type) -> EngineConfig {
         },
         Type::AwsRds(AwsRdsEngine::Postgres) => EngineConfig {
             r#type: "aws_rds_postgres".to_string(),
-            image: "postgres:13.4".to_string(),
+            image: "docker.io/library/postgres:13.4".to_string(),
             engine: "postgres".to_string(),
             username: "postgres".to_string(),
             password: "postgres".to_string(),
@@ -377,7 +377,7 @@ fn db_type_to_config(db_type: Type) -> EngineConfig {
         },
         Type::AwsRds(AwsRdsEngine::MariaDB) => EngineConfig {
             r#type: "aws_rds_mariadb".to_string(),
-            image: "mariadb:10.6.7".to_string(),
+            image: "docker.io/library/mariadb:10.6.7".to_string(),
             engine: "mariadb".to_string(),
             username: "root".to_string(),
             password: "mariadb".to_string(),
@@ -394,7 +394,7 @@ fn db_type_to_config(db_type: Type) -> EngineConfig {
         },
         Type::AwsRds(AwsRdsEngine::MySql) => EngineConfig {
             r#type: "aws_rds_mysql".to_string(),
-            image: "mysql:8.0.28".to_string(),
+            image: "docker.io/library/mysql:8.0.28".to_string(),
             engine: "mysql".to_string(),
             username: "root".to_string(),
             password: "mysql".to_string(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
         constraints:
           - node.hostname==postgres
   mongodb:
-    image: mongo:5.0.10
+    image: docker.io/library/mongo:5.0.10
     restart: always
     networks:
       user-net:
@@ -189,7 +189,7 @@ services:
         constraints:
           - node.hostname==controller
   deck-chores:
-    image: funkyfuture/deck-chores:1
+    image: docker.io/funkyfuture/deck-chores:1
     restart: unless-stopped
     environment:
       TIMEZONE: UTC

--- a/extras/otel/Containerfile
+++ b/extras/otel/Containerfile
@@ -1,6 +1,6 @@
 ARG OTEL_TAG=
 
-FROM otel/opentelemetry-collector-contrib:${OTEL_TAG}
+FROM docker.io/otel/opentelemetry-collector-contrib:${OTEL_TAG}
 
 COPY otel-collector-config.yaml /etc/otel-collector-config.yaml
 

--- a/extras/panamax/Containerfile
+++ b/extras/panamax/Containerfile
@@ -1,6 +1,6 @@
 ARG PANAMAX_TAG=
 
-FROM panamaxrs/panamax:${PANAMAX_TAG}
+FROM docker.io/panamaxrs/panamax:${PANAMAX_TAG}
 
 COPY mirror.toml /mirror/mirror.toml
 

--- a/extras/postgres/Containerfile
+++ b/extras/postgres/Containerfile
@@ -1,6 +1,6 @@
 ARG POSTGRES_TAG=
 
-FROM postgres:${POSTGRES_TAG}
+FROM docker.io/postgres:${POSTGRES_TAG}
 
 RUN apt-get update &&\
     apt-get install --yes curl python3 python3-aiohttp

--- a/provisioner/tests/helpers.rs
+++ b/provisioner/tests/helpers.rs
@@ -99,7 +99,7 @@ impl From<DbType> for Config<'_> {
         match db_type {
             DbType::Postgres => Config {
                 container_name: PG_CONTAINER_NAME,
-                image: "postgres:11",
+                image: "docker.io/library/postgres:11",
                 engine: "postgres",
                 port: "5432",
                 env: vec!["POSTGRES_PASSWORD=password"],
@@ -107,7 +107,7 @@ impl From<DbType> for Config<'_> {
             },
             DbType::MongoDb => Config {
                 container_name: MONGODB_CONTAINER_NAME,
-                image: "mongo:5.0.10",
+                image: "docker.io/library/mongo:5.0.10",
                 engine: "mongodb",
                 port: "27017",
                 env: vec![


### PR DESCRIPTION
This is useful for users of Podman, which isn't configured out-of-the-box to use the `docker.io` registry. It's also a good security practice, in case of a misconfigured default registry.