### PR TITLE
feat(cargo-shuttle): log reconnects and improved error messages

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -186,7 +186,7 @@ pub struct LoginArgs {
     pub api_key: Option<String>,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct DeployArgs {
     /// Allow deployment with uncommited files
     #[arg(long)]

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -16,6 +16,7 @@ use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use tracing::error;
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct Client {
     api_url: ApiUrl,
     api_key: Option<ApiKey>,

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -3,7 +3,7 @@ use strum::Display;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-#[derive(Clone, Debug, Deserialize, Display, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Display, Serialize)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]


### PR DESCRIPTION
## Description of change

Partially addresses #846, we still need to reproduce getting the incorrect output from cargo-shuttle. The main change is that the websockets client will try to reconnect if disconnected in the queuing, building, or loading phase of the deploy process. I also changed the error outputs for the running, completed, stopped, and unknown states.

## How Has This Been Tested (if applicable)?

`cargo fmt` and `cargo clippy` were run. I could try to reproduce a web-sockets disconnect, but I think that would be unnecessary.
