### PR TITLE
fix: wasm qa casing

### DIFF
--- a/.circleci/qa-wasm.sh
+++ b/.circleci/qa-wasm.sh
@@ -17,6 +17,6 @@ sleep 70
 
 echo "Testing local wasm endpoint"
 output=$(curl --silent localhost:8000/hello)
-[ "$output" != "Hello, world!" ] && ( echo "Did not expect output: $output"; exit 1 )
+[ "$output" != "Hello, World!" ] && ( echo "Did not expect output: $output"; exit 1 )
 
 killall cargo-shuttle


### PR DESCRIPTION
## Description of change

Shuttle-next example returns "Hello, World", not "Hello, world".
