### PR TITLE
build(docker): Change default provisioner port to 3000

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ cargo shuttle login --api-key test-key
 We're now ready to start a local run of the deployer:
 
 ```bash
-cargo run -p shuttle-deployer -- --provisioner-address http://localhost:5000 --auth-uri http://localhost:8008 --proxy-fqdn local.rs --admin-secret test-key --local --project <project_name>
+cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --proxy-fqdn local.rs --admin-secret test-key --local --project <project_name>
 ```
 
 The `<project_name>` needs to match the name of the project that will be deployed to this deployer. This is the `Cargo.toml` or `Shuttle.toml` name for the project.

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -16,7 +16,7 @@ pub struct Args {
     pub state: String,
 
     /// Address to connect to the provisioning service
-    #[clap(long, default_value = "http://provisioner:5000")]
+    #[clap(long, default_value = "http://provisioner:3000")]
     pub provisioner_address: Endpoint,
 
     /// FQDN where the proxy can be reached at

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
 
         exec /usr/local/bin/service "$${@:0}"
     ports:
-      - 5000:8000
+      - 3000:8000
   panamax:
     profiles:
       - panamax

--- a/runtime/src/alpha/args.rs
+++ b/runtime/src/alpha/args.rs
@@ -11,7 +11,7 @@ pub struct Args {
     pub port: u16,
 
     /// Address to reach provisioner at
-    #[arg(long, default_value = "http://localhost:5000")]
+    #[arg(long, default_value = "http://localhost:3000")]
     pub provisioner_address: Endpoint,
 
     /// Type of storage manager to start


### PR DESCRIPTION
Closes #851

On MacOs, port 5000 is used by AirPlay receiver which will make the 'make up' command described in CONTRIBUTING.md fail for Mac users

## Description of change

All occurrences of using port 5000 for the provisioner were changed to use port 3000 instead.

## How Has This Been Tested (if applicable)?
Tested by activating the AirPort receiver (on port 5000) and running 'make up' - works. `docker ps` shows that the provisioner is running on 3000.