### PR TITLE
tests: make provisioner test deterministic

### DIFF
--- a/provisioner/tests/provisioner.rs
+++ b/provisioner/tests/provisioner.rs
@@ -167,8 +167,19 @@ async fn shared_mongodb_role_does_not_exist() {
     .await
     .unwrap();
 
+    exec_mongosh(
+        r#"db.createUser({
+            user: "user-exist",
+            pwd: "secure_password",
+            roles: [
+                { role: "readWrite", db: "mongodb-not_exist" }
+            ]
+        })"#,
+        Some("mongodb-not_exist"),
+    );
+
     let user = exec_mongosh("db.getUser(\"user-not_exist\")", Some("mongodb-not_exist"));
-    assert_eq!(user, "");
+    assert_eq!(user, "null");
 
     provisioner
         .request_shared_db("not_exist", shared::Engine::Mongodb(String::new()))


### PR DESCRIPTION
## Description of change
The first time this test would run, it would output nothing since the DB did not exist (and therefore the user did not exist either). This fixes it so that the first run is the same as the subsequent runs by making sure the DB exists.

## How Has This Been Tested (if applicable)?
By running the tests locally
