### PR TITLE
fix: unknown resource type

### DIFF
--- a/deployer/src/persistence/resource/mod.rs
+++ b/deployer/src/persistence/resource/mod.rs
@@ -71,7 +71,7 @@ impl Display for Type {
         match self {
             Type::Database(db_type) => write!(f, "database::{db_type}"),
             Type::Secrets => write!(f, "secrets"),
-            Type::StaticFolder => write!(f, "static folder"),
+            Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
         }
     }
@@ -87,7 +87,12 @@ impl FromStr for Type {
                 _ => Err(format!("'{prefix}' is an unknown resource type")),
             }
         } else {
-            Err(format!("'{s}' is an unknown resource type"))
+            match s {
+                "secrets" => Ok(Self::Secrets),
+                "static_folder" => Ok(Self::StaticFolder),
+                "persist" => Ok(Self::Persist),
+                _ => Err(format!("'{s}' is an unknown resource type")),
+            }
         }
     }
 }
@@ -131,6 +136,9 @@ mod tests {
             Type::Database(database::Type::AwsRds(database::AwsRdsType::MariaDB)),
             Type::Database(database::Type::Shared(database::SharedType::Postgres)),
             Type::Database(database::Type::Shared(database::SharedType::MongoDb)),
+            Type::Secrets,
+            Type::StaticFolder,
+            Type::Persist,
         ];
 
         for input in inputs {


### PR DESCRIPTION
## Description of change

Fixes a bug where resources other than databases were not recognized due to missing match arms in the `FromStr` impl for `persistence::resource::Type`. Error message below:

```bash
Error: 500 Internal Server Error
message: Persistence failure: Database error: error occurred while decoding column "type": 'secrets' is an unknown resource type
```

## How Has This Been Tested (if applicable)?

Local deploy of the postgres poem example after adding `shuttle_secrets` to it, and also tested with all resources in https://github.com/shuttle-hq/shuttle/pull/750 with the fix from this branch.
