### PR TITLE
feat: polish CLI after 0.13 updates

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -414,7 +414,7 @@ impl Shuttle {
         let resources = client
             .get_service_resources(self.ctx.project_name())
             .await?;
-        let table = get_resources_table(&resources);
+        let table = get_resources_table(&resources, self.ctx.project_name().as_str());
 
         println!("{table}");
 
@@ -583,7 +583,7 @@ impl Shuttle {
             .map(resource::Response::from_bytes)
             .collect();
 
-        let resources = get_resources_table(&resources);
+        let resources = get_resources_table(&resources, self.ctx.project_name().as_str());
 
         let mut stream = runtime_client
             .subscribe_logs(tonic::Request::new(SubscribeLogsRequest {}))
@@ -695,7 +695,7 @@ impl Shuttle {
             let resources = client
                 .get_service_resources(self.ctx.project_name())
                 .await?;
-            let resources = get_resources_table(&resources);
+            let resources = get_resources_table(&resources, self.ctx.project_name().as_str());
 
             println!("{resources}{service}");
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -83,10 +83,11 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str) ->
 
         format!(
             r#"
-Most recent deployments for {}
+Most recent {} for {}
 {}
 "#,
-            service_name.bold(),
+            "deployments".bold(),
+            service_name,
             table,
         )
     }

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use chrono::{DateTime, Utc};
 use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, CellAlignment, Color,
+    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, CellAlignment, Color,
     ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
@@ -59,9 +59,15 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str) ->
             .apply_modifier(UTF8_ROUND_CORNERS)
             .set_content_arrangement(ContentArrangement::DynamicFullWidth)
             .set_header(vec![
-                Cell::new("ID").set_alignment(CellAlignment::Center),
-                Cell::new("Status").set_alignment(CellAlignment::Center),
-                Cell::new("Last updated").set_alignment(CellAlignment::Center),
+                Cell::new("Deployment ID")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
+                Cell::new("Status")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
+                Cell::new("Last updated")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
             ]);
 
         for deploy in deployments.iter() {
@@ -77,7 +83,7 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str) ->
 
         format!(
             r#"
-Most recent deploys for {}
+Most recent deployments for {}
 {}
 "#,
             service_name.bold(),

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -78,10 +78,11 @@ fn get_databases_table(databases: &Vec<&Response>, service_name: &str) -> String
     }
 
     format!(
-        r#"These databases are linked to {}
+        r#"These {} are linked to {}
 {table}
 "#,
-        service_name.bold()
+        "databases".bold(),
+        service_name
     )
 }
 
@@ -102,10 +103,11 @@ fn get_secrets_table(secrets: &[&Response], service_name: &str) -> String {
     }
 
     format!(
-        r#"These secrets can be accessed by {}
+        r#"These {} can be accessed by {}
 {table}
 "#,
-        service_name.bold()
+        "secrets".bold(),
+        service_name
     )
 }
 
@@ -115,7 +117,7 @@ fn get_static_folder_table(static_folders: &[&Response], service_name: &str) -> 
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(vec![Cell::new("Static Folders")
+        .set_header(vec![Cell::new("Folders")
             .set_alignment(CellAlignment::Center)
             .add_attribute(Attribute::Bold)]);
 
@@ -132,10 +134,11 @@ fn get_static_folder_table(static_folders: &[&Response], service_name: &str) -> 
     }
 
     format!(
-        r#"These static folders can be accessed by {}
+        r#"These {} can be accessed by {}
 {table}
 "#,
-        service_name.bold()
+        "static folders".bold(),
+        service_name
     )
 }
 
