### PR TITLE
fix: cargo shuttle integration tests, project cmd renaming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ start a deployer container:
 
 ```bash
 # the --manifest-path is used to locate the root of the shuttle workspace
-cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- project new
+cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- project start
 ```
 
 Deploy the example:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ And to deploy it, write:
 
 ```bash
 cd hello-world
-cargo shuttle project new  # Only needed if project has not already been created during init
+cargo shuttle project start  # Only needed if project has not already been created during init
 cargo shuttle deploy
 ```
 

--- a/cargo-shuttle/README.md
+++ b/cargo-shuttle/README.md
@@ -166,7 +166,7 @@ cargo shuttle login --api-key <your-api-key-from-browser>
 To deploy your shuttle project to the cloud, run:
 
 ```sh
-cargo shuttle project new
+cargo shuttle project start
 cargo shuttle deploy
 ```
 

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -25,9 +25,7 @@ async fn cargo_shuttle_command(
 }
 
 #[tokio::test]
-#[should_panic(
-    expected = "Could not locate the root of a cargo project. Are you inside a cargo project? You can also use `--working-directory` to locate your cargo project."
-)]
+#[should_panic(expected = "failed to start `cargo metadata`: No such file or directory")]
 async fn fails_if_working_directory_does_not_exist() {
     cargo_shuttle_command(Command::Status, "/path_that_does_not_exist")
         .await
@@ -35,9 +33,7 @@ async fn fails_if_working_directory_does_not_exist() {
 }
 
 #[tokio::test]
-#[should_panic(
-    expected = "Could not locate the root of a cargo project. Are you inside a cargo project? You can also use `--working-directory` to locate your cargo project."
-)]
+#[should_panic(expected = "could not find `Cargo.toml` in `/` or any parent directory")]
 async fn fails_if_working_directory_not_part_of_cargo_workspace() {
     cargo_shuttle_command(Command::Status, "/").await.unwrap();
 }

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -69,7 +69,7 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::UserAlreadyExists => (StatusCode::BAD_REQUEST, "user already exists"),
             ErrorKind::ProjectNotFound => (
                 StatusCode::NOT_FOUND,
-                "project not found. Run `cargo shuttle project new` to create a new project.",
+                "project not found. Run `cargo shuttle project start` to create a new project.",
             ),
             ErrorKind::ProjectNotReady => (StatusCode::SERVICE_UNAVAILABLE, "project not ready"),
             ErrorKind::ProjectUnavailable => {

--- a/e2e/tests/integration/helpers/mod.rs
+++ b/e2e/tests/integration/helpers/mod.rs
@@ -309,7 +309,7 @@ impl Services {
     ///
     /// * `target` - A string that describes the test target
     /// * `example_path` - Path to a specific example within the examples dir, this is where
-    ///   `project new` and `deploy` will run
+    ///   `project start` and `deploy` will run
     /// * `color` - a preferably unique `crossterm::style::Color` to distinguish test logs
     pub fn new_docker<D, C>(target: D, example_path: D, color: C) -> Self
     where

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -84,7 +84,7 @@
 //! now if you did in in the `cargo shuttle init` flow.
 //!
 //! ```bash
-//! $ cargo shuttle project new
+//! $ cargo shuttle project start
 //! ```
 //!
 //! Then, deploy the service with:


### PR DESCRIPTION
## Description of change

Fixes some missing renames of project commands, and update some tests that now give an error from cargo metadata rather than cargo.

## How Has This Been Tested (if applicable)?

Ran the updated tests.
