### PR TITLE
refactor: getting project name

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -5,6 +5,8 @@ use std::{
     path::PathBuf,
 };
 
+use anyhow::Context;
+use cargo_metadata::MetadataCommand;
 use clap::builder::{OsStringValueParser, PossibleValue, TypedValueParser};
 use clap::Parser;
 use clap_complete::Shell;
@@ -44,6 +46,41 @@ pub struct ProjectArgs {
     /// Specify the name of the project (overrides crate name)
     #[arg(global = true, long)]
     pub name: Option<ProjectName>,
+}
+
+impl ProjectArgs {
+    pub fn workspace_path(&self) -> anyhow::Result<PathBuf> {
+        let path = MetadataCommand::new()
+            .current_dir(&self.working_directory)
+            .exec()
+            .context("failed to get cargo metadata")?
+            .workspace_root
+            .into();
+
+        Ok(path)
+    }
+
+    pub fn project_name(&self) -> anyhow::Result<ProjectName> {
+        let workspace_path = self.workspace_path()?;
+
+        let meta = MetadataCommand::new()
+            .current_dir(&workspace_path)
+            .exec()
+            .unwrap();
+        let package_name = if let Some(root_package) = meta.root_package() {
+            root_package.name.clone().parse()?
+        } else {
+            workspace_path
+                .file_name()
+                .context("failed to get project name from workspace path")?
+                .to_os_string()
+                .into_string()
+                .expect("to turn workspace name into path")
+                .parse()?
+        };
+
+        Ok(package_name)
+    }
 }
 
 #[derive(Parser)]
@@ -270,6 +307,8 @@ pub(crate) fn parse_init_path(path: OsString) -> Result<PathBuf, io::Error> {
 mod tests {
     use strum::IntoEnumIterator;
 
+    use crate::tests::path_from_workspace_root;
+
     use super::*;
 
     fn init_args_factory(framework: &str) -> InitArgs {
@@ -316,5 +355,46 @@ mod tests {
             let args = init_args_factory(&framework.to_string());
             assert_eq!(args.framework(), Some(framework));
         }
+    }
+
+    #[test]
+    fn workspace_path() {
+        let project_args = ProjectArgs {
+            working_directory: path_from_workspace_root("examples/axum/hello-world/src"),
+            name: None,
+        };
+
+        assert_eq!(
+            project_args.workspace_path().unwrap(),
+            path_from_workspace_root("examples/axum/hello-world/")
+        );
+    }
+
+    #[test]
+    fn project_name() {
+        let project_args = ProjectArgs {
+            working_directory: path_from_workspace_root("examples/axum/hello-world/src"),
+            name: None,
+        };
+
+        assert_eq!(
+            project_args.project_name().unwrap().to_string(),
+            "hello-world"
+        );
+    }
+
+    #[test]
+    fn project_name_in_workspace() {
+        let project_args = ProjectArgs {
+            working_directory: path_from_workspace_root(
+                "examples/rocket/workspace/hello-world/src",
+            ),
+            name: None,
+        };
+
+        assert_eq!(
+            project_args.project_name().unwrap().to_string(),
+            "workspace"
+        );
     }
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -75,7 +75,7 @@ impl ProjectArgs {
                 .context("failed to get project name from workspace path")?
                 .to_os_string()
                 .into_string()
-                .expect("to turn workspace name into path")
+                .expect("workspace file name should be valid unicode")
                 .parse()?
         };
 

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -270,7 +270,7 @@ impl RequestContext {
         project_args: &ProjectArgs,
     ) -> Result<Config<LocalConfigManager, ProjectConfig>> {
         let local_manager =
-            LocalConfigManager::new(&project_args.workspace_path()?, "Shuttle.toml".to_string());
+            LocalConfigManager::new(project_args.workspace_path()?, "Shuttle.toml".to_string());
         let mut project = Config::new(local_manager);
 
         if !project.exists() {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -992,11 +992,11 @@ mod tests {
     use std::str::FromStr;
 
     pub fn path_from_workspace_root(path: &str) -> PathBuf {
-        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        let path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
             .join("..")
-            .join(path)
-            .canonicalize()
-            .unwrap()
+            .join(path);
+
+        dunce::canonicalize(path).unwrap()
     }
 
     fn get_archive_entries(mut project_args: ProjectArgs) -> Vec<String> {


### PR DESCRIPTION
## Description of change
This PR improves how we get the name of the project and how we identify the root `Cargo.toml` file in a project.

This is the preferred order for a project name:
1. Name given on command line                           
2. Name from Shuttle.toml file                          
3. Name from Cargo.toml package if it's a crate         
3. Name from the workspace directory if it's a workspace

## How Has This Been Tested (if applicable)?
By running the tests locally and adding new tests. Note, the tests require shuttle-hq/examples#35
