### PR TITLE
feat: commit generated proto files

### DIFF
--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -20,5 +20,5 @@ tracing = { workspace = true }
 workspace = true
 features = ["claims", "error", "service", "wasm"]
 
-[build-dependencies]
+[dev-dependencies]
 tonic-build = { workspace = true }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,5 +1,0 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure().compile(&["./provisioner.proto", "./runtime.proto"], &["./"])?;
-
-    Ok(())
-}

--- a/proto/src/generated/provisioner.rs
+++ b/proto/src/generated/provisioner.rs
@@ -1,0 +1,382 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DatabaseRequest {
+    #[prost(string, tag = "1")]
+    pub project_name: ::prost::alloc::string::String,
+    #[prost(oneof = "database_request::DbType", tags = "10, 11")]
+    pub db_type: ::core::option::Option<database_request::DbType>,
+}
+/// Nested message and enum types in `DatabaseRequest`.
+pub mod database_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum DbType {
+        #[prost(message, tag = "10")]
+        Shared(super::Shared),
+        #[prost(message, tag = "11")]
+        AwsRds(super::AwsRds),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Shared {
+    #[prost(oneof = "shared::Engine", tags = "1, 50")]
+    pub engine: ::core::option::Option<shared::Engine>,
+}
+/// Nested message and enum types in `Shared`.
+pub mod shared {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Engine {
+        #[prost(string, tag = "1")]
+        Postgres(::prost::alloc::string::String),
+        #[prost(string, tag = "50")]
+        Mongodb(::prost::alloc::string::String),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AwsRds {
+    #[prost(oneof = "aws_rds::Engine", tags = "1, 2, 3")]
+    pub engine: ::core::option::Option<aws_rds::Engine>,
+}
+/// Nested message and enum types in `AwsRds`.
+pub mod aws_rds {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Engine {
+        #[prost(message, tag = "1")]
+        Postgres(super::RdsConfig),
+        #[prost(message, tag = "2")]
+        Mysql(super::RdsConfig),
+        #[prost(message, tag = "3")]
+        Mariadb(super::RdsConfig),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RdsConfig {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DatabaseResponse {
+    #[prost(string, tag = "1")]
+    pub username: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub password: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub database_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub engine: ::prost::alloc::string::String,
+    #[prost(string, tag = "5")]
+    pub address_private: ::prost::alloc::string::String,
+    #[prost(string, tag = "6")]
+    pub address_public: ::prost::alloc::string::String,
+    #[prost(string, tag = "7")]
+    pub port: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DatabaseDeletionResponse {}
+/// Generated client implementations.
+pub mod provisioner_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct ProvisionerClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl ProvisionerClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> ProvisionerClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> ProvisionerClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            ProvisionerClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        pub async fn provision_database(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DatabaseRequest>,
+        ) -> Result<tonic::Response<super::DatabaseResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/provisioner.Provisioner/ProvisionDatabase",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete_database(
+            &mut self,
+            request: impl tonic::IntoRequest<super::DatabaseRequest>,
+        ) -> Result<tonic::Response<super::DatabaseDeletionResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/provisioner.Provisioner/DeleteDatabase",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod provisioner_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with ProvisionerServer.
+    #[async_trait]
+    pub trait Provisioner: Send + Sync + 'static {
+        async fn provision_database(
+            &self,
+            request: tonic::Request<super::DatabaseRequest>,
+        ) -> Result<tonic::Response<super::DatabaseResponse>, tonic::Status>;
+        async fn delete_database(
+            &self,
+            request: tonic::Request<super::DatabaseRequest>,
+        ) -> Result<tonic::Response<super::DatabaseDeletionResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct ProvisionerServer<T: Provisioner> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Provisioner> ProvisionerServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for ProvisionerServer<T>
+    where
+        T: Provisioner,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/provisioner.Provisioner/ProvisionDatabase" => {
+                    #[allow(non_camel_case_types)]
+                    struct ProvisionDatabaseSvc<T: Provisioner>(pub Arc<T>);
+                    impl<
+                        T: Provisioner,
+                    > tonic::server::UnaryService<super::DatabaseRequest>
+                    for ProvisionDatabaseSvc<T> {
+                        type Response = super::DatabaseResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DatabaseRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).provision_database(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ProvisionDatabaseSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/provisioner.Provisioner/DeleteDatabase" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteDatabaseSvc<T: Provisioner>(pub Arc<T>);
+                    impl<
+                        T: Provisioner,
+                    > tonic::server::UnaryService<super::DatabaseRequest>
+                    for DeleteDatabaseSvc<T> {
+                        type Response = super::DatabaseDeletionResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::DatabaseRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).delete_database(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteDatabaseSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Provisioner> Clone for ProvisionerServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Provisioner> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Provisioner> tonic::server::NamedService for ProvisionerServer<T> {
+        const NAME: &'static str = "provisioner.Provisioner";
+    }
+}

--- a/proto/src/generated/runtime.rs
+++ b/proto/src/generated/runtime.rs
@@ -1,0 +1,659 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LoadRequest {
+    /// Name of service to load
+    #[prost(string, tag = "1")]
+    pub service_name: ::prost::alloc::string::String,
+    /// Path to compiled file to load for service
+    #[prost(string, tag = "2")]
+    pub path: ::prost::alloc::string::String,
+    /// A cache of resource details to use instead when asked
+    #[prost(bytes = "vec", repeated, tag = "10")]
+    pub resources: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    /// Secrets that belong to this deployment
+    #[prost(map = "string, string", tag = "20")]
+    pub secrets: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LoadResponse {
+    /// Could the service be loaded
+    #[prost(bool, tag = "1")]
+    pub success: bool,
+    /// Error message if not successful
+    #[prost(string, tag = "2")]
+    pub message: ::prost::alloc::string::String,
+    /// Which resources where requested
+    #[prost(bytes = "vec", repeated, tag = "10")]
+    pub resources: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StartRequest {
+    /// Address and port to start the service on
+    #[prost(string, tag = "1")]
+    pub ip: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StartResponse {
+    /// Was the start successful
+    #[prost(bool, tag = "1")]
+    pub success: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StopRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StopResponse {
+    /// Was the stop successful
+    #[prost(bool, tag = "1")]
+    pub success: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubscribeStopRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubscribeStopResponse {
+    /// Reason the service has stopped
+    #[prost(enumeration = "StopReason", tag = "1")]
+    pub reason: i32,
+    /// Any extra message to go with the reason. If there are any
+    #[prost(string, tag = "2")]
+    pub message: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubscribeLogsRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LogItem {
+    #[prost(message, optional, tag = "2")]
+    pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
+    #[prost(enumeration = "LogLevel", tag = "4")]
+    pub level: i32,
+    #[prost(string, optional, tag = "5")]
+    pub file: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint32, optional, tag = "6")]
+    pub line: ::core::option::Option<u32>,
+    #[prost(string, tag = "7")]
+    pub target: ::prost::alloc::string::String,
+    #[prost(bytes = "vec", tag = "8")]
+    pub fields: ::prost::alloc::vec::Vec<u8>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum StopReason {
+    /// User requested this stop
+    Request = 0,
+    /// Service stopped by itself
+    End = 1,
+    /// Service crashed
+    Crash = 2,
+}
+impl StopReason {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            StopReason::Request => "Request",
+            StopReason::End => "End",
+            StopReason::Crash => "Crash",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Request" => Some(Self::Request),
+            "End" => Some(Self::End),
+            "Crash" => Some(Self::Crash),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum LogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+}
+impl LogLevel {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            LogLevel::Trace => "Trace",
+            LogLevel::Debug => "Debug",
+            LogLevel::Info => "Info",
+            LogLevel::Warn => "Warn",
+            LogLevel::Error => "Error",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "Trace" => Some(Self::Trace),
+            "Debug" => Some(Self::Debug),
+            "Info" => Some(Self::Info),
+            "Warn" => Some(Self::Warn),
+            "Error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+}
+/// Generated client implementations.
+pub mod runtime_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
+    #[derive(Debug, Clone)]
+    pub struct RuntimeClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl RuntimeClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: std::convert::TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> RuntimeClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> RuntimeClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+                Response = http::Response<
+                    <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
+                >,
+            >,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
+        {
+            RuntimeClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Load a service file to be ready to start it
+        pub async fn load(
+            &mut self,
+            request: impl tonic::IntoRequest<super::LoadRequest>,
+        ) -> Result<tonic::Response<super::LoadResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/runtime.Runtime/Load");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Start a loaded service file
+        pub async fn start(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StartRequest>,
+        ) -> Result<tonic::Response<super::StartResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/runtime.Runtime/Start");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Stop a started service
+        pub async fn stop(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StopRequest>,
+        ) -> Result<tonic::Response<super::StopResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/runtime.Runtime/Stop");
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        /// Channel to notify a service has been stopped
+        pub async fn subscribe_stop(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SubscribeStopRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::SubscribeStopResponse>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/runtime.Runtime/SubscribeStop",
+            );
+            self.inner.server_streaming(request.into_request(), path, codec).await
+        }
+        /// Subscribe to runtime logs
+        pub async fn subscribe_logs(
+            &mut self,
+            request: impl tonic::IntoRequest<super::SubscribeLogsRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::LogItem>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/runtime.Runtime/SubscribeLogs",
+            );
+            self.inner.server_streaming(request.into_request(), path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod runtime_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with RuntimeServer.
+    #[async_trait]
+    pub trait Runtime: Send + Sync + 'static {
+        /// Load a service file to be ready to start it
+        async fn load(
+            &self,
+            request: tonic::Request<super::LoadRequest>,
+        ) -> Result<tonic::Response<super::LoadResponse>, tonic::Status>;
+        /// Start a loaded service file
+        async fn start(
+            &self,
+            request: tonic::Request<super::StartRequest>,
+        ) -> Result<tonic::Response<super::StartResponse>, tonic::Status>;
+        /// Stop a started service
+        async fn stop(
+            &self,
+            request: tonic::Request<super::StopRequest>,
+        ) -> Result<tonic::Response<super::StopResponse>, tonic::Status>;
+        /// Server streaming response type for the SubscribeStop method.
+        type SubscribeStopStream: futures_core::Stream<
+                Item = Result<super::SubscribeStopResponse, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// Channel to notify a service has been stopped
+        async fn subscribe_stop(
+            &self,
+            request: tonic::Request<super::SubscribeStopRequest>,
+        ) -> Result<tonic::Response<Self::SubscribeStopStream>, tonic::Status>;
+        /// Server streaming response type for the SubscribeLogs method.
+        type SubscribeLogsStream: futures_core::Stream<
+                Item = Result<super::LogItem, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        /// Subscribe to runtime logs
+        async fn subscribe_logs(
+            &self,
+            request: tonic::Request<super::SubscribeLogsRequest>,
+        ) -> Result<tonic::Response<Self::SubscribeLogsStream>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct RuntimeServer<T: Runtime> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Runtime> RuntimeServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+            }
+        }
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for RuntimeServer<T>
+    where
+        T: Runtime,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/runtime.Runtime/Load" => {
+                    #[allow(non_camel_case_types)]
+                    struct LoadSvc<T: Runtime>(pub Arc<T>);
+                    impl<T: Runtime> tonic::server::UnaryService<super::LoadRequest>
+                    for LoadSvc<T> {
+                        type Response = super::LoadResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::LoadRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).load(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = LoadSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/runtime.Runtime/Start" => {
+                    #[allow(non_camel_case_types)]
+                    struct StartSvc<T: Runtime>(pub Arc<T>);
+                    impl<T: Runtime> tonic::server::UnaryService<super::StartRequest>
+                    for StartSvc<T> {
+                        type Response = super::StartResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StartRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).start(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StartSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/runtime.Runtime/Stop" => {
+                    #[allow(non_camel_case_types)]
+                    struct StopSvc<T: Runtime>(pub Arc<T>);
+                    impl<T: Runtime> tonic::server::UnaryService<super::StopRequest>
+                    for StopSvc<T> {
+                        type Response = super::StopResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StopRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move { (*inner).stop(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StopSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/runtime.Runtime/SubscribeStop" => {
+                    #[allow(non_camel_case_types)]
+                    struct SubscribeStopSvc<T: Runtime>(pub Arc<T>);
+                    impl<
+                        T: Runtime,
+                    > tonic::server::ServerStreamingService<super::SubscribeStopRequest>
+                    for SubscribeStopSvc<T> {
+                        type Response = super::SubscribeStopResponse;
+                        type ResponseStream = T::SubscribeStopStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SubscribeStopRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).subscribe_stop(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SubscribeStopSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/runtime.Runtime/SubscribeLogs" => {
+                    #[allow(non_camel_case_types)]
+                    struct SubscribeLogsSvc<T: Runtime>(pub Arc<T>);
+                    impl<
+                        T: Runtime,
+                    > tonic::server::ServerStreamingService<super::SubscribeLogsRequest>
+                    for SubscribeLogsSvc<T> {
+                        type Response = super::LogItem;
+                        type ResponseStream = T::SubscribeLogsStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::SubscribeLogsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).subscribe_logs(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = SubscribeLogsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
+            }
+        }
+    }
+    impl<T: Runtime> Clone for RuntimeServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+            }
+        }
+    }
+    impl<T: Runtime> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Runtime> tonic::server::NamedService for RuntimeServer<T> {
+        const NAME: &'static str = "runtime.Runtime";
+    }
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -10,7 +10,7 @@ pub mod provisioner {
         DatabaseReadyInfo,
     };
 
-    tonic::include_proto!("provisioner");
+    include!("generated/provisioner.rs");
 
     impl From<DatabaseResponse> for DatabaseReadyInfo {
         fn from(response: DatabaseResponse) -> Self {
@@ -118,7 +118,7 @@ pub mod runtime {
         WorkingDir(PathBuf),
     }
 
-    tonic::include_proto!("runtime");
+    include!("generated/runtime.rs");
 
     impl From<shuttle_common::log::Level> for LogLevel {
         fn from(level: shuttle_common::log::Level) -> Self {

--- a/proto/tests/bootstrap.rs
+++ b/proto/tests/bootstrap.rs
@@ -1,0 +1,34 @@
+use std::{path::PathBuf, process::Command};
+
+// This test will compile the `.proto` files and put the generated code
+// in `src/generated`. We commit the generated code, and run this test in
+// CI to make sure that the generated files are up to date with any changes
+// to the `.proto` files.
+#[test]
+fn bootstrap() {
+    let proto_files = &["provisioner.proto", "runtime.proto"];
+
+    let out_dir = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("generated");
+
+    tonic_build::configure()
+        .out_dir(format!("{}", out_dir.display()))
+        .compile(proto_files, &["./"])
+        .unwrap();
+
+    let status = Command::new("git")
+        .arg("diff")
+        .arg("--exit-code")
+        .arg("--")
+        .arg(format!("{}", out_dir.display()))
+        .status()
+        .unwrap();
+
+    if !status.success() {
+        panic!("You should commit the protobuf files");
+    }
+}
+
+// This solution is based on this tonic-health pull request:
+// https://github.com/hyperium/tonic/pull/1065/


### PR DESCRIPTION
## Description of change

This commit uses a test to compile and generate the `.proto` files, which we then commit, and with the test running in CI we ensure that the generated files are up-to-date if any changes are made to the `.proto` files. This means the protobuf compiler does not need to be installed to compile `shuttle-proto`, which also means it won't be required to install the `cargo-shuttle` CLI.

Protoc will still be required to run/build shuttle projects until we update `opentelemetry-otlp` to 0.19, which has been released, we just need to wait for `tracing-opentelemtry` to be updated as well (or do it ourselves). After upgrading these crates `protoc` will no longer be required for shuttle users, it will only be required to make changes to the `.proto` files in `shuttle-proto`.

With this PR we should also be able to remove the protoc install from the binary builds.

Big thanks to @sd2k for suggesting this solution, this PR is largely based on their PR to tonic-health: https://github.com/hyperium/tonic/pull/1065/
## How Has This Been Tested (if applicable)?

Added a test in `shuttle-proto` and ran `PROTOC="" cargo build -p cargo-shuttle`.
