### PR TITLE
feat: start all services in a workspace for local runs

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -457,8 +457,6 @@ impl Shuttle {
 
         let runtimes = build_workspace(working_directory, run_args.release, tx).await?;
 
-        let mut service_count = 0;
-
         let mut runtime_handles = JoinSet::new();
 
         for Runtime {
@@ -468,8 +466,6 @@ impl Shuttle {
             working_directory,
         } in runtimes
         {
-            service_count += 1;
-
             trace!("loading secrets");
 
             let secrets_path = if working_directory.join("Secrets.dev.toml").exists() {
@@ -497,7 +493,7 @@ impl Shuttle {
                         .expect("failed to find cargo home dir")
                         .join("bin/shuttle-next");
 
-                    println!("Installing shuttle runtime. This can take a while...");
+                    println!("Installing shuttle-next runtime. This can take a while...");
 
                     if cfg!(debug_assertions) {
                         // Canonicalized path to shuttle-runtime for dev to work on windows
@@ -548,7 +544,7 @@ impl Shuttle {
                 runtime::StorageManagerType::WorkingDir(working_directory.to_path_buf()),
                 &format!("http://localhost:{}", run_args.port + 1),
                 None,
-                run_args.port + 2 + service_count, // TODO: use portpicker?
+                portpicker::pick_unused_port().unwrap(),
                 runtime_path,
             )
             .await
@@ -657,7 +653,7 @@ impl Shuttle {
             println!(
                 "a service future completed with exit status: {:?}",
                 res.unwrap().unwrap().code()
-            )
+            );
         }
 
         Ok(())

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -12,6 +12,7 @@ use shuttle_common::models::resource::get_resources_table;
 use shuttle_common::project::ProjectName;
 use shuttle_common::resource;
 use shuttle_proto::runtime::{self, LoadRequest, StartRequest, SubscribeLogsRequest};
+use tokio::task::JoinSet;
 
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -448,197 +449,216 @@ impl Shuttle {
             working_directory.display()
         );
 
-        let runtimes = build_workspace(working_directory, run_args.release, tx).await?;
-
-        trace!("loading secrets");
-
-        let secrets_path = if working_directory.join("Secrets.dev.toml").exists() {
-            working_directory.join("Secrets.dev.toml")
-        } else {
-            working_directory.join("Secrets.toml")
-        };
-
-        let secrets: HashMap<String, String> = if let Ok(secrets_str) = read_to_string(secrets_path)
-        {
-            let secrets: HashMap<String, String> =
-                secrets_str.parse::<toml::Value>()?.try_into()?;
-
-            trace!(keys = ?secrets.keys(), "available secrets");
-
-            secrets
-        } else {
-            trace!("no Secrets.toml was found");
-            Default::default()
-        };
-
-        let service_name = self.ctx.project_name().to_string();
-
-        let (is_wasm, executable_path) = match runtimes[0].clone() {
-            Runtime::Next(path) => (true, path),
-            Runtime::Alpha(path) => (false, path),
-        };
-
         let provisioner = LocalProvisioner::new()?;
         let provisioner_server = provisioner.start(SocketAddr::new(
             Ipv4Addr::LOCALHOST.into(),
             run_args.port + 1,
         ));
 
-        let runtime_path = || {
-            if is_wasm {
-                let runtime_path = home::cargo_home()
-                    .expect("failed to find cargo home dir")
-                    .join("bin/shuttle-next");
+        let runtimes = build_workspace(working_directory, run_args.release, tx).await?;
 
-                println!("Installing shuttle runtime. This can take a while...");
+        let mut service_count = 0;
 
-                if cfg!(debug_assertions) {
-                    // Canonicalized path to shuttle-runtime for dev to work on windows
-                    let path = std::fs::canonicalize(format!("{MANIFEST_DIR}/../runtime"))
-                        .expect("path to shuttle-runtime does not exist or is invalid");
+        let mut runtime_handles = JoinSet::new();
 
-                    trace!(?path, "installing runtime from local filesystem");
+        for Runtime {
+            executable_path,
+            is_wasm,
+            service_name,
+            working_directory,
+        } in runtimes
+        {
+            service_count += 1;
 
-                    std::process::Command::new("cargo")
-                        .arg("install")
-                        .arg("shuttle-runtime")
-                        .arg("--path")
-                        .arg(path)
-                        .arg("--bin")
-                        .arg("shuttle-next")
-                        .arg("--features")
-                        .arg("next")
-                        .output()
-                        .expect("failed to install the shuttle runtime");
+            trace!("loading secrets");
+
+            let secrets_path = if working_directory.join("Secrets.dev.toml").exists() {
+                working_directory.join("Secrets.dev.toml")
+            } else {
+                working_directory.join("Secrets.toml")
+            };
+
+            let secrets: HashMap<String, String> =
+                if let Ok(secrets_str) = read_to_string(secrets_path) {
+                    let secrets: HashMap<String, String> =
+                        secrets_str.parse::<toml::Value>()?.try_into()?;
+
+                    trace!(keys = ?secrets.keys(), "available secrets");
+
+                    secrets
                 } else {
-                    // If the version of cargo-shuttle is different from shuttle-runtime,
-                    // or it isn't installed, try to install shuttle-runtime from crates.io.
-                    if let Err(err) = check_version(&runtime_path) {
-                        warn!("{}", err);
+                    trace!("no Secrets.toml was found");
+                    Default::default()
+                };
 
-                        trace!("installing shuttle-runtime");
+            let runtime_path = || {
+                if is_wasm {
+                    let runtime_path = home::cargo_home()
+                        .expect("failed to find cargo home dir")
+                        .join("bin/shuttle-next");
+
+                    println!("Installing shuttle runtime. This can take a while...");
+
+                    if cfg!(debug_assertions) {
+                        // Canonicalized path to shuttle-runtime for dev to work on windows
+                        let path = std::fs::canonicalize(format!("{MANIFEST_DIR}/../runtime"))
+                            .expect("path to shuttle-runtime does not exist or is invalid");
+
+                        trace!(?path, "installing runtime from local filesystem");
+
                         std::process::Command::new("cargo")
                             .arg("install")
                             .arg("shuttle-runtime")
+                            .arg("--path")
+                            .arg(path)
                             .arg("--bin")
                             .arg("shuttle-next")
                             .arg("--features")
                             .arg("next")
                             .output()
                             .expect("failed to install the shuttle runtime");
+                    } else {
+                        // If the version of cargo-shuttle is different from shuttle-runtime,
+                        // or it isn't installed, try to install shuttle-runtime from crates.io.
+                        if let Err(err) = check_version(&runtime_path) {
+                            warn!("{}", err);
+
+                            trace!("installing shuttle-runtime");
+                            std::process::Command::new("cargo")
+                                .arg("install")
+                                .arg("shuttle-runtime")
+                                .arg("--bin")
+                                .arg("shuttle-next")
+                                .arg("--features")
+                                .arg("next")
+                                .output()
+                                .expect("failed to install the shuttle runtime");
+                        };
                     };
-                };
 
-                runtime_path
-            } else {
-                trace!(path = ?executable_path, "using alpha runtime");
-                executable_path.clone()
-            }
-        };
+                    runtime_path
+                } else {
+                    trace!(path = ?executable_path, "using alpha runtime");
+                    executable_path.clone()
+                }
+            };
 
-        let (mut runtime, mut runtime_client) = runtime::start(
-            is_wasm,
-            runtime::StorageManagerType::WorkingDir(working_directory.to_path_buf()),
-            &format!("http://localhost:{}", run_args.port + 1),
-            None,
-            run_args.port + 2,
-            runtime_path,
-        )
-        .await
-        .map_err(|err| {
-            provisioner_server.abort();
-
-            err
-        })?;
-
-        let load_request = tonic::Request::new(LoadRequest {
-            path: executable_path
-                .into_os_string()
-                .into_string()
-                .expect("to convert path to string"),
-            service_name: service_name.clone(),
-            resources: Default::default(),
-            secrets,
-        });
-        trace!("loading service");
-        let response = runtime_client
-            .load(load_request)
-            .or_else(|err| async {
+            let (mut runtime, mut runtime_client) = runtime::start(
+                is_wasm,
+                runtime::StorageManagerType::WorkingDir(working_directory.to_path_buf()),
+                &format!("http://localhost:{}", run_args.port + 1),
+                None,
+                run_args.port + 2 + service_count, // TODO: use portpicker?
+                runtime_path,
+            )
+            .await
+            .map_err(|err| {
                 provisioner_server.abort();
-                runtime.kill().await?;
 
-                Err(err)
-            })
-            .await?
-            .into_inner();
+                err
+            })?;
 
-        if !response.success {
-            error!(error = response.message, "failed to load your service");
-            exit(1);
+            let load_request = tonic::Request::new(LoadRequest {
+                path: executable_path
+                    .into_os_string()
+                    .into_string()
+                    .expect("to convert path to string"),
+                service_name: service_name.clone(),
+                resources: Default::default(),
+                secrets,
+            });
+            trace!("loading service");
+            let response = runtime_client
+                .load(load_request)
+                .or_else(|err| async {
+                    provisioner_server.abort();
+                    runtime.kill().await?;
+
+                    Err(err)
+                })
+                .await?
+                .into_inner();
+
+            if !response.success {
+                error!(error = response.message, "failed to load your service");
+                exit(1);
+            }
+
+            let resources = response
+                .resources
+                .into_iter()
+                .map(resource::Response::from_bytes)
+                .collect();
+
+            let resources = get_resources_table(&resources, &service_name);
+
+            let mut stream = runtime_client
+                .subscribe_logs(tonic::Request::new(SubscribeLogsRequest {}))
+                .or_else(|err| async {
+                    provisioner_server.abort();
+                    runtime.kill().await?;
+
+                    Err(err)
+                })
+                .await?
+                .into_inner();
+
+            tokio::spawn(async move {
+                while let Ok(Some(log)) = stream.message().await {
+                    let log: shuttle_common::LogItem = log.try_into().expect("to convert log");
+                    println!("{log}");
+                }
+            });
+
+            println!("{resources}");
+
+            let addr = if run_args.external {
+                std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
+            } else {
+                Ipv4Addr::LOCALHOST.into()
+            };
+
+            let addr = SocketAddr::new(
+                addr,
+                portpicker::pick_unused_port().expect("unable to find available port"),
+            );
+
+            let start_request = StartRequest {
+                ip: addr.to_string(),
+            };
+
+            trace!(?start_request, "starting service");
+            let response = runtime_client
+                .start(tonic::Request::new(start_request))
+                .or_else(|err| async {
+                    provisioner_server.abort();
+                    runtime.kill().await?;
+
+                    Err(err)
+                })
+                .await?
+                .into_inner();
+
+            trace!(response = ?response,  "client response: ");
+
+            println!(
+                "\n{:>12} {} on http://{}",
+                "Starting".bold().green(),
+                &service_name,
+                addr
+            );
+
+            runtime_handles.spawn(async move { runtime.wait().await });
         }
 
-        let resources = response
-            .resources
-            .into_iter()
-            .map(resource::Response::from_bytes)
-            .collect();
-
-        let resources = get_resources_table(&resources, self.ctx.project_name().as_str());
-
-        let mut stream = runtime_client
-            .subscribe_logs(tonic::Request::new(SubscribeLogsRequest {}))
-            .or_else(|err| async {
-                provisioner_server.abort();
-                runtime.kill().await?;
-
-                Err(err)
-            })
-            .await?
-            .into_inner();
-
-        tokio::spawn(async move {
-            while let Ok(Some(log)) = stream.message().await {
-                let log: shuttle_common::LogItem = log.try_into().expect("to convert log");
-                println!("{log}");
-            }
-        });
-
-        println!("{resources}");
-
-        let addr = if run_args.external {
-            std::net::IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
-        } else {
-            Ipv4Addr::LOCALHOST.into()
-        };
-
-        let addr = SocketAddr::new(addr, run_args.port);
-
-        let start_request = StartRequest {
-            ip: addr.to_string(),
-        };
-
-        trace!(?start_request, "starting service");
-        let response = runtime_client
-            .start(tonic::Request::new(start_request))
-            .or_else(|err| async {
-                provisioner_server.abort();
-                runtime.kill().await?;
-
-                Err(err)
-            })
-            .await?
-            .into_inner();
-
-        trace!(response = ?response,  "client response: ");
-
-        println!(
-            "\n{:>12} {} on http://{}",
-            "Starting".bold().green(),
-            self.ctx.project_name(),
-            addr
-        );
-
-        runtime.wait().await?;
+        // TODO: figure out how best to handle the runtime handles, and what to do if
+        // one completes.
+        while let Some(res) = runtime_handles.join_next().await {
+            println!(
+                "a service future completed with exit status: {:?}",
+                res.unwrap().unwrap().code()
+            )
+        }
 
         Ok(())
     }

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -12,7 +12,7 @@ use crossbeam_channel::Sender;
 use opentelemetry::global;
 use serde_json::json;
 use shuttle_common::claims::Claim;
-use shuttle_service::builder::{build_workspace, get_config, Runtime};
+use shuttle_service::builder::{build_workspace, get_config, BuiltService};
 use tokio::time::{sleep, timeout};
 use tracing::{debug, debug_span, error, info, instrument, trace, warn, Instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -331,7 +331,7 @@ async fn extract_tar_gz_data(data: impl Read, dest: impl AsRef<Path>) -> Result<
 async fn build_deployment(
     project_path: &Path,
     tx: crossbeam_channel::Sender<Message>,
-) -> Result<Runtime> {
+) -> Result<BuiltService> {
     let runtimes = build_workspace(project_path, true, tx)
         .await
         .map_err(|e| Error::Build(e.into()))?;

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -226,9 +226,9 @@ impl Queued {
 
         info!("Moving built executable");
 
-        store_executable(&storage_manager, &runtime, &self.id).await?;
+        store_executable(&storage_manager, runtime.executable_path.clone(), &self.id).await?;
 
-        let is_next = matches!(runtime, Runtime::Next(_));
+        let is_next = runtime.is_wasm;
 
         deployment_updater
             .set_is_next(&id, is_next)
@@ -397,17 +397,12 @@ async fn run_pre_deploy_tests(
 
 /// This will store the path to the executable for each runtime, which will be the users project with
 /// an embedded runtime for alpha, and a .wasm file for shuttle-next.
-#[instrument(skip(storage_manager, runtime, id))]
+#[instrument(skip(storage_manager, executable_path, id))]
 async fn store_executable(
     storage_manager: &ArtifactsStorageManager,
-    runtime: &Runtime,
+    executable_path: PathBuf,
     id: &Uuid,
 ) -> Result<()> {
-    let executable_path = match runtime {
-        Runtime::Next(path) => path,
-        Runtime::Alpha(path) => path,
-    };
-
     let new_executable_path = storage_manager.deployment_executable_path(id)?;
 
     fs::rename(executable_path, new_executable_path).await?;
@@ -420,7 +415,6 @@ mod tests {
     use std::{collections::BTreeMap, fs::File, io::Write, path::Path};
 
     use shuttle_common::storage_manager::ArtifactsStorageManager;
-    use shuttle_service::builder::Runtime;
     use tempfile::Builder;
     use tokio::fs;
     use uuid::Uuid;
@@ -558,12 +552,11 @@ ff0e55bda1ff01000000000000000000e0079c01ff12a55500280000",
         let build_p = storage_manager.builds_path().unwrap();
 
         let executable_path = build_p.join("xyz");
-        let runtime = Runtime::Alpha(executable_path.clone());
         let id = Uuid::new_v4();
 
         fs::write(&executable_path, "barfoo").await.unwrap();
 
-        super::store_executable(&storage_manager, &runtime, &id)
+        super::store_executable(&storage_manager, executable_path.clone(), &id)
             .await
             .unwrap();
 

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -229,7 +229,7 @@ impl RouterBuilder {
         let module = Module::from_file(&self.engine, file)?;
 
         for export in module.exports() {
-            println!("export: {}", export.name());
+            trace!("export: {}", export.name());
         }
 
         Ok(Router {

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -41,15 +41,16 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
 
     let secrets: HashMap<String, String> = Default::default();
 
-    let (is_wasm, bin_path) = match runtimes[0].clone() {
-        Runtime::Next(path) => (true, path),
-        Runtime::Alpha(path) => (false, path),
-    };
+    let Runtime {
+        executable_path,
+        is_wasm,
+        ..
+    } = runtimes[0].clone();
 
     start_provisioner(DummyProvisioner, provisioner_address);
 
     // TODO: update this to work with shuttle-next projects, see cargo-shuttle local run
-    let runtime_path = || bin_path.clone();
+    let runtime_path = || executable_path.clone();
 
     let (_, runtime_client) = runtime::start(
         is_wasm,
@@ -63,7 +64,7 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
 
     Ok(TestRuntime {
         runtime_client,
-        bin_path: bin_path
+        bin_path: executable_path
             .into_os_string()
             .into_string()
             .expect("to convert path to string"),

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -14,7 +14,7 @@ use shuttle_proto::{
     },
     runtime::{self, runtime_client::RuntimeClient},
 };
-use shuttle_service::builder::{build_workspace, Runtime};
+use shuttle_service::builder::{build_workspace, BuiltService};
 use tonic::{
     transport::{Channel, Server},
     Request, Response, Status,
@@ -41,7 +41,7 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
 
     let secrets: HashMap<String, String> = Default::default();
 
-    let Runtime {
+    let BuiltService {
         executable_path,
         is_wasm,
         ..

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true, features = ["derive"] }
 strfmt = "0.2.2"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"], optional = true }
+toml = { workspace = true, optional = true  }
 tracing = { workspace = true, optional = true }
 
 [dependencies.shuttle-codegen]
@@ -44,5 +45,6 @@ builder = [
     "crossbeam-channel",
     "pipe",
     "tokio",
+    "toml",
     "tracing",
 ]

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -61,7 +61,7 @@ impl BuiltService {
 }
 
 fn extract_shuttle_toml_name(path: PathBuf) -> anyhow::Result<String> {
-    let shuttle_toml = read_to_string(path.clone()).context("Shuttle.toml not found")?;
+    let shuttle_toml = read_to_string(path).context("Shuttle.toml not found")?;
 
     let toml: toml::Value =
         toml::from_str(&shuttle_toml).context("failed to parse Shuttle.toml")?;

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -16,9 +16,27 @@ use crate::{NEXT_NAME, RUNTIME_NAME};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// How to run/build the project
-pub enum Runtime {
-    Next(PathBuf),
-    Alpha(PathBuf),
+pub struct Runtime {
+    pub executable_path: PathBuf,
+    pub is_wasm: bool,
+    pub service_name: String,
+    pub working_directory: PathBuf,
+}
+
+impl Runtime {
+    pub fn new(
+        executable_path: PathBuf,
+        is_wasm: bool,
+        service_name: String,
+        working_directory: PathBuf,
+    ) -> Self {
+        Self {
+            executable_path,
+            is_wasm,
+            service_name,
+            working_directory,
+        }
+    }
 }
 
 /// Given a project directory path, builds the crate
@@ -75,7 +93,14 @@ pub async fn build_workspace(
         let mut alpha_binaries = compilation
             .binaries
             .iter()
-            .map(|binary| Runtime::Alpha(binary.path.clone()))
+            .map(|binary| {
+                Runtime::new(
+                    binary.path.clone(),
+                    false,
+                    binary.unit.pkg.name().to_string(),
+                    binary.unit.pkg.manifest_path().to_path_buf(),
+                )
+            })
             .collect();
 
         runtimes.append(&mut alpha_binaries);
@@ -88,7 +113,14 @@ pub async fn build_workspace(
         let mut next_libraries = compilation
             .cdylibs
             .iter()
-            .map(|binary| Runtime::Next(binary.path.clone()))
+            .map(|binary| {
+                Runtime::new(
+                    binary.path.clone(),
+                    true,
+                    binary.unit.pkg.name().to_string(),
+                    binary.unit.pkg.manifest_path().to_path_buf(),
+                )
+            })
             .collect();
 
         runtimes.append(&mut next_libraries);

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -35,7 +35,7 @@ async fn is_bin() {
         vec![BuiltService::new(
             PathBuf::from(&project_path).join("target/debug/is-bin"),
             false,
-            "is_bin".to_string(),
+            "is-bin".to_string(),
             PathBuf::from(&project_path),
             PathBuf::from(&project_path).join("Cargo.toml")
         ),]

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use shuttle_service::builder::{build_workspace, Runtime};
+use shuttle_service::builder::{build_workspace, BuiltService};
 
 #[tokio::test]
 #[should_panic(expected = "1 job failed")]
@@ -32,10 +32,11 @@ async fn is_bin() {
         build_workspace(Path::new(&project_path), false, tx)
             .await
             .unwrap(),
-        vec![Runtime::new(
+        vec![BuiltService::new(
             PathBuf::from(&project_path).join("target/debug/is-bin"),
             false,
             "is_bin".to_string(),
+            PathBuf::from(&project_path),
             PathBuf::from(&project_path).join("Cargo.toml")
         ),]
     );
@@ -65,16 +66,18 @@ async fn workspace() {
             .await
             .unwrap(),
         vec![
-            Runtime::new(
+            BuiltService::new(
                 PathBuf::from(&project_path).join("target/debug/alpha"),
                 false,
                 "alpha".to_string(),
+                PathBuf::from(&project_path).join("alpha"),
                 PathBuf::from(&project_path).join("alpha/Cargo.toml")
             ),
-            Runtime::new(
+            BuiltService::new(
                 PathBuf::from(&project_path).join("target/wasm32-wasi/debug/next.wasm"),
                 true,
                 "next".to_string(),
+                PathBuf::from(&project_path).join("next"),
                 PathBuf::from(&project_path).join("next/Cargo.toml")
             ),
         ]

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -32,9 +32,12 @@ async fn is_bin() {
         build_workspace(Path::new(&project_path), false, tx)
             .await
             .unwrap(),
-        vec![Runtime::Alpha(
-            PathBuf::from(project_path).join("target/debug/is-bin")
-        )]
+        vec![Runtime::new(
+            PathBuf::from(&project_path).join("target/debug/is-bin"),
+            false,
+            "is_bin".to_string(),
+            PathBuf::from(&project_path).join("Cargo.toml")
+        ),]
     );
 }
 
@@ -62,8 +65,18 @@ async fn workspace() {
             .await
             .unwrap(),
         vec![
-            Runtime::Alpha(PathBuf::from(&project_path).join("target/debug/alpha")),
-            Runtime::Next(PathBuf::from(&project_path).join("target/wasm32-wasi/debug/next.wasm"))
+            Runtime::new(
+                PathBuf::from(&project_path).join("target/debug/alpha"),
+                false,
+                "alpha".to_string(),
+                PathBuf::from(&project_path).join("alpha/Cargo.toml")
+            ),
+            Runtime::new(
+                PathBuf::from(&project_path).join("target/wasm32-wasi/debug/next.wasm"),
+                true,
+                "next".to_string(),
+                PathBuf::from(&project_path).join("next/Cargo.toml")
+            ),
         ]
     );
 }

--- a/service/tests/resources/workspace/Cargo.toml
+++ b/service/tests/resources/workspace/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-
 members = [
     "alpha",
     "next",

--- a/service/tests/resources/workspace/Shuttle.toml
+++ b/service/tests/resources/workspace/Shuttle.toml
@@ -1,0 +1,1 @@
+name = "workspace-test"

--- a/service/tests/resources/workspace/Shuttle.toml
+++ b/service/tests/resources/workspace/Shuttle.toml
@@ -1,1 +1,0 @@
-name = "workspace-test"

--- a/service/tests/resources/workspace/alpha/Shuttle.toml
+++ b/service/tests/resources/workspace/alpha/Shuttle.toml
@@ -1,0 +1,1 @@
+name = 'named-service'


### PR DESCRIPTION
## Description of change

This makes it so all services in a workspace are started for local runs. This required making some changes to build_crate and refactoring the runtime enum so we can get the working directory of each crate, as well as the service name.

TODO:

- [x] properly get the service_name for each crate (check for shuttle.toml before using package name)
- [ ] consider making abstractions for the runtime that would work for both deployer and local run, perhaps a trait with a start method? 

## How Has This Been Tested (if applicable)?

Tested by running updated tests and local runs of the `service/tests/resources/workspace` project.
