### PR TITLE
bug: next runtime not sending stop signal

### DIFF
--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -60,15 +60,25 @@ pub async fn task(
             active_deployment_getter.clone(),
             runtime_manager.clone(),
         );
-        let cleanup = move |response: SubscribeStopResponse| {
+        let cleanup = move |response: Option<SubscribeStopResponse>| {
             debug!(response = ?response,  "stop client response: ");
 
-            match StopReason::from_i32(response.reason).unwrap_or_default() {
-                StopReason::Request => stopped_cleanup(&id),
-                StopReason::End => completed_cleanup(&id),
-                StopReason::Crash => {
-                    crashed_cleanup(&id, Error::Run(anyhow::Error::msg(response.message).into()))
+            if let Some(response) = response {
+                match StopReason::from_i32(response.reason).unwrap_or_default() {
+                    StopReason::Request => stopped_cleanup(&id),
+                    StopReason::End => completed_cleanup(&id),
+                    StopReason::Crash => crashed_cleanup(
+                        &id,
+                        Error::Run(anyhow::Error::msg(response.message).into()),
+                    ),
                 }
+            } else {
+                crashed_cleanup(
+                    &id,
+                    Error::Runtime(anyhow::anyhow!(
+                        "stop subscribe channel stopped unexpectedly"
+                    )),
+                )
             }
         };
         let runtime_manager = runtime_manager.clone();
@@ -188,7 +198,7 @@ impl Built {
         runtime_manager: Arc<Mutex<RuntimeManager>>,
         deployment_updater: impl DeploymentUpdater,
         kill_old_deployments: impl futures::Future<Output = Result<()>>,
-        cleanup: impl FnOnce(SubscribeStopResponse) + Send + 'static,
+        cleanup: impl FnOnce(Option<SubscribeStopResponse>) + Send + 'static,
     ) -> Result<()> {
         // For alpha this is the path to the users project with an embedded runtime.
         // For shuttle-next this is the path to the compiled .wasm file, which will be
@@ -343,7 +353,7 @@ async fn run(
     mut runtime_client: RuntimeClient<ClaimService<InjectPropagation<Channel>>>,
     address: SocketAddr,
     deployment_updater: impl DeploymentUpdater,
-    cleanup: impl FnOnce(SubscribeStopResponse) + Send + 'static,
+    cleanup: impl FnOnce(Option<SubscribeStopResponse>) + Send + 'static,
 ) {
     deployment_updater
         .set_address(&id, &address)
@@ -369,15 +379,15 @@ async fn run(
             info!(response = ?response.into_inner(),  "start client response: ");
 
             // Wait for stop reason
-            let reason = stream.message().await.unwrap().unwrap();
+            let reason = stream.message().await.unwrap();
 
             cleanup(reason);
         }
         Err(ref status) if status.code() == Code::InvalidArgument => {
-            cleanup(SubscribeStopResponse {
+            cleanup(Some(SubscribeStopResponse {
                 reason: StopReason::Crash as i32,
                 message: status.to_string(),
-            });
+            }));
         }
         Err(ref status) => {
             start_crashed_cleanup(
@@ -534,12 +544,15 @@ mod tests {
         let runtime_manager = get_runtime_manager();
         let (cleanup_send, cleanup_recv) = oneshot::channel();
 
-        let handle_cleanup = |response: SubscribeStopResponse| match (
-            StopReason::from_i32(response.reason).unwrap(),
-            response.message,
-        ) {
-            (StopReason::Request, mes) if mes.is_empty() => cleanup_send.send(()).unwrap(),
-            _ => panic!("expected stop due to request"),
+        let handle_cleanup = |response: Option<SubscribeStopResponse>| {
+            let response = response.unwrap();
+            match (
+                StopReason::from_i32(response.reason).unwrap(),
+                response.message,
+            ) {
+                (StopReason::Request, mes) if mes.is_empty() => cleanup_send.send(()).unwrap(),
+                _ => panic!("expected stop due to request"),
+            }
         };
 
         built
@@ -574,12 +587,15 @@ mod tests {
         let runtime_manager = get_runtime_manager();
         let (cleanup_send, cleanup_recv) = oneshot::channel();
 
-        let handle_cleanup = |response: SubscribeStopResponse| match (
-            StopReason::from_i32(response.reason).unwrap(),
-            response.message,
-        ) {
-            (StopReason::End, mes) if mes.is_empty() => cleanup_send.send(()).unwrap(),
-            _ => panic!("expected stop due to self end"),
+        let handle_cleanup = |response: Option<SubscribeStopResponse>| {
+            let response = response.unwrap();
+            match (
+                StopReason::from_i32(response.reason).unwrap(),
+                response.message,
+            ) {
+                (StopReason::End, mes) if mes.is_empty() => cleanup_send.send(()).unwrap(),
+                _ => panic!("expected stop due to self end"),
+            }
         };
 
         built
@@ -611,14 +627,17 @@ mod tests {
         let runtime_manager = get_runtime_manager();
         let (cleanup_send, cleanup_recv) = oneshot::channel();
 
-        let handle_cleanup = |response: SubscribeStopResponse| match (
-            StopReason::from_i32(response.reason).unwrap(),
-            response.message,
-        ) {
-            (StopReason::Crash, mes) if mes.contains("panic in bind") => {
-                cleanup_send.send(()).unwrap()
+        let handle_cleanup = |response: Option<SubscribeStopResponse>| {
+            let response = response.unwrap();
+            match (
+                StopReason::from_i32(response.reason).unwrap(),
+                response.message,
+            ) {
+                (StopReason::Crash, mes) if mes.contains("panic in bind") => {
+                    cleanup_send.send(()).unwrap()
+                }
+                (_, mes) => panic!("expected stop due to crash: {mes}"),
             }
-            (_, mes) => panic!("expected stop due to crash: {mes}"),
         };
 
         built

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -154,6 +154,8 @@ impl RuntimeManager {
             let stop_request = tonic::Request::new(StopRequest {});
             let response = runtime_client.stop(stop_request).await.unwrap();
 
+            trace!(?response, "stop deployment response");
+
             let result = response.into_inner().success;
             let _ = process.start_kill();
 

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -42,7 +42,7 @@ use tonic::{
     Request, Response, Status,
 };
 use tower::ServiceBuilder;
-use tracing::{error, info, trace};
+use tracing::{error, info, trace, warn};
 
 use crate::{provisioner_factory::ProvisionerFactory, Logger};
 
@@ -378,7 +378,9 @@ where
 
             Ok(Response::new(StopResponse { success: true }))
         } else {
-            Err(Status::internal("failed to stop deployment"))
+            warn!("failed to stop deployment");
+
+            Ok(tonic::Response::new(StopResponse { success: false }))
         }
     }
 


### PR DESCRIPTION
## Description of change
Fixes the next runtime that missed an implementation for the stop subscriber

## How Has This Been Tested (if applicable)?
Fails locally currently.
