### PR TITLE
docs: clarify shuttle_static_folder will not be adjacent to executable

### DIFF
--- a/resources/static-folder/README.md
+++ b/resources/static-folder/README.md
@@ -20,8 +20,8 @@ The folder obtained will be consistent between deployments, but will not be in t
 
 
 ``` rust
-#[shuttle_service::main]
-async fn main(
+#[shuttle_runtime::main]
+async fn app(
     #[shuttle_static_folder::StaticFolder] static_folder: PathBuf,
 ) -> __ { ... }
 ```
@@ -37,8 +37,8 @@ async fn main(
 Since this plugin defaults to the `static` folder, the arguments can be used to use the `public` folder instead.
 
 ``` rust
-#[shuttle_service::main]
-async fn main(
+#[shuttle_runtime::main]
+async fn app(
     #[shuttle_static_folder::StaticFolder(folder = "public")] public_folder: PathBuf,
 ) -> __ { ... }
 ```

--- a/resources/static-folder/README.md
+++ b/resources/static-folder/README.md
@@ -1,12 +1,23 @@
 # Shuttle Static Folder
 
-This plugin allows services to get the path to a static folder at runtime
+This plugin allows services to get the path to a static folder at runtime.
 
 ## Usage
 
-Add `shuttle-static-folder` to the dependencies for your service. This resource can be using by the `shuttle_static_folder::StaticFolder` attribute to get a `PathBuf` with the location of the static folder.
+Add `shuttle-static-folder` to the dependencies for your service. 
+This resource will be provided by adding the `shuttle_static_folder::StaticFolder` attribute to `main`.  
 
-An example using the Axum framework can be found on [GitHub](https://github.com/shuttle-hq/examples/tree/main/axum/websocket)
+It returns  a `PathBuf` which holds the location of the static folder.
+
+The folder obtained will be consistent between deployments, but will not be in the same folder as the executable.  This has implications when using some frameworks such as [Rocket](https://github.com/SergioBenitez/rocket) because it becomes necessary to override the default location when using Rocket's dynamic templates or static file serving features.
+
+#### Example projects that use `shuttle-static-folder`
+
+| Framework | Link                                                                                                        |
+|-----------|-------------------------------------------------------------------------------------------------------------|
+| Axum      | [axum websocket example](https://github.com/shuttle-hq/examples/tree/main/axum/websocket)                   |
+| Rocket    | [rocket dynamic template example](https://github.com/shuttle-hq/examples/tree/main/rocket/dyn_template_hbs) |
+
 
 ``` rust
 #[shuttle_service::main]


### PR DESCRIPTION
## Description of change

Following discussion on https://github.com/shuttle-hq/shuttle/issues/763 add information about shuttle-static-folder to the documentation.

Note. Example link assumes that https://github.com/shuttle-hq/examples/pull/38 has been merged to examples.

Intended to close https://github.com/shuttle-hq/shuttle/issues/763

## How Has This Been Tested (if applicable)?

Docs change so not really testable, but I checked the that .md renders ok in CLion.
