### PR TITLE
fix(common): feature flagged utoipa dependency

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -40,7 +40,7 @@ tracing = { workspace = true, features = ["std"] }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ttl_cache = { workspace = true, optional = true }
-utoipa = { workspace = true }
+utoipa = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 
 [features]
@@ -54,7 +54,7 @@ backend = [
     "tower-http",
     "tracing-subscriber/env-filter",
     "tracing-subscriber/fmt",
-    "ttl_cache",
+    "ttl_cache"
 ]
 claims = [
     "bytes",
@@ -72,6 +72,7 @@ claims = [
 ]
 display = ["chrono/clock", "comfy-table", "crossterm"]
 error = ["prost-types", "thiserror", "uuid"]
+openapi = ["utoipa/chrono", "utoipa/uuid"]
 models = ["anyhow", "async-trait", "display", "http", "reqwest", "service"]
 service = ["chrono/serde", "once_cell", "rustrict", "serde/derive", "uuid"]
 tracing = []

--- a/common/src/database.rs
+++ b/common/src/database.rs
@@ -2,28 +2,32 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use strum::Display;
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
-#[schema(as = shuttle_common::database::Type)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::database::Type))]
 pub enum Type {
     AwsRds(AwsRdsEngine),
     Shared(SharedEngine),
 }
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum AwsRdsEngine {
     Postgres,
     MySql,
     MariaDB,
 }
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Display, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum SharedEngine {
     Postgres,
     MongoDb,

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -1,11 +1,13 @@
 use serde::{Deserialize, Serialize};
 use strum::Display;
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Display, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
-#[schema(as = shuttle_common::deployment::State)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::deployment::State))]
 pub enum State {
     Queued,
     Building,

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "display")]
 use crossterm::style::{StyledContent, Stylize};
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -12,16 +13,17 @@ use crate::deployment::State;
 
 pub const STATE_MESSAGE: &str = "NEW STATE";
 
-#[derive(Clone, Debug, Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::log::Item)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::log::Item))]
 pub struct Item {
-    #[schema(value_type = KnownFormat::Uuid)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::Uuid))]
     pub id: Uuid,
-    #[schema(value_type = KnownFormat::DateTime)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::DateTime))]
     pub timestamp: DateTime<Utc>,
-    #[schema(value_type = shuttle_common::deployment::State)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::deployment::State))]
     pub state: State,
-    #[schema(value_type = shuttle_common::log::Level)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::log::Level))]
     pub level: Level,
     pub file: Option<String>,
     pub line: Option<u32>,
@@ -83,9 +85,10 @@ impl std::fmt::Display for Item {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
-#[schema(as = shuttle_common::log::Level)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::log::Level))]
 pub enum Level {
     Trace,
     Debug,

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -7,21 +7,23 @@ use comfy_table::{
 };
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::deployment::State;
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::deployment::Response)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::deployment::Response))]
 pub struct Response {
-    #[schema(value_type = KnownFormat::Uuid)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::Uuid))]
     pub id: Uuid,
-    #[schema(value_type = KnownFormat::Uuid)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::Uuid))]
     pub service_id: Uuid,
-    #[schema(value_type = shuttle_common::deployment::State)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::deployment::State))]
     pub state: State,
-    #[schema(value_type = KnownFormat::DateTime)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::DateTime))]
     pub last_update: DateTime<Utc>,
 }
 

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -6,6 +6,7 @@ use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use strum::EnumString;
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
 /// Timeframe before a project is considered idle
@@ -16,17 +17,19 @@ pub const fn idle_minutes() -> u64 {
     IDLE_MINUTES
 }
 
-#[derive(Deserialize, Serialize, Clone, ToSchema)]
-#[schema(as = shuttle_common::models::project::Response)]
+#[derive(Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::project::Response))]
 pub struct Response {
     pub name: String,
-    #[schema(value_type = shuttle_common::models::project::State)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::models::project::State))]
     pub state: State,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, EnumString, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, EnumString)]
 #[serde(rename_all = "lowercase")]
-#[schema(as = shuttle_common::models::project::State)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::project::State))]
 pub enum State {
     Creating { recreate_count: usize },
     Attaching { recreate_count: usize },
@@ -173,8 +176,9 @@ pub struct Config {
     pub idle_minutes: u64,
 }
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::project::AdminResponse)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::project::AdminResponse))]
 pub struct AdminResponse {
     pub project_name: String,
     pub account_name: String,

--- a/common/src/models/secret.rs
+++ b/common/src/models/secret.rs
@@ -5,13 +5,15 @@ use comfy_table::{
 };
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::secret::Response)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::secret::Response))]
 pub struct Response {
     pub key: String,
-    #[schema(value_type = KnownFormat::DateTime)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::DateTime))]
     pub last_update: DateTime<Utc>,
 }
 

--- a/common/src/models/service.rs
+++ b/common/src/models/service.rs
@@ -1,24 +1,27 @@
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::models::deployment;
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::service::Response)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::service::Response))]
 pub struct Response {
-    #[schema(value_type = KnownFormat::Uuid)]
+    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::Uuid))]
     pub id: Uuid,
     pub name: String,
 }
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::service::Summary)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::service::Summary))]
 pub struct Summary {
     pub name: String,
-    #[schema(value_type = shuttle_common::models::deployment::Response)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::models::deployment::Response))]
     pub deployment: Option<deployment::Response>,
     pub uri: String,
 }

--- a/common/src/models/stats.rs
+++ b/common/src/models/stats.rs
@@ -1,15 +1,18 @@
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::stats::LoadRequest)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::stats::LoadRequest))]
 pub struct LoadRequest {
     pub id: Uuid,
 }
 
-#[derive(Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::models::stats::LoadResponse)]
+#[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::stats::LoadResponse))]
 pub struct LoadResponse {
     pub builds_count: usize,
     pub has_capacity: bool,

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -2,32 +2,35 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
 use crate::database;
 
 /// Common type to hold all the information we need for a generic resource
-#[derive(Clone, Deserialize, Serialize, ToSchema)]
-#[schema(as = shuttle_common::resource::Response)]
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::resource::Response))]
 pub struct Response {
     /// The type of this resource.
-    #[schema(value_type = shuttle_common::resource::Type)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::resource::Type))]
     pub r#type: Type,
 
     /// The config used when creating this resource. Use the [Self::r#type] to know how to parse this data.
-    #[schema(value_type = Object)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub config: Value,
 
     /// The data associated with this resource. Use the [Self::r#type] to know how to parse this data.
-    #[schema(value_type = Object)]
+    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub data: Value,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
-#[schema(as = shuttle_common::resource::Type)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(as = shuttle_common::resource::Type))]
 pub enum Type {
-    #[schema(value_type = shuttle_common::database::Type)]
+    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::database::Type))]
     Database(database::Type),
     Secrets,
     StaticFolder,

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -58,7 +58,7 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["backend", "models"]
+features = ["backend", "models", "openapi"]
 
 [dependencies.shuttle-proto]
 workspace = true

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -54,7 +54,7 @@ x509-parser = "0.14.0"
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["backend", "models"]
+features = ["backend", "models", "openapi"]
 
 [dev-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Description of change

User projects have a dependency on `shuttle-common`, which depends on `utoipa`. Howerver, `utoipa` dependency is not relevant to the user projects so this PR is feature gating the use of `utoipa` dependency and makes it optional when consuming `shuttle-common`.

## How Has This Been Tested (if applicable)?

Created a shuttle-rocket project, built it, and verified that `utoipa` is not appearing as a dependency in the `target` directory.
