### PR TITLE
feat: admin command to destroy projects

### DIFF
--- a/admin/src/args.rs
+++ b/admin/src/args.rs
@@ -18,6 +18,9 @@ pub enum Command {
     /// Try to revive projects in the crashed state
     Revive,
 
+    /// Destroy all the current running projects
+    Destroy,
+
     /// Manage custom domains
     #[command(subcommand)]
     Acme(AcmeCommand),

--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -20,6 +20,10 @@ impl Client {
         self.post("/admin/revive", Option::<String>::None).await
     }
 
+    pub async fn destroy(&self) -> Result<String> {
+        self.post("/admin/destroy", Option::<String>::None).await
+    }
+
     pub async fn acme_account_create(
         &self,
         email: &str,

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -24,6 +24,7 @@ async fn main() {
 
     let res = match args.command {
         Command::Revive => client.revive().await.expect("revive to succeed"),
+        Command::Destroy => client.destroy().await.expect("destroy to succeed"),
         Command::Acme(AcmeCommand::CreateAccount { email, acme_server }) => {
             let account = client
                 .acme_account_create(&email, acme_server)

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -299,6 +299,17 @@ async fn revive_projects(
         .map_err(|_| Error::from_kind(ErrorKind::Internal))
 }
 
+#[instrument(skip_all)]
+async fn destroy_projects(
+    State(RouterState {
+        service, sender, ..
+    }): State<RouterState>,
+) -> Result<(), Error> {
+    crate::project::exec::destroy(service, sender)
+        .await
+        .map_err(|_| Error::from_kind(ErrorKind::Internal))
+}
+
 #[instrument(skip_all, fields(%email, ?acme_server))]
 async fn create_acme_account(
     Extension(acme_client): Extension<AcmeClient>,
@@ -498,6 +509,10 @@ impl ApiBuilder {
             .route(
                 "/admin/revive",
                 post(revive_projects.layer(ScopedLayer::new(vec![Scope::Admin]))),
+            )
+            .route(
+                "/admin/destroy",
+                post(destroy_projects.layer(ScopedLayer::new(vec![Scope::Admin]))),
             )
             .route(
                 "/admin/stats/load",

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -1611,6 +1611,26 @@ pub mod exec {
 
         Ok(())
     }
+
+    pub async fn destroy(
+        gateway: Arc<GatewayService>,
+        sender: Sender<BoxedTask>,
+    ) -> Result<(), ProjectError> {
+        for (project_name, _) in gateway
+            .iter_projects()
+            .await
+            .expect("could not list projects")
+        {
+            let _ = gateway
+                .new_task()
+                .project(project_name)
+                .and_then(task::destroy())
+                .send(&sender)
+                .await;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of change
An extra admin command to destroy old projects which we need to force all users to upgrade

## How Has This Been Tested (if applicable)?
Using the local docker runs
