### PR TITLE
refactor: get the static folder name from the

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,6 +54,12 @@ pub enum ParseError {
     Serde(#[from] serde_json::Error),
 }
 
+/// Holds the input for a DB resource
+#[derive(Deserialize, Serialize, Default)]
+pub struct DbInput {
+    pub local_uri: Option<String>,
+}
+
 /// Holds the output for a DB resource
 #[derive(Deserialize, Serialize)]
 pub enum DbOutput {

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
 use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, CellAlignment,
@@ -122,13 +122,7 @@ fn get_static_folder_table(static_folders: &[&Response], service_name: &str) -> 
             .add_attribute(Attribute::Bold)]);
 
     for folder in static_folders {
-        let path = serde_json::from_value::<PathBuf>(folder.data.clone())
-            .unwrap()
-            .file_name()
-            .expect("static folder path should have a final component")
-            .to_str()
-            .expect("static folder file name should be valid unicode")
-            .to_owned();
+        let path = serde_json::from_value::<String>(folder.config.clone()).unwrap();
 
         table.add_row(vec![path]);
     }

--- a/resources/persist/src/lib.rs
+++ b/resources/persist/src/lib.rs
@@ -71,10 +71,16 @@ impl PersistInstance {
 impl ResourceBuilder<PersistInstance> for Persist {
     const TYPE: Type = Type::Persist;
 
+    type Config = ();
+
     type Output = PersistInstance;
 
     fn new() -> Self {
         Self {}
+    }
+
+    fn config(&self) -> &Self::Config {
+        &()
     }
 
     async fn output(

--- a/resources/secrets/src/lib.rs
+++ b/resources/secrets/src/lib.rs
@@ -12,19 +12,25 @@ pub struct Secrets;
 impl ResourceBuilder<SecretStore> for Secrets {
     const TYPE: Type = Type::Secrets;
 
+    type Config = ();
+
     type Output = SecretStore;
 
     fn new() -> Self {
         Self {}
     }
 
-    async fn build(build_data: &Self::Output) -> Result<SecretStore, crate::Error> {
-        Ok(build_data.clone())
+    fn config(&self) -> &Self::Config {
+        &()
     }
 
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, crate::Error> {
         let secrets = factory.get_secrets().await?;
 
         Ok(SecretStore::new(secrets))
+    }
+
+    async fn build(build_data: &Self::Output) -> Result<SecretStore, crate::Error> {
+        Ok(build_data.clone())
     }
 }

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -32,10 +32,16 @@ impl<'a> StaticFolder<'a> {
 impl<'a> ResourceBuilder<PathBuf> for StaticFolder<'a> {
     const TYPE: Type = Type::StaticFolder;
 
+    type Config = &'a str;
+
     type Output = PathBuf;
 
     fn new() -> Self {
         Self { folder: "static" }
+    }
+
+    fn config(&self) -> &&'a str {
+        &self.folder
     }
 
     async fn output(

--- a/runtime/src/resource_tracker.rs
+++ b/runtime/src/resource_tracker.rs
@@ -58,8 +58,8 @@ where
     B: ResourceBuilder<T, Output = O>,
     O: Serialize + DeserializeOwned,
 {
-    let config =
-        serde_json::to_value(&builder).context("failed to turn builder config into a value")?;
+    let config = serde_json::to_value(builder.config())
+        .context("failed to turn builder config into a value")?;
     let output = if let Some(output) = resource_tracker.get_cached_output(B::TYPE, &config) {
         match serde_json::from_value(output) {
             Ok(output) => output,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -139,17 +139,29 @@ pub trait Factory: Send + Sync {
 ///
 /// #[async_trait]
 /// impl ResourceBuilder<Resource> for Builder {
+///     const TYPE: Type = Type::Custom;
+///
+///     type Config = Self;
+///
+///     type Output = String;
+///
 ///     fn new() -> Self {
 ///         Self {
 ///             name: String::new(),
 ///         }
 ///     }
 ///
-///     async fn build(
-///         self,
-///         factory: &mut dyn Factory,
-///     ) -> Result<Resource, shuttle_service::Error> {
-///         Ok(Resource { name: self.name })
+///     fn config(&self) -> &Self::Config {
+///         &self
+///     }
+///
+///
+///     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, shuttle_service::Error> {
+///         Ok(self.name)
+///     }
+///
+///     async fn build(build_data: &Self::Output) -> Result<Resource, shuttle_service::Error> {
+///         Ok(Resource { name: build_data })
 ///     }
 /// }
 /// ```

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -8,7 +8,9 @@ pub mod error;
 pub use error::{CustomError, Error};
 
 use serde::{de::DeserializeOwned, Serialize};
-pub use shuttle_common::{database, resource::Type, DatabaseReadyInfo, DbOutput, SecretStore};
+pub use shuttle_common::{
+    database, resource::Type, DatabaseReadyInfo, DbInput, DbOutput, SecretStore,
+};
 
 #[cfg(feature = "codegen")]
 extern crate shuttle_codegen;
@@ -161,9 +163,12 @@ pub trait Factory: Send + Sync {
 ///     -> shuttle_axum::ShuttleAxum {}
 /// ```
 #[async_trait]
-pub trait ResourceBuilder<T>: Serialize {
+pub trait ResourceBuilder<T> {
     /// The type of resource this creates
     const TYPE: Type;
+
+    /// The internal config being constructed by this builder. This will be used to find cached [Self::Output].
+    type Config: Serialize;
 
     /// The output type used to build this resource later
     type Output: Serialize + DeserializeOwned;
@@ -171,11 +176,22 @@ pub trait ResourceBuilder<T>: Serialize {
     /// Create a new instance of this resource builder
     fn new() -> Self;
 
-    /// Build this resource from its config output
-    async fn build(build_data: &Self::Output) -> Result<T, crate::Error>;
+    /// Get the internal config state of the builder
+    ///
+    /// If the exact same config was returned by a previous deployement that used this resource, then [Self::output()]
+    /// will not be called to get the builder output again. Rather the output state of the previous deployment
+    /// will be passed to [Self::build()].
+    fn config(&self) -> &Self::Config;
 
     /// Get the config output of this builder
+    ///
+    /// This method is where the actual resource provisioning should take place and is expected to take the longest. It
+    /// can at times even take minutes. That is why the output of this method is cached and calling this method can be
+    /// skipped as explained in [Self::config()].
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, crate::Error>;
+
+    /// Build this resource from its config output
+    async fn build(build_data: &Self::Output) -> Result<T, crate::Error>;
 }
 
 /// The core trait of the shuttle platform. Every crate deployed to shuttle needs to implement this trait.


### PR DESCRIPTION
## Description of change
This change causes `ResourceBuilder`s to output the build config they were constructed with. This allows for richer info when building the resource tables.

## How Has This Been Tested (if applicable)?
Using the local runner
