### PR TITLE
gateway/certs: serve certificate as default

### DIFF
--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -177,9 +177,13 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
 
         tokio::spawn(async move {
             // Make sure we have a certificate for ourselves.
-            gateway
+            let certs = gateway
                 .fetch_certificate(&acme_client, resolver.clone(), gateway.credentials())
                 .await;
+            resolver
+                .serve_default_der(certs)
+                .await
+                .expect("failed to set certs to be served as default");
         });
     } else {
         warn!("TLS is disabled in the proxy service. This is only acceptable in testing, and should *never* be used in deployments.");

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -599,10 +599,6 @@ impl GatewayService {
         buf.extend(chain.as_bytes());
         buf.extend(private_key.as_bytes());
         let certs = ChainAndPrivateKey::parse_pem(Cursor::new(buf)).expect("Malformed PEM buffer.");
-        resolver
-            .serve_default_der(certs.clone())
-            .await
-            .expect("Failed to serve the default certs");
 
         certs
     }
@@ -657,6 +653,10 @@ impl GatewayService {
             let certs = self
                 .create_certificate(acme, resolver.clone(), account.credentials())
                 .await;
+            resolver
+                .serve_default_der(certs.clone())
+                .await
+                .expect("Failed to serve the default certs");
             certs.save_pem(&tls_path).unwrap();
         }
     }


### PR DESCRIPTION
## Description of change

When the gateway starts it should serve a default certificate which is fetched either from the filesystem or from the letsencrypt server.

## How Has This Been Tested (if applicable)?

N/A
