### PR TITLE
fix: stop logging the full loadresponse

### DIFF
--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -317,7 +317,7 @@ async fn load(
     match response {
         Ok(response) => {
             let response = response.into_inner();
-            info!(?response, "loading response");
+            info!(?response.success, "loading response");
 
             for resource in response.resources {
                 let resource: resource::Response = serde_json::from_slice(&resource).unwrap();


### PR DESCRIPTION
## Description of change

Stop logging the full load response.

## How Has This Been Tested (if applicable)?

Tested that we no longer log all the data.
