### PR TITLE
chore: bump static folder to 0.13.1

### DIFF
--- a/resources/static-folder/Cargo.toml
+++ b/resources/static-folder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-static-folder"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to get a static folder at runtime on shuttle"


### PR DESCRIPTION
## Description of change

Bump static folder to 0.13.1, a new release that includes #762 fix for windows.
