### PR TITLE
gateway: expect on refreshing projects

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -76,8 +76,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
             .and_then(task::refresh())
             .send(&sender)
             .await
-            .ok()
-            .unwrap();
+            .expect("failed sending the task");
     }
 
     let worker_handle = tokio::spawn(


### PR DESCRIPTION
## Description of change

Expect instead of unwrapping an Ok value, which is helpful in debugging any error that might pop up in refreshing proejct upon gateway starting.

## How Has This Been Tested (if applicable)?

N/A
