### PR TITLE
fix: minor development bug fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,7 +410,7 @@ jobs:
   linux-qa:
     machine:
       image: ubuntu-2004:current
-      resource_class: xlarge
+    resource_class: xlarge
     steps:
       - checkout
       - run:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,6 @@ dependencies = [
  "serde_json",
  "shuttle-common",
  "shuttle-proto",
- "shuttle-secrets",
  "shuttle-service",
  "sqlx",
  "strum",
@@ -5326,15 +5325,6 @@ dependencies = [
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
-]
-
-[[package]]
-name = "shuttle-secrets"
-version = "0.14.0"
-dependencies = [
- "async-trait",
- "serde",
- "shuttle-service",
 ]
 
 [[package]]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -64,10 +64,6 @@ features = ["models"]
 [dependencies.shuttle-proto]
 workspace = true
 
-[dependencies.shuttle-secrets]
-version = "0.14.0"
-path = "../resources/secrets"
-
 [dependencies.shuttle-service]
 workspace = true
 features = ["builder"]

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -8,8 +8,13 @@ use std::fmt::{Display, Formatter};
 use strum::EnumString;
 use utoipa::ToSchema;
 
-// Timeframe before a project is considered idle
+/// Timeframe before a project is considered idle
 pub const IDLE_MINUTES: u64 = 30;
+
+/// Function to set [IDLE_MINUTES] as a serde default
+pub const fn idle_minutes() -> u64 {
+    IDLE_MINUTES
+}
 
 #[derive(Deserialize, Serialize, Clone, ToSchema)]
 #[schema(as = shuttle_common::models::project::Response)]

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -20,7 +20,7 @@ use hyper::Client;
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use serde::{Deserialize, Serialize};
-use shuttle_common::models::project::IDLE_MINUTES;
+use shuttle_common::models::project::{idle_minutes, IDLE_MINUTES};
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, instrument};
 
@@ -582,6 +582,7 @@ pub struct ProjectCreating {
     #[serde(default)]
     recreate_count: usize,
     /// Label set on container as to how many minutes to wait before a project is considered idle
+    #[serde(default = "idle_minutes")]
     idle_minutes: u64,
 }
 


### PR DESCRIPTION
## Description of change

This fixes some minor development bug fixes, namely:
- When releasing a new version some old projects without `idle_minutes` set will be deserialized without it, leading to panics. Added a serde default to `ProjectCreating` to remedy this.
- Removed the unused shuttle-secrets dependency from cargo-shuttle that was causing the new version of cargo-chef to fail to cook.

## How Has This Been Tested (if applicable)?

The idle-minutes change is hard to test since we're not entirely sure which projects caused it, but we should not see the panics anymore. The cargo-chef fix is tested by running `make images`.
