### PR TITLE
chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Indentation settings matching the default rustfmt config
+[*.rs]
+charset = utf-8
+indent_style = space
+indent_size = 4
+


### PR DESCRIPTION
## Description of change

This adds a simple `.editorconfig` file to the root of the repository so that different editors/IDEs may pick up the settings. This makes it easier to have consistent formatting while editing, not just after running `cargo fmt`. See [here](https://editorconfig.org) for more details.

## How Has This Been Tested (if applicable)?

My neovim likes it.
