### PR TITLE
feat examples: switch to relative url for examples submodule to allow…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples"]
 	path = examples
-	url = git@github.com:shuttle-hq/examples.git
+	url = ../examples.git


### PR DESCRIPTION
… git cloning via git or https

## Description of change

I use PAT token to access github, rather than an ssh key.
The submodules specification is currently hardcoded to use a git:// url which means when I follow the contributing instructions, `git submodule update` fails.

This PR changes the submodule referent to a relative url which allows `git submodule update` to work.

There are no linked issues, but I have mentioned this in contributors channel on discord.

## How Has This Been Tested (if applicable)?

Only testing I have done is locally on my machine.
I guess this PR might have the potential to break CI as I found I had to run `git submodule sync` before the change in the PR took effect.  Other developers who have existing code checked out will also need to run `git submodule sync` so this ought to go in the release notes and/or contributing guide.