### PR TITLE
feat: ensure API key is valid

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,13 +93,15 @@ Before we can login to our local instance of shuttle, we need to create a user.
 The following command inserts a user into the `auth` state with admin privileges:
 
 ```bash
-docker compose --file docker-compose.rendered.yml --project-name shuttle-dev exec auth /usr/local/bin/service --state=/var/lib/shuttle-auth init --name admin --key test-key
+# the --key needs to be 16 alphanumeric characters
+docker compose --file docker-compose.rendered.yml --project-name shuttle-dev exec auth /usr/local/bin/service --state=/var/lib/shuttle-auth init --name admin --key dh9z58jttoes3qvt
 ```
 
 Login to shuttle service in a new terminal window from the root of the shuttle directory:
 
 ```bash
-cargo run --bin cargo-shuttle -- login --api-key "test-key"
+# the --api-kei should be the same one you inserted in the auth state
+cargo run --bin cargo-shuttle -- login --api-key "dh9z58jttoes3qvt"
 ```
 
 The [shuttle examples](https://github.com/shuttle-hq/examples) are linked to the main repo as a [git submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules), to initialize it run the following commands:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1898,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
  "console",
  "fuzzy-matcher",
@@ -3201,6 +3216,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
 name = "libnghttp2-sys"
 version = "0.1.7+1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,6 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4156,6 +4178,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags 1.3.2",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,6 +4285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4284,6 +4333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -4476,7 +4534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -4688,6 +4746,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -5092,6 +5162,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "pin-project",
+ "proptest",
  "prost-types",
  "reqwest",
  "ring",
@@ -6420,6 +6491,12 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -18,7 +18,7 @@ clap = { workspace = true, features = ["env"] }
 clap_complete = "4.1.5"
 crossbeam-channel = { workspace = true }
 crossterm = { workspace = true }
-dialoguer = { version = "0.10.3", features = ["fuzzy-select"] }
+dialoguer = { version = "0.10.4", features = ["fuzzy-select"] }
 dirs = { workspace = true }
 dunce = "1.0.3"
 flate2 = { workspace = true }

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -216,7 +216,7 @@ impl Client {
         let mut request = url.into_client_request()?;
 
         if let Some(ref api_key) = self.api_key {
-            let auth_header = Authorization::bearer(api_key)?;
+            let auth_header = Authorization::bearer(api_key.as_ref())?;
             request.headers_mut().typed_insert(auth_header);
         }
 
@@ -282,7 +282,7 @@ impl Client {
 
     fn set_builder_auth(&self, builder: RequestBuilder) -> RequestBuilder {
         if let Some(ref api_key) = self.api_key {
-            builder.bearer_auth(api_key)
+            builder.bearer_auth(api_key.as_ref())
         } else {
             builder
         }

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -122,24 +122,24 @@ impl ConfigManager for LocalConfigManager {
 /// Global client config for things like API keys.
 #[derive(Deserialize, Serialize, Default)]
 pub struct GlobalConfig {
-    pub api_key: Option<ApiKey>,
+    api_key: Option<String>,
     pub api_url: Option<ApiUrl>,
 }
 
 impl GlobalConfig {
-    pub fn api_key(&self) -> Option<&ApiKey> {
-        self.api_key.as_ref()
+    pub fn api_key(&self) -> Option<Result<ApiKey>> {
+        self.api_key.as_ref().map(|key| ApiKey::parse(key))
     }
 
-    pub fn set_api_key(&mut self, api_key: ApiKey) -> Option<ApiKey> {
-        self.api_key.replace(api_key)
+    pub fn set_api_key(&mut self, api_key: ApiKey) -> Option<String> {
+        self.api_key.replace(api_key.as_ref().to_string())
     }
 
     pub fn clear_api_key(&mut self) {
         self.api_key = None;
     }
 
-    pub fn api_url(&self) -> Option<ApiKey> {
+    pub fn api_url(&self) -> Option<ApiUrl> {
         self.api_url.clone()
     }
 }
@@ -324,24 +324,22 @@ impl RequestContext {
     /// otherwise from the global configuration. Returns an error if
     /// an API key is not set.
     pub fn api_key(&self) -> Result<ApiKey> {
-        std::env::var("SHUTTLE_API_KEY")
-            .context("environment variable SHUTTLE_API_KEY is not set or invalid")
-            .or_else(|_| {
-                self.global
-                    .as_ref()
-                    .unwrap()
-                    .api_key()
-                    .map(|key| key.to_owned())
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "Configuration file: `{}`",
-                            self.global.manager.path().display()
-                        )
-                        .context(anyhow!(
-                            "No valid API key found, try logging in first with:\n\tcargo shuttle login"
-                        ))
-                    })
-            })
+        let api_key = std::env::var("SHUTTLE_API_KEY");
+
+        if let Ok(key) = api_key {
+            ApiKey::parse(&key).context("environment variable SHUTTLE_API_KEY is invalid")
+        } else {
+            match self.global.as_ref().unwrap().api_key() {
+                Some(key) => key,
+                None => Err(anyhow!(
+                    "Configuration file: `{}`",
+                    self.global.manager.path().display()
+                )
+                .context(anyhow!(
+                    "No valid API key found, try logging in first with:\n\tcargo shuttle login"
+                ))),
+            }
+        }
     }
 
     /// Get the current context working directory
@@ -358,10 +356,10 @@ impl RequestContext {
     }
 
     /// Set the API key to the global configuration. Will persist the file.
-    pub fn set_api_key(&mut self, api_key: ApiKey) -> Result<Option<ApiKey>> {
-        let res = self.global.as_mut().unwrap().set_api_key(api_key);
+    pub fn set_api_key(&mut self, api_key: ApiKey) -> Result<()> {
+        self.global.as_mut().unwrap().set_api_key(api_key);
         self.global.save()?;
-        Ok(res)
+        Ok(())
     }
 
     pub fn clear_api_key(&mut self) -> Result<()> {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -9,7 +9,7 @@ use shuttle_common::models::deployment::get_deployments_table;
 use shuttle_common::models::project::{State, IDLE_MINUTES};
 use shuttle_common::models::resource::get_resources_table;
 use shuttle_common::project::ProjectName;
-use shuttle_common::resource;
+use shuttle_common::{resource, ApiKey};
 use shuttle_proto::runtime::{self, LoadRequest, StartRequest, SubscribeLogsRequest};
 use tokio::task::JoinSet;
 
@@ -261,11 +261,12 @@ impl Shuttle {
 
                 Password::with_theme(&ColorfulTheme::default())
                     .with_prompt("API key")
+                    .validate_with(|input: &String| ApiKey::parse(input).map(|_| {}))
                     .interact()?
             }
         };
 
-        let api_key = api_key_str.trim().parse()?;
+        let api_key = ApiKey::parse(&api_key_str)?;
 
         self.ctx.set_api_key(api_key)?;
 

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -18,7 +18,7 @@ async fn non_interactive_basic_init() {
         "http://shuttle.invalid:80",
         "init",
         "--api-key",
-        "fake-api-key",
+        "dh9z58jttoes3qvt",
         "--name",
         "my-project",
         "--no-framework",
@@ -44,7 +44,7 @@ async fn non_interactive_rocket_init() {
         "http://shuttle.invalid:80",
         "init",
         "--api-key",
-        "fake-api-key",
+        "dh9z58jttoes3qvt",
         "--name",
         "my-project",
         "--rocket",
@@ -67,7 +67,7 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
         "http://shuttle.invalid:80",
         "init",
         "--api-key",
-        "fake-api-key",
+        "dh9z58jttoes3qvt",
     ]);
     let mut session = rexpect::session::spawn_command(command, Some(2000))?;
 
@@ -106,7 +106,7 @@ fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::er
         "http://shuttle.invalid:80",
         "init",
         "--api-key",
-        "fake-api-key",
+        "dh9z58jttoes3qvt",
         "--rocket",
     ]);
     let mut session = rexpect::session::spawn_command(command, Some(2000))?;
@@ -141,7 +141,7 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
         "http://shuttle.invalid:80",
         "init",
         "--api-key",
-        "fake-api-key",
+        "dh9z58jttoes3qvt",
         "--name",
         "my-project",
     ]);

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -88,6 +88,7 @@ axum = { workspace = true }
 base64 = { workspace = true }
 cap-std = { workspace = true }
 hyper = { workspace = true }
+proptest = "1.1.0"
 ring = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tower = { workspace = true, features = ["util"] }


### PR DESCRIPTION
## Description of change

This creates a newtype for the api-key on the client side, so we can maintain that it is always a valid api-key. We should extend this type to also be usable in the `auth` crate in the future.

Closes https://github.com/shuttle-hq/shuttle/issues/779

## How Has This Been Tested (if applicable)?

Added tests for the `parse` function, and tested variations of login and other commands with and without the `SHUTTLE_API_KEY` env against unstable.
