### PR TITLE
cargo-shuttle: fix address in use error when service panicked in a previous run

### DIFF
--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -41,7 +41,7 @@ serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio-native-tls", "postgres"] }
 strum = { workspace = true }
 tar = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "signal"] }
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }
 toml = { workspace = true }
 toml_edit = { workspace = true }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -657,7 +657,7 @@ impl Shuttle {
             .stop(tonic::Request::new(stop_request))
             .or_else(|err| async {
                 runtime.kill().await?;
-                error!(status = ?err, "killed the runtime by force because stopping it errored out");
+                trace!(status = ?err, "killed the runtime by force because stopping it errored out");
                 Err(err)
             })
             .await?

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -684,8 +684,6 @@ impl Shuttle {
         // Compile all the alpha or shuttle-next services in the workspace.
         let services = build_workspace(working_directory, run_args.release, tx).await?;
 
-        // TODO: figure out how best to handle the runtime handles, and what to do if
-        // one completes.
         let (mut sigterm_notif, mut sigint_notif) = if cfg!(target_family = "unix") {
             (
                 Some(
@@ -773,7 +771,7 @@ impl Shuttle {
         }
 
         // If no signal was received during runtimes initialization, then we must handle each runtime until
-        // comletion and handle the signals during this time.
+        // completion and handle the signals during this time.
         if cfg!(target_family = "unix") {
             let sigterm = sigterm_notif.as_mut().expect("SIGTERM reactor failure");
             let sigint = sigint_notif.as_mut().expect("SIGINT reactor failure");

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -607,10 +607,9 @@ impl Shuttle {
 
             if !response.success {
                 error!(error = response.message, "failed to load your service");
-                // TODO: we must kill the rest of the runtimes when we'll start multiple services from a workspace,
-                // but now this is not concerning given we're not supporting more than one services.
                 provisioner_server.abort();
                 runtime.kill().await?;
+                runtime_handles.abort_all();
                 exit(1);
             }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -249,6 +249,7 @@ pub mod runtime {
 
         let runtime = process::Command::new(runtime_executable_path)
             .args(&args)
+            .kill_on_drop(true)
             .spawn()
             .context("spawning runtime process")?;
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -249,7 +249,6 @@ pub mod runtime {
 
         let runtime = process::Command::new(runtime_executable_path)
             .args(&args)
-            .kill_on_drop(true)
             .spawn()
             .context("spawning runtime process")?;
 

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -315,6 +315,21 @@ where
         tokio::spawn(async move {
             let mut background = handle.spawn(service.bind(service_address));
 
+            let (_sigterm_notif, _sigint_notif) = if cfg!(target_family = "unix") {
+                (
+                    Some(
+                        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                            .expect("Can not get the SIGTERM signal receptor"),
+                    ),
+                    Some(
+                        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+                            .expect("Can not get the SIGINT signal receptor"),
+                    ),
+                )
+            } else {
+                (None, None)
+            };
+
             tokio::select! {
                 res = &mut background => {
                     match res {
@@ -354,7 +369,7 @@ where
                     info!("will now abort the service");
                     background.abort();
                     background.await.unwrap().expect("to stop service");
-                }
+                },
             }
         });
 

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -315,21 +315,6 @@ where
         tokio::spawn(async move {
             let mut background = handle.spawn(service.bind(service_address));
 
-            let (_sigterm_notif, _sigint_notif) = if cfg!(target_family = "unix") {
-                (
-                    Some(
-                        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                            .expect("Can not get the SIGTERM signal receptor"),
-                    ),
-                    Some(
-                        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-                            .expect("Can not get the SIGINT signal receptor"),
-                    ),
-                )
-            } else {
-                (None, None)
-            };
-
             tokio::select! {
                 res = &mut background => {
                     match res {
@@ -369,7 +354,7 @@ where
                     info!("will now abort the service");
                     background.abort();
                     background.await.unwrap().expect("to stop service");
-                },
+                }
             }
         });
 

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -15,6 +15,7 @@ use shuttle_proto::{
     runtime::{self, runtime_client::RuntimeClient},
 };
 use shuttle_service::builder::{build_workspace, BuiltService};
+use tokio::process::Child;
 use tonic::{
     transport::{Channel, Server},
     Request, Response, Status,
@@ -26,6 +27,7 @@ pub struct TestRuntime {
     pub service_name: String,
     pub runtime_address: SocketAddr,
     pub secrets: HashMap<String, String>,
+    pub runtime: Child,
 }
 
 pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<TestRuntime> {
@@ -52,7 +54,7 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
     // TODO: update this to work with shuttle-next projects, see cargo-shuttle local run
     let runtime_path = || executable_path.clone();
 
-    let (_, runtime_client) = runtime::start(
+    let (runtime, runtime_client) = runtime::start(
         is_wasm,
         runtime::StorageManagerType::WorkingDir(PathBuf::from(project_path.clone())),
         &format!("http://{}", provisioner_address),
@@ -71,6 +73,7 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
         service_name: service_name.to_string(),
         runtime_address,
         secrets,
+        runtime,
     })
 }
 

--- a/runtime/tests/integration/loader.rs
+++ b/runtime/tests/integration/loader.rs
@@ -12,6 +12,7 @@ async fn bind_panic() {
         secrets,
         mut runtime_client,
         runtime_address,
+        runtime: _runtime, // Keep it to not be dropped and have the process killed.
     } = spawn_runtime(project_path, "bind-panic").await.unwrap();
 
     let load_request = tonic::Request::new(LoadRequest {
@@ -21,7 +22,7 @@ async fn bind_panic() {
         secrets,
     });
 
-    let _ = runtime_client.load(load_request).await.unwrap();
+    runtime_client.load(load_request).await.unwrap();
 
     let mut stream = runtime_client
         .subscribe_stop(tonic::Request::new(SubscribeStopRequest {}))


### PR DESCRIPTION
## Description of change

Running user services locally through `cargo shuttle run` will run a runtime that will load/start a service as a tokio task. If the task panics, the shuttle-runtime will live on because of tokio behavior: https://github.com/tokio-rs/tokio/issues/2002.

This is not the case anymore. I haven't seen this making any difference for our use cases. Removing it to have the `bind_panic` test succeed.
~~Extra: set to true the `kill_on_drop` flag for started shuttle-runtimes to make sure we either `.wait()` or `.kill()` on them or if dropped, the `kill` is automatically issued: https://docs.rs/tokio/latest/tokio/process/struct.Command.html#method.kill_on_drop.~~

## How Has This Been Tested (if applicable)?

Run locally the `hello-world-rocket-app` example with panic in it. Consequent local runs without the fix hang with the `Address in use` error. The fix ensures the runtime and provisioner are killed in case the runtime response is not successful.

Also, if `cargo-shuttle` process receives `SIGINT` or `SIGTERM` it's successfully stopping the existing runtimes.
