### PR TITLE
fix: windows path canonicalization bug in static folder

### DIFF
--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["shuttle-service", "static-folder"]
 
 [dependencies]
 async-trait = "0.1.56"
+dunce = "1.0.3"
 fs_extra = "1.3.0"
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.13.0", default-features = false }

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -56,7 +56,7 @@ impl<'a> ResourceBuilder<PathBuf> for StaticFolder<'a> {
 
         trace!(input_directory = ?input_dir, "got input directory");
 
-        match input_dir.canonicalize() {
+        match dunce::canonicalize(input_dir.clone()) {
             Ok(canonical_path) if canonical_path != input_dir => return Err(Error::TransversedUp)?,
             Ok(_) => {
                 // The path did not change to outside the crate's build folder


### PR DESCRIPTION
## Description of change

The static folder will fail to be provisioned on windows due to path canonicalization converting the input path to UNC. This PR fixes that by using the `dunce` crate, like we did in cargo-shuttle.

## How Has This Been Tested (if applicable)?

Tested local run of `examples/axum/static-files` with and without this fix on windows. Without this fix, it will fail to provision the static folder for local runs, but deployments work.
