### PR TITLE
fix: is_dirty path bug on windows

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -885,8 +885,9 @@ impl Shuttle {
         if let Ok(repo) = Repository::discover(working_directory) {
             let repo_path = repo
                 .workdir()
-                .context("getting working directory of repository")?
-                .canonicalize()?;
+                .context("getting working directory of repository")?;
+
+            let repo_path = dunce::canonicalize(repo_path)?;
 
             trace!(?repo_path, "found git repository");
 

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -618,7 +618,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(360)) => {
+            _ = sleep(Duration::from_secs(400)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Running' for a valid service: {:#?}", states);
             },
@@ -702,7 +702,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(360)) => {
+            _ = sleep(Duration::from_secs(400)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Completed' when a service stops by itself: {:#?}", states);
             }
@@ -749,7 +749,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(360)) => {
+            _ = sleep(Duration::from_secs(400)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Crashed' panicking in bind: {:#?}", states);
             }
@@ -792,7 +792,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(360)) => {
+            _ = sleep(Duration::from_secs(400)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Crashed' when panicking in main: {:#?}", states);
             }

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -618,7 +618,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(400)) => {
+            _ = sleep(Duration::from_secs(460)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Running' for a valid service: {:#?}", states);
             },
@@ -702,7 +702,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(400)) => {
+            _ = sleep(Duration::from_secs(460)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Completed' when a service stops by itself: {:#?}", states);
             }
@@ -749,7 +749,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(400)) => {
+            _ = sleep(Duration::from_secs(460)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Crashed' panicking in bind: {:#?}", states);
             }
@@ -792,7 +792,7 @@ mod tests {
         );
 
         select! {
-            _ = sleep(Duration::from_secs(400)) => {
+            _ = sleep(Duration::from_secs(460)) => {
                 let states = RECORDER.lock().unwrap().get_deployment_states(&id);
                 panic!("states should go into 'Crashed' when panicking in main: {:#?}", states);
             }


### PR DESCRIPTION
## Description of change

This fixes the bug where the deploy command would error if the working tree is dirty, rather than display the warning about the working tree being dirty and the suggestion to us --allow-dirty.

Fixes https://github.com/shuttle-hq/shuttle/issues/775

## How Has This Been Tested (if applicable)?

Tested by deploying to unstable (on windows).
