### PR TITLE
docs: update deployer local run guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,8 +167,16 @@ config (which will be a file named `config.toml` in a directory named `shuttle` 
 echo "api_key = '<jwt>'" > ~/.config/shuttle/config.toml
 ```
 
+> Note: if you have [`jq`](https://github.com/stedolan/jq/wiki/Installation) installed you can combine the two
+>above commands into the following:
+>```bash
+>curl -s -H "Authorization: Bearer test-key" localhost:8008/auth/key \
+>    | jq -r '.token' \
+>    | read token; echo "api_key='$token'" > ~/.config/shuttle/config.toml
+>```
+
 Finally we need to comment out the admin layer in the deployer handlers. So in `deployer/handlers/mod.rs`,
-comment out this line: `.layer(AdminSecretLayer::new(admin_secret))`.
+in the `make_router` function comment out this line: `.layer(AdminSecretLayer::new(admin_secret))`.
 
 And that's it, we're ready to start our deployer!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,16 +151,19 @@ AUTH_CONTAINER_ID=$(docker ps -aqf "name=shuttle-auth") \
 ```
 
 Before we can run commands against a local deployer, we need to get a valid JWT and set it in our
-`.config/shuttle/config.toml` as our `api_key`:
+`.config/shuttle/config.toml` as our `api_key`. By running the following curl command, we will request
+that our api-key in the `Authorization` header be converted to a JWT, which will be returned in the response:
 
 ```bash
 curl -H "Authorization: Bearer test-key" localhost:8008/auth/key
 ```
 
-Now copy the `token` value, the full JWT, and write it to your shuttle config (which will be in one of
+Now copy the `token` value (just the value, not the key) from the curl response, and write it to your shuttle
+config (which will be a file named `config.toml` in a directory named `shuttle` in one of 
 [these places](https://docs.rs/dirs/latest/dirs/fn.config_dir.html) depending on your OS).
 
 ```bash
+# replace <jwt> with the token from the previous command
 echo "api_key = '<jwt>'" > ~/.config/shuttle/config.toml
 ```
 


### PR DESCRIPTION
## Description of change

With the addition of the auth service, how we start the deployer for local development has changed quite a bit. This PR updates the guide in contributing.md with the new steps.

This PR does make any changes to make starting the deployer locally easier, it just documents how it can be done currently.

## How Has This Been Tested (if applicable)?

Tested by starting the deployer locally and deploying examples to it.
