### PR TITLE
chore: bump otel crates to remove protoc requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,9 +3707,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
+checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -3717,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc79add46364183ece1a4542592ca593e6421c60807232f5b8f7a31703825d"
+checksum = "a819b71d6530c4297b49b3cae2939ab3a8cc1b9f382826a1bc29dd0ca3864906"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3729,9 +3729,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
+checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
 dependencies = [
  "async-trait",
  "futures",
@@ -3747,39 +3747,38 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
+checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
 dependencies = [
  "futures",
  "futures-util",
  "opentelemetry",
  "prost",
  "tonic",
- "tonic-build",
 ]
 
 [[package]]
 name = "opentelemetry_api"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
+checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
 dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
  "indexmap",
- "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
+checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
@@ -6279,9 +6278,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+version = "0.19.0"
+source = "git+https://github.com/oddgrd/tracing-opentelemetry?branch=update-opentelemetry-0.19#76b0a0fe45fd53c352e8bfdcdfad775aed727e4c"
 dependencies = [
  "once_cell",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ http = "0.2.8"
 hyper = "0.14.23"
 jsonwebtoken = { version = "8.2.0" }
 once_cell = "1.16.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-http = "0.7.0"
+opentelemetry = { version = "0.19.0", features = ["rt-tokio"] }
+opentelemetry-http = "0.8.0"
 pin-project = "1.0.12"
 pipe = "0.4.0"
 portpicker = "0.1.1"
@@ -87,7 +87,8 @@ tonic-build = "0.8.3"
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = { version = "0.1.37", default-features = false }
-tracing-opentelemetry = "0.18.0"
+# temporary git dependency until 0.19 is released
+tracing-opentelemetry = { git = "https://github.com/oddgrd/tracing-opentelemetry", branch = "update-opentelemetry-0.19" }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
   "registry",
   "std",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,7 @@ jsonwebtoken = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
-opentelemetry-otlp = { version = "0.11.0", optional = true }
+opentelemetry-otlp = { version = "0.12.0", optional = true }
 pin-project = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }


### PR DESCRIPTION
## Description of change

This bumps otel deps to get rid of the protoc requirement, using a git dependency for tracing-opentelemetry until the PR for 0.19 is merged.

TODO: remove protoc from CI and docs.

## How Has This Been Tested (if applicable)?

TODO
