### PR TITLE
refactor: switch to resource endpoint

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -53,6 +53,9 @@ pub enum Command {
     /// manage deployments of a shuttle service
     #[command(subcommand)]
     Deployment(DeploymentCommand),
+    /// manage resources of a shuttle project
+    #[command(subcommand)]
+    Resource(ResourceCommand),
     /// create a new shuttle service
     Init(InitArgs),
     /// generate shell completions
@@ -103,6 +106,12 @@ pub enum DeploymentCommand {
         /// ID of deployment to get status for
         id: Uuid,
     },
+}
+
+#[derive(Parser)]
+pub enum ResourceCommand {
+    /// list all the resources for a project
+    List,
 }
 
 #[derive(Parser)]

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -9,7 +9,7 @@ use reqwest_retry::RetryTransientMiddleware;
 use serde::{Deserialize, Serialize};
 use shuttle_common::models::{deployment, project, secret, service, ToJson};
 use shuttle_common::project::ProjectName;
-use shuttle_common::{ApiKey, ApiUrl, LogItem};
+use shuttle_common::{resource, ApiKey, ApiUrl, LogItem};
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
@@ -75,7 +75,7 @@ impl Client {
         self.delete(path).await
     }
 
-    pub async fn get_service_details(&self, project: &ProjectName) -> Result<service::Detailed> {
+    pub async fn get_service(&self, project: &ProjectName) -> Result<service::Summary> {
         let path = format!(
             "/projects/{}/services/{}",
             project.as_str(),
@@ -85,9 +85,12 @@ impl Client {
         self.get(path).await
     }
 
-    pub async fn get_service_summary(&self, project: &ProjectName) -> Result<service::Summary> {
+    pub async fn get_service_resources(
+        &self,
+        project: &ProjectName,
+    ) -> Result<Vec<resource::Response>> {
         let path = format!(
-            "/projects/{}/services/{}/summary",
+            "/projects/{}/services/{}/resources",
             project.as_str(),
             project.as_str()
         );
@@ -182,6 +185,15 @@ impl Client {
         );
 
         self.ws_get(path).await
+    }
+
+    pub async fn get_deployments(
+        &self,
+        project: &ProjectName,
+    ) -> Result<Vec<deployment::Response>> {
+        let path = format!("/projects/{}/deployments", project.as_str());
+
+        self.get(path).await
     }
 
     pub async fn get_deployment_details(

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,6 +54,13 @@ pub enum ParseError {
     Serde(#[from] serde_json::Error),
 }
 
+/// Holds the output for a DB resource
+#[derive(Deserialize, Serialize)]
+pub enum DbOutput {
+    Info(DatabaseReadyInfo),
+    Local(String),
+}
+
 /// Holds the details for a database connection
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabaseReadyInfo {

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod deployment;
 pub mod error;
 pub mod project;
+pub mod resource;
 pub mod secret;
 pub mod service;
 pub mod stats;

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -1,0 +1,151 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use comfy_table::{
+    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, CellAlignment, ContentArrangement,
+    Table,
+};
+use crossterm::style::Stylize;
+
+use crate::{
+    resource::{Response, Type},
+    DbOutput, SecretStore,
+};
+
+pub fn get_resources_table(resources: &Vec<Response>) -> String {
+    if resources.is_empty() {
+        format!("{}\n", "No resources are linked to this service".bold())
+    } else {
+        let resource_groups = resources.iter().fold(HashMap::new(), |mut acc, x| {
+            let title = match x.r#type {
+                Type::Database(_) => "Databases",
+                Type::Secrets => "Secrets",
+                Type::StaticFolder => "Static Folder",
+                Type::Persist => "Persist",
+            };
+
+            let elements = acc.entry(title).or_insert(Vec::new());
+            elements.push(x);
+
+            acc
+        });
+
+        let mut output = Vec::new();
+
+        if let Some(databases) = resource_groups.get("Databases") {
+            output.push(get_databases_table(databases));
+        };
+
+        if let Some(secrets) = resource_groups.get("Secrets") {
+            output.push(get_secrets_table(secrets));
+        };
+
+        if let Some(static_folders) = resource_groups.get("Static Folder") {
+            output.push(get_static_folder_table(static_folders));
+        };
+
+        if let Some(persist) = resource_groups.get("Persist") {
+            output.push(get_persist_table(persist));
+        };
+
+        output.join("\n")
+    }
+}
+
+fn get_databases_table(databases: &Vec<&Response>) -> String {
+    let mut table = Table::new();
+
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+        .set_header(vec![
+            Cell::new("Type").set_alignment(CellAlignment::Center),
+            Cell::new("Connection string").set_alignment(CellAlignment::Center),
+        ]);
+
+    for database in databases {
+        let info = serde_json::from_value::<DbOutput>(database.data.clone()).unwrap();
+        let connection_string = match info {
+            DbOutput::Local(local_uri) => local_uri.clone(),
+            DbOutput::Info(info) => info.connection_string_public(),
+        };
+
+        table.add_row(vec![database.r#type.to_string(), connection_string]);
+    }
+
+    format!(
+        r#"These databases are linked to this service
+{table}
+"#,
+    )
+}
+
+fn get_secrets_table(secrets: &[&Response]) -> String {
+    let mut table = Table::new();
+
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![Cell::new("Key").set_alignment(CellAlignment::Center)]);
+
+    let secrets = serde_json::from_value::<SecretStore>(secrets[0].data.clone()).unwrap();
+
+    for key in secrets.secrets.keys() {
+        table.add_row(vec![key]);
+    }
+
+    format!(
+        r#"These secrets can be accessed by the service
+{table}
+"#,
+    )
+}
+
+fn get_static_folder_table(static_folders: &[&Response]) -> String {
+    let mut table = Table::new();
+
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+        .set_header(vec![
+            Cell::new("Static Folders").set_alignment(CellAlignment::Center)
+        ]);
+
+    for folder in static_folders {
+        let path = serde_json::from_value::<PathBuf>(folder.data.clone())
+            .unwrap()
+            .display()
+            .to_string();
+
+        table.add_row(vec![path]);
+    }
+
+    format!(
+        r#"These static folders can be accessed by the service
+{table}
+"#,
+    )
+}
+
+fn get_persist_table(persist_instances: &[&Response]) -> String {
+    let mut table = Table::new();
+
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+        .set_header(vec![
+            Cell::new("Persist Instances").set_alignment(CellAlignment::Center)
+        ]);
+
+    for _ in persist_instances {
+        table.add_row(vec!["Instance"]);
+    }
+
+    format!(
+        r#"These instances are linked to this service
+{table}
+"#,
+    )
+}

--- a/common/src/models/service.rs
+++ b/common/src/models/service.rs
@@ -1,16 +1,8 @@
-use crate::{
-    models::{deployment, secret},
-    resource::{self, Type},
-    DatabaseReadyInfo, SecretStore,
-};
+use crate::models::deployment;
 
-use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, CellAlignment, ContentArrangement,
-    Table,
-};
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, path::PathBuf};
+use std::fmt::Display;
 use uuid::Uuid;
 
 #[derive(Deserialize, Serialize)]
@@ -20,29 +12,10 @@ pub struct Response {
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct Detailed {
-    pub name: String,
-    pub deployments: Vec<deployment::Response>,
-    pub resources: Vec<resource::Response>,
-    pub secrets: Vec<secret::Response>,
-}
-
-#[derive(Deserialize, Serialize)]
 pub struct Summary {
     pub name: String,
     pub deployment: Option<deployment::Response>,
-    pub resources: Vec<resource::Response>,
     pub uri: String,
-}
-
-impl Display for Detailed {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let deploys = get_deployments_table(&self.deployments, &self.name);
-        let resources = get_resources_table(&self.resources);
-        let secrets = secret::get_table(&self.secrets);
-
-        write!(f, "{deploys}{resources}{secrets}")
-    }
 }
 
 impl Display for Summary {
@@ -55,7 +28,6 @@ Deployment ID: {}
 Status:        {}
 Last Updated:  {}
 URI:           {}
-
 "#,
                 self.name,
                 deployment.id,
@@ -75,187 +47,6 @@ URI:           {}
             )
         };
 
-        let resources = get_resources_table(&self.resources);
-
-        write!(f, "{deployment}{resources}")
+        write!(f, "{deployment}")
     }
-}
-
-fn get_deployments_table(deployments: &Vec<deployment::Response>, service_name: &str) -> String {
-    if deployments.is_empty() {
-        format!(
-            "{}\n",
-            "No deployments are linked to this service".yellow().bold()
-        )
-    } else {
-        let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .apply_modifier(UTF8_ROUND_CORNERS)
-            .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-            .set_header(vec![
-                Cell::new("ID").set_alignment(CellAlignment::Center),
-                Cell::new("Status").set_alignment(CellAlignment::Center),
-                Cell::new("Last updated").set_alignment(CellAlignment::Center),
-            ]);
-
-        for deploy in deployments.iter() {
-            table.add_row(vec![
-                Cell::new(deploy.id),
-                Cell::new(&deploy.state)
-                    .fg(deploy.state.get_color())
-                    .set_alignment(CellAlignment::Center),
-                Cell::new(deploy.last_update.format("%Y-%m-%dT%H:%M:%SZ"))
-                    .set_alignment(CellAlignment::Center),
-            ]);
-        }
-
-        format!(
-            r#"
-Most recent deploys for {}
-{}
-
-"#,
-            service_name.bold(),
-            table,
-        )
-    }
-}
-
-pub fn get_resources_table(resources: &Vec<resource::Response>) -> String {
-    if resources.is_empty() {
-        format!("{}\n", "No resources are linked to this service".bold())
-    } else {
-        let resource_groups = resources.iter().fold(HashMap::new(), |mut acc, x| {
-            let title = match x.r#type {
-                Type::Database(_) => "Databases",
-                Type::Secrets => "Secrets",
-                Type::StaticFolder => "Static Folder",
-                Type::Persist => "Persist",
-            };
-
-            let elements = acc.entry(title).or_insert(Vec::new());
-            elements.push(x);
-
-            acc
-        });
-
-        let mut output = Vec::new();
-
-        if let Some(databases) = resource_groups.get("Databases") {
-            output.push(get_databases_table(databases));
-        };
-
-        if let Some(secrets) = resource_groups.get("Secrets") {
-            output.push(get_secrets_table(secrets));
-        };
-
-        if let Some(static_folders) = resource_groups.get("Static Folder") {
-            output.push(get_static_folder_table(static_folders));
-        };
-
-        if let Some(persist) = resource_groups.get("Persist") {
-            output.push(get_persist_table(persist));
-        };
-
-        output.join("\n")
-    }
-}
-
-fn get_databases_table(databases: &Vec<&resource::Response>) -> String {
-    let mut table = Table::new();
-
-    table
-        .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("Type").set_alignment(CellAlignment::Center),
-            Cell::new("Connection string").set_alignment(CellAlignment::Center),
-        ]);
-
-    for database in databases {
-        let info = serde_json::from_value::<DatabaseReadyInfo>(database.data.clone()).unwrap();
-
-        table.add_row(vec![
-            database.r#type.to_string(),
-            info.connection_string_public(),
-        ]);
-    }
-
-    format!(
-        r#"These databases are linked to this service
-{table}
-"#,
-    )
-}
-
-fn get_secrets_table(secrets: &[&resource::Response]) -> String {
-    let mut table = Table::new();
-
-    table
-        .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(vec![Cell::new("Key").set_alignment(CellAlignment::Center)]);
-
-    let secrets = serde_json::from_value::<SecretStore>(secrets[0].data.clone()).unwrap();
-
-    for key in secrets.secrets.keys() {
-        table.add_row(vec![key]);
-    }
-
-    format!(
-        r#"These secrets can be accessed by the service
-{table}
-"#,
-    )
-}
-
-fn get_static_folder_table(static_folders: &[&resource::Response]) -> String {
-    let mut table = Table::new();
-
-    table
-        .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("Static Folders").set_alignment(CellAlignment::Center)
-        ]);
-
-    for folder in static_folders {
-        let path = serde_json::from_value::<PathBuf>(folder.data.clone())
-            .unwrap()
-            .display()
-            .to_string();
-
-        table.add_row(vec![path]);
-    }
-
-    format!(
-        r#"These static folders can be accessed by the service
-{table}
-"#,
-    )
-}
-
-fn get_persist_table(persist_instances: &[&resource::Response]) -> String {
-    let mut table = Table::new();
-
-    table
-        .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("Persist Instances").set_alignment(CellAlignment::Center)
-        ]);
-
-    for _ in persist_instances {
-        table.add_row(vec!["Instance"]);
-    }
-
-    format!(
-        r#"These instances are linked to this service
-{table}
-"#,
-    )
 }

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -55,12 +55,12 @@ pub async fn make_router(
                 .delete(stop_service.layer(ScopedLayer::new(vec![Scope::ServiceCreate]))),
         )
         .route(
-            "/projects/:project_name/services/:service_name/summary",
-            get(get_service_summary).layer(ScopedLayer::new(vec![Scope::Service])),
-        )
-        .route(
             "/projects/:project_name/services/:service_name/resources",
             get(get_service_resources).layer(ScopedLayer::new(vec![Scope::Resources])),
+        )
+        .route(
+            "/projects/:project_name/deployments",
+            get(get_deployments).layer(ScopedLayer::new(vec![Scope::Service])),
         )
         .route(
             "/projects/:project_name/deployments/:deployment_id",
@@ -127,46 +127,8 @@ async fn list_services(
     Ok(Json(services))
 }
 
-#[instrument(skip(persistence))]
-async fn get_service(
-    Extension(persistence): Extension<Persistence>,
-    Path((project_name, service_name)): Path<(String, String)>,
-) -> Result<Json<shuttle_common::models::service::Detailed>> {
-    if let Some(service) = persistence.get_service_by_name(&service_name).await? {
-        let deployments = persistence
-            .get_deployments(&service.id)
-            .await?
-            .into_iter()
-            .map(Into::into)
-            .collect();
-        let resources = persistence
-            .get_resources(&service.id)
-            .await?
-            .into_iter()
-            .map(Into::into)
-            .collect();
-        let secrets = persistence
-            .get_secrets(&service.id)
-            .await?
-            .into_iter()
-            .map(Into::into)
-            .collect();
-
-        let response = shuttle_common::models::service::Detailed {
-            name: service.name,
-            deployments,
-            resources,
-            secrets,
-        };
-
-        Ok(Json(response))
-    } else {
-        Err(Error::NotFound)
-    }
-}
-
 #[instrument(skip_all, fields(%project_name, %service_name))]
-async fn get_service_summary(
+async fn get_service(
     Extension(persistence): Extension<Persistence>,
     Extension(proxy_fqdn): Extension<FQDN>,
     Path((project_name, service_name)): Path<(String, String)>,
@@ -176,18 +138,11 @@ async fn get_service_summary(
             .get_active_deployment(&service.id)
             .await?
             .map(Into::into);
-        let resources = persistence
-            .get_resources(&service.id)
-            .await?
-            .into_iter()
-            .map(Into::into)
-            .collect();
 
         let response = shuttle_common::models::service::Summary {
             uri: format!("https://{proxy_fqdn}"),
             name: service.name,
             deployment,
-            resources,
         };
 
         Ok(Json(response))
@@ -277,21 +232,32 @@ async fn stop_service(
             return Err(Error::NotFound);
         }
 
-        let resources = persistence
-            .get_resources(&service.id)
+        let response = shuttle_common::models::service::Summary {
+            name: service.name,
+            deployment: running_deployment.map(Into::into),
+            uri: format!("https://{proxy_fqdn}"),
+        };
+
+        Ok(Json(response))
+    } else {
+        Err(Error::NotFound)
+    }
+}
+
+#[instrument(skip(persistence))]
+async fn get_deployments(
+    Extension(persistence): Extension<Persistence>,
+    Path(project_name): Path<String>,
+) -> Result<Json<Vec<shuttle_common::models::deployment::Response>>> {
+    if let Some(service) = persistence.get_service_by_name(&project_name).await? {
+        let deployments = persistence
+            .get_deployments(&service.id)
             .await?
             .into_iter()
             .map(Into::into)
             .collect();
 
-        let response = shuttle_common::models::service::Summary {
-            name: service.name,
-            deployment: running_deployment.map(Into::into),
-            resources,
-            uri: format!("https://{proxy_fqdn}"),
-        };
-
-        Ok(Json(response))
+        Ok(Json(deployments))
     } else {
         Err(Error::NotFound)
     }

--- a/resources/shared-db/src/lib.rs
+++ b/resources/shared-db/src/lib.rs
@@ -10,11 +10,3 @@ mod postgres;
 
 #[cfg(feature = "postgres")]
 pub use postgres::Postgres;
-
-use serde::{Deserialize, Serialize};
-
-#[derive(Deserialize, Serialize)]
-pub enum SharedDbOutput {
-    Shared(shuttle_service::DatabaseReadyInfo),
-    Local(String),
-}

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -8,7 +8,7 @@ pub mod error;
 pub use error::{CustomError, Error};
 
 use serde::{de::DeserializeOwned, Serialize};
-pub use shuttle_common::{database, resource::Type, DatabaseReadyInfo, SecretStore};
+pub use shuttle_common::{database, resource::Type, DatabaseReadyInfo, DbOutput, SecretStore};
 
 #[cfg(feature = "codegen")]
 extern crate shuttle_codegen;


### PR DESCRIPTION
## Description of change
This switches the CLI to use the new resources API. It also trims some extra fluff from the other API endpoints.

## How Has This Been Tested (if applicable)?
By running deployer locally
