### PR TITLE
fix: some panic messages get lost

### DIFF
--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -247,10 +247,13 @@ where
 
                 if error.is_panic() {
                     let panic = error.into_panic();
-                    let msg = panic
-                        .downcast_ref::<&str>()
-                        .map(|x| x.to_string())
-                        .unwrap_or_else(|| "<no panic message>".to_string());
+                    let msg = match panic.downcast_ref::<String>() {
+                        Some(msg) => msg.to_string(),
+                        None => match panic.downcast_ref::<&str>() {
+                            Some(msg) => msg.to_string(),
+                            None => "<no panic message>".to_string(),
+                        },
+                    };
 
                     error!(error = msg, "loading service panicked");
 
@@ -325,9 +328,13 @@ where
                         Err(error) => {
                             if error.is_panic() {
                                 let panic = error.into_panic();
-                                let msg = panic.downcast_ref::<&str>()
-                                    .map(|x| x.to_string())
-                                    .unwrap_or_else(|| "<no panic message>".to_string());
+                                let msg = match panic.downcast_ref::<String>() {
+                                    Some(msg) => msg.to_string(),
+                                    None => match panic.downcast_ref::<&str>() {
+                                        Some(msg) => msg.to_string(),
+                                        None => "<no panic message>".to_string(),
+                                    },
+                                };
 
                                 error!(error = msg, "service panicked");
 

--- a/runtime/tests/integration/loader.rs
+++ b/runtime/tests/integration/loader.rs
@@ -42,5 +42,114 @@ async fn bind_panic() {
     let reason = stream.message().await.unwrap().unwrap();
 
     assert_eq!(reason.reason, StopReason::Crash as i32);
+    assert_ne!(reason.message, "<no panic message>");
     assert_eq!(reason.message, "panic in bind");
+}
+
+#[tokio::test]
+async fn bind_panic_owned() {
+    let project_path = format!(
+        "{}/tests/resources/bind-panic-owned",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let TestRuntime {
+        bin_path,
+        service_name,
+        secrets,
+        mut runtime_client,
+        runtime_address,
+        runtime: _runtime, // Keep it to not be dropped and have the process killed.
+    } = spawn_runtime(project_path, "bind-panic-owned")
+        .await
+        .unwrap();
+
+    let load_request = tonic::Request::new(LoadRequest {
+        path: bin_path,
+        service_name,
+        resources: Default::default(),
+        secrets,
+    });
+
+    runtime_client.load(load_request).await.unwrap();
+
+    let mut stream = runtime_client
+        .subscribe_stop(tonic::Request::new(SubscribeStopRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+
+    let start_request = StartRequest {
+        ip: runtime_address.to_string(),
+    };
+
+    runtime_client
+        .start(tonic::Request::new(start_request))
+        .await
+        .unwrap();
+
+    let reason = stream.message().await.unwrap().unwrap();
+
+    assert_eq!(reason.reason, StopReason::Crash as i32);
+    assert_ne!(reason.message, "<no panic message>");
+    assert_eq!(reason.message, "panic in bind");
+}
+#[tokio::test]
+async fn loader_panic() {
+    let project_path = format!(
+        "{}/tests/resources/loader-panic",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let TestRuntime {
+        bin_path,
+        service_name,
+        secrets,
+        mut runtime_client,
+        runtime_address: _,
+        runtime: _runtime, // Keep it to not be dropped and have the process killed.
+    } = spawn_runtime(project_path, "loader-panic").await.unwrap();
+
+    let load_request = tonic::Request::new(LoadRequest {
+        path: bin_path,
+        service_name,
+        resources: Default::default(),
+        secrets,
+    });
+
+    let load_response = runtime_client.load(load_request).await.unwrap();
+    let message = load_response.into_inner().message;
+    assert_eq!(message, "panic in loader");
+    assert_ne!(message, "<no panic message>");
+}
+
+#[tokio::test]
+async fn loader_panic_owned() {
+    let project_path = format!(
+        "{}/tests/resources/loader-panic-owned",
+        env!("CARGO_MANIFEST_DIR")
+    );
+
+    let TestRuntime {
+        bin_path,
+        service_name,
+        secrets,
+        mut runtime_client,
+        runtime_address: _,
+        runtime: _runtime, // Keep it to not be dropped and have the process killed.
+    } = spawn_runtime(project_path, "loader-panic-owned")
+        .await
+        .unwrap();
+
+    let load_request = tonic::Request::new(LoadRequest {
+        path: bin_path,
+        service_name,
+        resources: Default::default(),
+        secrets,
+    });
+
+    let load_response = runtime_client.load(load_request).await.unwrap();
+    let message = load_response.into_inner().message;
+    assert_ne!(message, "<no panic message>");
+    assert_eq!(message, "panic in loader");
 }

--- a/runtime/tests/resources/bind-panic-owned/Cargo.toml
+++ b/runtime/tests/resources/bind-panic-owned/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "bind-panic-owned"
+version = "0.1.0"
+edition = "2021"
+
+
+[workspace]
+
+[dependencies]
+shuttle-runtime = { path = "../../../" }
+tokio = { version = "1.22.0" }

--- a/runtime/tests/resources/bind-panic-owned/src/main.rs
+++ b/runtime/tests/resources/bind-panic-owned/src/main.rs
@@ -1,0 +1,13 @@
+struct MyService;
+
+#[shuttle_runtime::async_trait]
+impl shuttle_runtime::Service for MyService {
+    async fn bind(mut self, _: std::net::SocketAddr) -> Result<(), shuttle_runtime::Error> {
+        panic!("panic in {}", "bind");
+    }
+}
+
+#[shuttle_runtime::main]
+async fn bind_panic_owned() -> Result<MyService, shuttle_runtime::Error> {
+    Ok(MyService)
+}

--- a/runtime/tests/resources/loader-panic-owned/Cargo.toml
+++ b/runtime/tests/resources/loader-panic-owned/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "loader-panic-owned-message"
+version = "0.1.0"
+edition = "2021"
+
+
+[workspace]
+
+[dependencies]
+shuttle-runtime = { path = "../../../" }
+tokio = { version = "1.22.0" }

--- a/runtime/tests/resources/loader-panic-owned/src/main.rs
+++ b/runtime/tests/resources/loader-panic-owned/src/main.rs
@@ -1,0 +1,13 @@
+struct MyService;
+
+#[shuttle_runtime::async_trait]
+impl shuttle_runtime::Service for MyService {
+    async fn bind(mut self, _: std::net::SocketAddr) -> Result<(), shuttle_runtime::Error> {
+        Ok(())
+    }
+}
+
+#[shuttle_runtime::main]
+async fn panic_message() -> Result<MyService, shuttle_runtime::Error> {
+    panic!("panic in {}", "loader");
+}

--- a/runtime/tests/resources/loader-panic/Cargo.toml
+++ b/runtime/tests/resources/loader-panic/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "loader-panic-message"
+version = "0.1.0"
+edition = "2021"
+
+
+[workspace]
+
+[dependencies]
+shuttle-runtime = { path = "../../../" }
+tokio = { version = "1.22.0" }

--- a/runtime/tests/resources/loader-panic/src/main.rs
+++ b/runtime/tests/resources/loader-panic/src/main.rs
@@ -1,0 +1,13 @@
+struct MyService;
+
+#[shuttle_runtime::async_trait]
+impl shuttle_runtime::Service for MyService {
+    async fn bind(mut self, _: std::net::SocketAddr) -> Result<(), shuttle_runtime::Error> {
+        Ok(())
+    }
+}
+
+#[shuttle_runtime::main]
+async fn panic_message() -> Result<MyService, shuttle_runtime::Error> {
+    panic!("panic in loader");
+}


### PR DESCRIPTION
## Description of change
Downcast panic message to `String` or `&str`.

closes issue #843 

## How Has This Been Tested (if applicable)?
Causing panics with Option and Result types.

