### PR TITLE
feat: refactor deployer to run locally without auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,7 @@ members = [
 exclude = [
   "e2e",
   "examples",
-  "resources/aws-rds",
-  "resources/persist",
-  "resources/secrets",
-  "resources/shared-db",
-  "resources/static-folder",
+  "resources",
   "services",
 ]
 

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -185,33 +185,11 @@ pub enum AccountTier {
 
 impl From<AccountTier> for Vec<Scope> {
     fn from(tier: AccountTier) -> Self {
-        let mut base = vec![
-            Scope::Deployment,
-            Scope::DeploymentPush,
-            Scope::Logs,
-            Scope::Service,
-            Scope::ServiceCreate,
-            Scope::Project,
-            Scope::ProjectCreate,
-            Scope::Resources,
-            Scope::ResourcesWrite,
-            Scope::Secret,
-            Scope::SecretWrite,
-        ];
-
         if tier == AccountTier::Admin {
-            base.append(&mut vec![
-                Scope::User,
-                Scope::UserCreate,
-                Scope::AcmeCreate,
-                Scope::CustomDomainCreate,
-                Scope::CustomDomainCertificateRenew,
-                Scope::GatewayCertificateRenew,
-                Scope::Admin,
-            ]);
+            Scope::admin()
+        } else {
+            Scope::base()
         }
-
-        base
     }
 }
 

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -64,10 +64,6 @@ features = ["models"]
 [dependencies.shuttle-proto]
 workspace = true
 
-[dependencies.shuttle-secrets]
-version = "0.14.0"
-path = "../resources/secrets"
-
 [dependencies.shuttle-service]
 workspace = true
 features = ["builder"]

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -88,6 +88,42 @@ pub enum Scope {
     Admin,
 }
 
+impl Scope {
+    /// Standard scopes for a new user in the free tier.
+    pub fn base() -> Vec<Self> {
+        vec![
+            Scope::Deployment,
+            Scope::DeploymentPush,
+            Scope::Logs,
+            Scope::Service,
+            Scope::ServiceCreate,
+            Scope::Project,
+            Scope::ProjectCreate,
+            Scope::Resources,
+            Scope::ResourcesWrite,
+            Scope::Secret,
+            Scope::SecretWrite,
+        ]
+    }
+
+    /// All scopes for an admin user.
+    pub fn admin() -> Vec<Self> {
+        let mut base = Scope::base();
+
+        base.extend(vec![
+            Scope::User,
+            Scope::UserCreate,
+            Scope::AcmeCreate,
+            Scope::CustomDomainCreate,
+            Scope::CustomDomainCertificateRenew,
+            Scope::GatewayCertificateRenew,
+            Scope::Admin,
+        ]);
+
+        base
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Claim {
     /// Expiration time (as UTC timestamp).

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -58,7 +58,7 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["backend", "models"]
+features = ["backend", "models", "claims"]
 
 [dependencies.shuttle-proto]
 workspace = true

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -50,4 +50,8 @@ pub struct Args {
     /// Uri to folder to store all artifacts
     #[clap(long, default_value = "/tmp")]
     pub artifacts_path: PathBuf,
+
+    /// Run deployer without auth locally
+    #[arg(long)]
+    pub local: bool,
 }

--- a/deployer/src/handlers/local.rs
+++ b/deployer/src/handlers/local.rs
@@ -1,0 +1,13 @@
+use axum::http::Request;
+use shuttle_common::claims::{Claim, Scope};
+
+/// This middleware sets an admin token in the claim extension of every request, so we can
+/// develop deployer locally without starting it with the gateway and without proxying commands
+/// through gateway.
+pub async fn set_admin_claim<B>(mut request: Request<B>) -> Request<B> {
+    let claim = Claim::new("admin".to_string(), Scope::admin());
+
+    request.extensions_mut().insert::<Claim>(claim);
+
+    request
+}

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -4,7 +4,7 @@ use axum::extract::ws::{self, WebSocket};
 use axum::extract::{Extension, Path, Query};
 use axum::handler::Handler;
 use axum::headers::HeaderMapExt;
-use axum::middleware::from_extractor;
+use axum::middleware::{from_extractor, map_request};
 use axum::routing::{get, post, Router};
 use axum::{extract::BodyStream, Json};
 use bytes::BufMut;
@@ -34,8 +34,9 @@ use crate::persistence::{Deployment, Log, Persistence, ResourceManager, SecretGe
 
 use std::collections::HashMap;
 
-pub use {self::error::Error, self::error::Result};
+pub use {self::error::Error, self::error::Result, self::local::set_admin_claim};
 
+mod local;
 mod project;
 
 #[derive(OpenApi)]
@@ -72,88 +73,118 @@ mod project;
 )]
 pub struct ApiDoc;
 
-pub async fn make_router(
-    persistence: Persistence,
-    deployment_manager: DeploymentManager,
-    proxy_fqdn: FQDN,
-    admin_secret: String,
-    auth_uri: Uri,
+#[derive(Clone)]
+pub struct RouterBuilder {
+    router: Router,
     project_name: ProjectName,
-) -> Router {
-    Router::new()
-        // TODO: The `/swagger-ui` responds with a 303 See Other response which is followed in
-        // browsers but leads to 404 Not Found. This must be investigated.
-        .merge(SwaggerUi::new("/projects/:project_name/swagger-ui").url(
-            "/projects/:project_name/api-docs/openapi.json",
-            ApiDoc::openapi(),
-        ))
-        .route(
-            "/projects/:project_name/services",
-            get(get_services.layer(ScopedLayer::new(vec![Scope::Service]))),
-        )
-        .route(
-            "/projects/:project_name/services/:service_name",
-            get(get_service.layer(ScopedLayer::new(vec![Scope::Service])))
-                .post(create_service.layer(ScopedLayer::new(vec![Scope::ServiceCreate])))
-                .delete(stop_service.layer(ScopedLayer::new(vec![Scope::ServiceCreate]))),
-        )
-        .route(
-            "/projects/:project_name/services/:service_name/resources",
-            get(get_service_resources).layer(ScopedLayer::new(vec![Scope::Resources])),
-        )
-        .route(
-            "/projects/:project_name/deployments",
-            get(get_deployments).layer(ScopedLayer::new(vec![Scope::Service])),
-        )
-        .route(
-            "/projects/:project_name/deployments/:deployment_id",
-            get(get_deployment.layer(ScopedLayer::new(vec![Scope::Deployment])))
-                .delete(delete_deployment.layer(ScopedLayer::new(vec![Scope::DeploymentPush]))),
-        )
-        .route(
-            "/projects/:project_name/ws/deployments/:deployment_id/logs",
-            get(get_logs_subscribe.layer(ScopedLayer::new(vec![Scope::Logs]))),
-        )
-        .route(
-            "/projects/:project_name/deployments/:deployment_id/logs",
-            get(get_logs.layer(ScopedLayer::new(vec![Scope::Logs]))),
-        )
-        .route(
-            "/projects/:project_name/secrets/:service_name",
-            get(get_secrets.layer(ScopedLayer::new(vec![Scope::Secret]))),
-        )
-        .route(
-            "/projects/:project_name/clean",
-            post(clean_project.layer(ScopedLayer::new(vec![Scope::DeploymentPush]))),
-        )
-        .layer(Extension(persistence))
-        .layer(Extension(deployment_manager))
-        .layer(Extension(proxy_fqdn))
-        .layer(JwtAuthenticationLayer::new(AuthPublicKey::new(auth_uri)))
-        .layer(AdminSecretLayer::new(admin_secret))
-        // This route should be below the auth bearer since it does not need authentication
-        .route("/projects/:project_name/status", get(get_status))
-        .route_layer(from_extractor::<Metrics>())
-        .layer(
-            TraceLayer::new(|request| {
-                let account_name = request
-                    .headers()
-                    .typed_get::<XShuttleAccountName>()
-                    .unwrap_or_default();
+}
 
-                request_span!(
-                    request,
-                    account.name = account_name.0,
-                    request.params.project_name = field::Empty,
-                    request.params.service_name = field::Empty,
-                    request.params.deployment_id = field::Empty,
-                )
-            })
-            .with_propagation()
-            .build(),
-        )
-        .route_layer(from_extractor::<project::ProjectNameGuard>())
-        .layer(Extension(project_name))
+impl RouterBuilder {
+    pub fn new(
+        persistence: Persistence,
+        deployment_manager: DeploymentManager,
+        proxy_fqdn: FQDN,
+        project_name: ProjectName,
+    ) -> Self {
+        let router = Router::new()
+            // TODO: The `/swagger-ui` responds with a 303 See Other response which is followed in
+            // browsers but leads to 404 Not Found. This must be investigated.
+            .merge(SwaggerUi::new("/projects/:project_name/swagger-ui").url(
+                "/projects/:project_name/api-docs/openapi.json",
+                ApiDoc::openapi(),
+            ))
+            .route(
+                "/projects/:project_name/services",
+                get(get_services.layer(ScopedLayer::new(vec![Scope::Service]))),
+            )
+            .route(
+                "/projects/:project_name/services/:service_name",
+                get(get_service.layer(ScopedLayer::new(vec![Scope::Service])))
+                    .post(create_service.layer(ScopedLayer::new(vec![Scope::ServiceCreate])))
+                    .delete(stop_service.layer(ScopedLayer::new(vec![Scope::ServiceCreate]))),
+            )
+            .route(
+                "/projects/:project_name/services/:service_name/resources",
+                get(get_service_resources).layer(ScopedLayer::new(vec![Scope::Resources])),
+            )
+            .route(
+                "/projects/:project_name/deployments",
+                get(get_deployments).layer(ScopedLayer::new(vec![Scope::Service])),
+            )
+            .route(
+                "/projects/:project_name/deployments/:deployment_id",
+                get(get_deployment.layer(ScopedLayer::new(vec![Scope::Deployment])))
+                    .delete(delete_deployment.layer(ScopedLayer::new(vec![Scope::DeploymentPush]))),
+            )
+            .route(
+                "/projects/:project_name/ws/deployments/:deployment_id/logs",
+                get(get_logs_subscribe.layer(ScopedLayer::new(vec![Scope::Logs]))),
+            )
+            .route(
+                "/projects/:project_name/deployments/:deployment_id/logs",
+                get(get_logs.layer(ScopedLayer::new(vec![Scope::Logs]))),
+            )
+            .route(
+                "/projects/:project_name/secrets/:service_name",
+                get(get_secrets.layer(ScopedLayer::new(vec![Scope::Secret]))),
+            )
+            .route(
+                "/projects/:project_name/clean",
+                post(clean_project.layer(ScopedLayer::new(vec![Scope::DeploymentPush]))),
+            )
+            .layer(Extension(persistence))
+            .layer(Extension(deployment_manager))
+            .layer(Extension(proxy_fqdn));
+
+        Self {
+            router,
+            project_name,
+        }
+    }
+
+    pub fn with_auth_layer(mut self, auth_uri: Uri, admin_secret: String) -> Self {
+        let auth_public_key = AuthPublicKey::new(auth_uri);
+
+        self.router = self
+            .router
+            .layer(JwtAuthenticationLayer::new(auth_public_key))
+            .layer(AdminSecretLayer::new(admin_secret));
+
+        self
+    }
+
+    /// Sets an admin jwt extension on every request for use when running deployer locally.
+    pub fn with_local_admin_layer(mut self) -> Self {
+        self.router = self.router.layer(map_request(set_admin_claim));
+
+        self
+    }
+
+    pub fn into_router(self) -> Router {
+        self.router
+            .route("/projects/:project_name/status", get(get_status))
+            .route_layer(from_extractor::<Metrics>())
+            .layer(
+                TraceLayer::new(|request| {
+                    let account_name = request
+                        .headers()
+                        .typed_get::<XShuttleAccountName>()
+                        .unwrap_or_default();
+
+                    request_span!(
+                        request,
+                        account.name = account_name.0,
+                        request.params.project_name = field::Empty,
+                        request.params.service_name = field::Empty,
+                        request.params.deployment_id = field::Empty,
+                    )
+                })
+                .with_propagation()
+                .build(),
+            )
+            .route_layer(from_extractor::<project::ProjectNameGuard>())
+            .layer(Extension(self.project_name))
+    }
 }
 
 #[instrument(skip_all)]


### PR DESCRIPTION
## Description of change

This PR makes it much easier to run deployer locally for development by opting out of auth with a CLI flag.

## How Has This Been Tested (if applicable)?

Tested running the deployer locally and sending commands.

TODO: everything seems to work except deploying.