@@ -145,7 +148,7 @@ fn get_persist_table(persist_instances: &[&Response], service_name: &str) -> Str
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(vec![Cell::new("Persist Instances")
+        .set_header(vec![Cell::new("Instances")
             .set_alignment(CellAlignment::Center)
             .add_attribute(Attribute::Bold)]);
 
@@ -154,9 +157,10 @@ fn get_persist_table(persist_instances: &[&Response], service_name: &str) -> Str
     }
 
     format!(
-        r#"These instances are linked to {}
+        r#"These {} are linked to {}
 {table}
 "#,
-        service_name.bold()
+        "persist instances".bold(),
+        service_name
     )
 }

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, CellAlignment, ContentArrangement,
-    Table,
+    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, CellAlignment,
+    ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
 
@@ -11,7 +11,7 @@ use crate::{
     DbOutput, SecretStore,
 };
 
-pub fn get_resources_table(resources: &Vec<Response>) -> String {
+pub fn get_resources_table(resources: &Vec<Response>, service_name: &str) -> String {
     if resources.is_empty() {
         format!("{}\n", "No resources are linked to this service".bold())
     } else {
@@ -32,26 +32,26 @@ pub fn get_resources_table(resources: &Vec<Response>) -> String {
         let mut output = Vec::new();
 
         if let Some(databases) = resource_groups.get("Databases") {
-            output.push(get_databases_table(databases));
+            output.push(get_databases_table(databases, service_name));
         };
 
         if let Some(secrets) = resource_groups.get("Secrets") {
-            output.push(get_secrets_table(secrets));
+            output.push(get_secrets_table(secrets, service_name));
         };
 
         if let Some(static_folders) = resource_groups.get("Static Folder") {
-            output.push(get_static_folder_table(static_folders));
+            output.push(get_static_folder_table(static_folders, service_name));
         };
 
         if let Some(persist) = resource_groups.get("Persist") {
-            output.push(get_persist_table(persist));
+            output.push(get_persist_table(persist, service_name));
         };
 
         output.join("\n")
     }
 }
 
-fn get_databases_table(databases: &Vec<&Response>) -> String {
+fn get_databases_table(databases: &Vec<&Response>, service_name: &str) -> String {
     let mut table = Table::new();
 
     table
@@ -59,8 +59,12 @@ fn get_databases_table(databases: &Vec<&Response>) -> String {
         .apply_modifier(UTF8_ROUND_CORNERS)
         .set_content_arrangement(ContentArrangement::DynamicFullWidth)
         .set_header(vec![
-            Cell::new("Type").set_alignment(CellAlignment::Center),
-            Cell::new("Connection string").set_alignment(CellAlignment::Center),
+            Cell::new("Type")
+                .add_attribute(Attribute::Bold)
+                .set_alignment(CellAlignment::Center),
+            Cell::new("Connection string")
+                .add_attribute(Attribute::Bold)
+                .set_alignment(CellAlignment::Center),
         ]);
 
     for database in databases {
@@ -74,19 +78,22 @@ fn get_databases_table(databases: &Vec<&Response>) -> String {
     }
 
     format!(
-        r#"These databases are linked to this service
+        r#"These databases are linked to {}
 {table}
 "#,
+        service_name.bold()
     )
 }
 
-fn get_secrets_table(secrets: &[&Response]) -> String {
+fn get_secrets_table(secrets: &[&Response], service_name: &str) -> String {
     let mut table = Table::new();
 
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_header(vec![Cell::new("Key").set_alignment(CellAlignment::Center)]);
+        .set_header(vec![Cell::new("Keys")
+            .add_attribute(Attribute::Bold)
+            .set_alignment(CellAlignment::Center)]);
 
     let secrets = serde_json::from_value::<SecretStore>(secrets[0].data.clone()).unwrap();
 
@@ -95,57 +102,61 @@ fn get_secrets_table(secrets: &[&Response]) -> String {
     }
 
     format!(
-        r#"These secrets can be accessed by the service
+        r#"These secrets can be accessed by {}
 {table}
 "#,
+        service_name.bold()
     )
 }
 
-fn get_static_folder_table(static_folders: &[&Response]) -> String {
+fn get_static_folder_table(static_folders: &[&Response], service_name: &str) -> String {
     let mut table = Table::new();
 
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("Static Folders").set_alignment(CellAlignment::Center)
-        ]);
+        .set_header(vec![Cell::new("Static Folders")
+            .set_alignment(CellAlignment::Center)
+            .add_attribute(Attribute::Bold)]);
 
     for folder in static_folders {
         let path = serde_json::from_value::<PathBuf>(folder.data.clone())
             .unwrap()
-            .display()
-            .to_string();
+            .file_name()
+            .expect("static folder path should have a final component")
+            .to_str()
+            .expect("static folder file name should be valid unicode")
+            .to_owned();
 
         table.add_row(vec![path]);
     }
 
     format!(
-        r#"These static folders can be accessed by the service
+        r#"These static folders can be accessed by {}
 {table}
 "#,
+        service_name.bold()
     )
 }
 
-fn get_persist_table(persist_instances: &[&Response]) -> String {
+fn get_persist_table(persist_instances: &[&Response], service_name: &str) -> String {
     let mut table = Table::new();
 
     table
         .load_preset(UTF8_FULL)
         .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(vec![
-            Cell::new("Persist Instances").set_alignment(CellAlignment::Center)
-        ]);
+        .set_header(vec![Cell::new("Persist Instances")
+            .set_alignment(CellAlignment::Center)
+            .add_attribute(Attribute::Bold)]);
 
     for _ in persist_instances {
         table.add_row(vec!["Instance"]);
     }
 
     format!(
-        r#"These instances are linked to this service
+        r#"These instances are linked to {}
 {table}
 "#,
+        service_name.bold()
     )
 }

--- a/common/src/models/secret.rs
+++ b/common/src/models/secret.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, CellAlignment, ContentArrangement,
-    Table,
+    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, CellAlignment,
+    ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
@@ -22,8 +22,12 @@ pub fn get_table(secrets: &Vec<Response>) -> String {
             .apply_modifier(UTF8_ROUND_CORNERS)
             .set_content_arrangement(ContentArrangement::DynamicFullWidth)
             .set_header(vec![
-                Cell::new("Key").set_alignment(CellAlignment::Center),
-                Cell::new("Last updated").set_alignment(CellAlignment::Center),
+                Cell::new("Key")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
+                Cell::new("Last updated")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
             ]);
 
         for resource in secrets.iter() {

--- a/common/src/models/service.rs
+++ b/common/src/models/service.rs
@@ -29,7 +29,7 @@ Status:        {}
 Last Updated:  {}
 URI:           {}
 "#,
-                self.name,
+                self.name.clone().bold(),
                 deployment.id,
                 deployment
                     .state


### PR DESCRIPTION
## Description of change

This polishes the resource tables by:
- Adding the service name in bold to the table description
- Making the table headers bold
- Making the static folder display only the name of the folder, not the full path
- Changing the small tables to not use full width (making them consistent with the secrets table).
- Updating the existing tables (deployment list, secrets) with the above changes to be consistent.
- Making the service name bold in `cargo shuttle status` output.

What I did not do in this PR was remove the `cargo shuttle secrets` command, since I don't want to make this last-minute PR too large. I suggest we do it for the next release.

## How Has This Been Tested (if applicable)?

Tested locally on this branch: https://github.com/shuttle-hq/shuttle/pull/749, with the `postgres` poem example, but with all resources (database, static, persist, secrets). Here is what it looks like:

![image](https://user-images.githubusercontent.com/29732646/227725599-9ddeb9dd-ed22-4221-b484-d01893464dcf.png)

![image](https://user-images.githubusercontent.com/29732646/227725700-2df3dca1-0243-45dc-a73a-b6daf6764b9f.png)

![image](https://user-images.githubusercontent.com/29732646/227725744-1b7dfd2b-a4d0-4c58-aa2c-1bb6caef521a.png)
