### PR TITLE
feat: allow resetting a user's API-key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ shuttle-service = { path = "service", version = "0.16.0" }
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 axum = { version = "0.6.0", default-features = false }
+axum-sessions = "0.4.1"
 base64 = "0.13.1"
 bollard = "0.14.0"
 bytes = "1.3.0"

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["headers"] }
-axum-sessions = "0.4.1"
+axum-sessions = { workspace = true }
 clap = { workspace = true }
 http = { workspace = true }
 jsonwebtoken = { workspace = true }

--- a/auth/src/api/builder.rs
+++ b/auth/src/api/builder.rs
@@ -72,7 +72,7 @@ impl ApiBuilder {
             .route("/public-key", get(get_public_key))
             .route("/users/:account_name", get(get_user))
             .route("/users/:account_name/:account_tier", post(post_user))
-            .route("/users/:account_name/reset-key", put(put_user_reset_key))
+            .route("/users/reset-key", put(put_user_reset_key))
             .route_layer(from_extractor::<Metrics>())
             .layer(
                 TraceLayer::new(|request| {

--- a/auth/src/api/builder.rs
+++ b/auth/src/api/builder.rs
@@ -3,7 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 use axum::{
     extract::FromRef,
     middleware::from_extractor,
-    routing::{get, post},
+    routing::{get, post, put},
     Router, Server,
 };
 use axum_sessions::{async_session::MemoryStore, SessionLayer};
@@ -22,7 +22,8 @@ use crate::{
 };
 
 use super::handlers::{
-    convert_cookie, convert_key, get_public_key, get_user, login, logout, post_user, refresh_token,
+    convert_cookie, convert_key, get_public_key, get_user, login, logout, post_user,
+    put_user_reset_key, refresh_token,
 };
 
 pub type UserManagerState = Arc<Box<dyn UserManagement>>;
@@ -71,6 +72,7 @@ impl ApiBuilder {
             .route("/public-key", get(get_public_key))
             .route("/users/:account_name", get(get_user))
             .route("/users/:account_name/:account_tier", post(post_user))
+            .route("/users/:account_name/reset-key", put(put_user_reset_key))
             .route_layer(from_extractor::<Metrics>())
             .layer(
                 TraceLayer::new(|request| {

--- a/auth/src/api/builder.rs
+++ b/auth/src/api/builder.rs
@@ -72,7 +72,7 @@ impl ApiBuilder {
             .route("/public-key", get(get_public_key))
             .route("/users/:account_name", get(get_user))
             .route("/users/:account_name/:account_tier", post(post_user))
-            .route("/users/reset-key", put(put_user_reset_key))
+            .route("/users/reset-api-key", put(put_user_reset_key))
             .route_layer(from_extractor::<Metrics>())
             .layer(
                 TraceLayer::new(|request| {

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -40,9 +40,19 @@ pub(crate) async fn post_user(
 }
 
 pub(crate) async fn put_user_reset_key(
+    session: ReadableSession,
     State(user_manager): State<UserManagerState>,
-    Path(account_name): Path<AccountName>,
+    key: Option<Key>,
 ) -> Result<(), Error> {
+    let account_name = match session.get::<String>("account_name") {
+        Some(account_name) => account_name.into(),
+
+        None => match key {
+            Some(key) => user_manager.get_user_by_key(key.into()).await?.name,
+            None => return Err(Error::Unauthorized),
+        },
+    };
+
     user_manager.reset_key(account_name).await
 }
 
@@ -71,12 +81,12 @@ pub(crate) async fn convert_cookie(
     session: ReadableSession,
     State(key_manager): State<KeyManagerState>,
 ) -> Result<Json<shuttle_common::backends::auth::ConvertResponse>, StatusCode> {
-    let account_name: String = session
-        .get("account_name")
+    let account_name = session
+        .get::<String>("account_name")
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let account_tier: AccountTier = session
-        .get("account_tier")
+    let account_tier = session
+        .get::<AccountTier>("account_tier")
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
     let claim = Claim::new(account_name, account_tier.into());
@@ -99,7 +109,7 @@ pub(crate) async fn convert_key(
     let User {
         name, account_tier, ..
     } = user_manager
-        .get_user_by_key(key.as_ref().clone())
+        .get_user_by_key(key.into())
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -39,6 +39,13 @@ pub(crate) async fn post_user(
     Ok(Json(user.into()))
 }
 
+pub(crate) async fn put_user_reset_key(
+    State(user_manager): State<UserManagerState>,
+    Path(account_name): Path<AccountName>,
+) -> Result<(), Error> {
+    user_manager.reset_key(account_name).await
+}
+
 pub(crate) async fn login(
     mut session: WritableSession,
     State(user_manager): State<UserManagerState>,

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -124,7 +124,7 @@ where
         let user_manager: UserManagerState = UserManagerState::from_ref(state);
 
         let user = user_manager
-            .get_user_by_key(key.as_ref().clone())
+            .get_user_by_key(key.into())
             .await
             // Absorb any error into `Unauthorized`
             .map_err(|_| Error::Unauthorized)?;
@@ -146,13 +146,12 @@ impl From<User> for shuttle_common::models::user::Response {
     }
 }
 
-/// A wrapper around [ApiKey] so we can implement [FromRequestParts]
-/// for it.
+/// A wrapper around [ApiKey] so we can implement [FromRequestParts] for it.
 pub struct Key(ApiKey);
 
-impl AsRef<ApiKey> for Key {
-    fn as_ref(&self) -> &ApiKey {
-        &self.0
+impl From<Key> for ApiKey {
+    fn from(key: Key) -> Self {
+        key.0
     }
 }
 
@@ -210,11 +209,17 @@ impl From<AccountTier> for Vec<Scope> {
 #[sqlx(transparent)]
 pub struct AccountName(String);
 
+impl From<String> for AccountName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
 impl FromStr for AccountName {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(s.to_string()))
+        Ok(s.to_string().into())
     }
 }
 

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -22,6 +22,7 @@ pub trait UserManagement: Send + Sync {
     async fn create_user(&self, name: AccountName, tier: AccountTier) -> Result<User, Error>;
     async fn get_user(&self, name: AccountName) -> Result<User, Error>;
     async fn get_user_by_key(&self, key: ApiKey) -> Result<User, Error>;
+    async fn reset_key(&self, name: AccountName) -> Result<(), Error>;
 }
 
 #[derive(Clone)]
@@ -68,6 +69,23 @@ impl UserManagement for UserManager {
                 account_tier: row.try_get("account_tier").unwrap(),
             })
             .ok_or(Error::UserNotFound)
+    }
+
+    async fn reset_key(&self, name: AccountName) -> Result<(), Error> {
+        let key = ApiKey::generate();
+
+        let rows_affected = query("UPDATE users SET key = ?1 WHERE account_name = ?2")
+            .bind(&key)
+            .bind(&name)
+            .execute(&self.pool)
+            .await?
+            .rows_affected();
+
+        if rows_affected > 0 {
+            Ok(())
+        } else {
+            Err(Error::UserNotFound)
+        }
     }
 }
 

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -53,6 +53,24 @@ async fn post_user() {
     assert_eq!(user["name"], "pro-user");
     assert_eq!(user["account_tier"], "pro");
     assert!(user["key"].to_string().is_ascii());
+
+    // Reset API key for non-existing user.
+    let request = Request::builder()
+        .uri(format!("/users/non-existing/reset-key"))
+        .method("PUT")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // Reset API key for existing user.
+    let request = Request::builder()
+        .uri(format!("/users/test-user/reset-key"))
+        .method("PUT")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -111,7 +111,7 @@ async fn test_reset_key() {
 
     // Reset API key without cookie or API key.
     let request = Request::builder()
-        .uri("/users/reset-key")
+        .uri("/users/reset-api-key")
         .method("PUT")
         .body(Body::empty())
         .unwrap();
@@ -140,7 +140,7 @@ async fn test_reset_key() {
     let cookie = Cookie::parse(cookie).unwrap();
 
     let request = Request::builder()
-        .uri("/users/reset-key")
+        .uri("/users/reset-api-key")
         .method("PUT")
         .header("Cookie", cookie.stripped().to_string())
         .body(Body::empty())
@@ -150,7 +150,7 @@ async fn test_reset_key() {
 
     // Reset API key with API key.
     let request = Request::builder()
-        .uri("/users/reset-key")
+        .uri("/users/reset-api-key")
         .method("PUT")
         .header(AUTHORIZATION, format!("Bearer {}", helpers::ADMIN_KEY))
         .body(Body::empty())

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -56,7 +56,7 @@ async fn post_user() {
 
     // Reset API key for non-existing user.
     let request = Request::builder()
-        .uri(format!("/users/non-existing/reset-key"))
+        .uri("/users/non-existing/reset-key")
         .method("PUT")
         .body(Body::empty())
         .unwrap();
@@ -65,7 +65,7 @@ async fn post_user() {
 
     // Reset API key for existing user.
     let request = Request::builder()
-        .uri(format!("/users/test-user/reset-key"))
+        .uri("/users/test-user/reset-key")
         .method("PUT")
         .body(Body::empty())
         .unwrap();

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -53,24 +53,6 @@ async fn post_user() {
     assert_eq!(user["name"], "pro-user");
     assert_eq!(user["account_tier"], "pro");
     assert!(user["key"].to_string().is_ascii());
-
-    // Reset API key for non-existing user.
-    let request = Request::builder()
-        .uri("/users/non-existing/reset-key")
-        .method("PUT")
-        .body(Body::empty())
-        .unwrap();
-    let response = app.send_request(request).await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
-
-    // Reset API key for existing user.
-    let request = Request::builder()
-        .uri("/users/test-user/reset-key")
-        .method("PUT")
-        .body(Body::empty())
-        .unwrap();
-    let response = app.send_request(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[tokio::test]
@@ -120,4 +102,29 @@ async fn get_user() {
     let persisted_user: Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(user, persisted_user);
+}
+
+#[tokio::test]
+async fn test_reset_key() {
+    let app = app().await;
+
+    // Reset API key for non-existing user.
+    let request = Request::builder()
+        .uri("/users/non-existing/reset-key")
+        .method("PUT")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    // Reset API key for existing user.
+    let response = app.post_user("test-user", "basic").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let request = Request::builder()
+        .uri("/users/test-user/reset-key")
+        .method("PUT")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.send_request(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -190,9 +190,9 @@ pub struct LoginArgs {
 
 #[derive(Parser, Clone, Debug)]
 pub struct LogoutArgs {
-    /// Invalidate the API key before logging out
+    /// Reset the API key before logging out
     #[arg(long)]
-    pub invalidate_api_key: bool,
+    pub reset_api_key: bool,
 }
 #[derive(Parser)]
 pub struct DeployArgs {

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -124,7 +124,7 @@ pub enum Command {
     /// Login to the shuttle platform
     Login(LoginArgs),
     /// Log out of the shuttle platform
-    Logout,
+    Logout(LogoutArgs),
     /// Generate shell completions
     Generate {
         /// Which shell
@@ -188,6 +188,12 @@ pub struct LoginArgs {
     pub api_key: Option<String>,
 }
 
+#[derive(Parser, Clone, Debug)]
+pub struct LogoutArgs {
+    /// Invalidate the API key before logging out
+    #[arg(long)]
+    pub invalidate_api_key: bool,
+}
 #[derive(Parser)]
 pub struct DeployArgs {
     /// Allow deployment with uncommited files

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -16,6 +16,7 @@ use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use tracing::error;
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct Client {
     api_url: ApiUrl,
     api_key: Option<ApiKey>,
@@ -201,7 +202,7 @@ impl Client {
         self.get(path).await
     }
 
-    pub async fn invalidate_api_key(&self) -> Result<Response> {
+    pub async fn reset_api_key(&self) -> Result<Response> {
         self.put("/users/reset-api-key".into(), Option::<()>::None)
             .await
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -295,16 +295,13 @@ impl Shuttle {
     }
 
     async fn reset_api_key(&self, client: &Client) -> Result<()> {
-        client
-            .reset_api_key()
-            .await
-            .and_then(|res| {
-                if res.status().is_success() {
-                    Ok(())
-                } else {
-                    Err(anyhow!("Resetting API key failed."))
-                }
-            })
+        client.reset_api_key().await.and_then(|res| {
+            if res.status().is_success() {
+                Ok(())
+            } else {
+                Err(anyhow!("Resetting API key failed."))
+            }
+        })
     }
 
     async fn stop(&self, client: &Client) -> Result<()> {

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -115,8 +115,8 @@ where
             other => other.starts_with("/users"),
         };
 
-        // If /users/reset-key is called, invalidate the cached JWT.
-        if req.uri().path() == "/users/reset-key" {
+        // If /users/reset-api-key is called, invalidate the cached JWT.
+        if req.uri().path() == "/users/reset-api-key" {
             if let Some((cache_key, _)) = cache_key_and_token_req(&req) {
                 self.cache_manager.invalidate(&cache_key);
             };

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -115,13 +115,16 @@ where
             other => other.starts_with("/users"),
         };
 
+        // If /users/reset-key is called, invalidate the cached JWT.
+        if let Some((cache_key, _)) = cache_key_and_token_req(&req) {
+            self.cache_manager.invalidate(&cache_key);
+        };
+
         // If logout is called, invalidate the cached JWT for the callers cookie.
         if req.uri().path() == "/logout" {
-            let cache_manager = self.cache_manager.clone();
-
             if let Ok(Some(cookie)) = req.headers().typed_try_get::<Cookie>() {
-                if let Some(key) = cookie.get("shuttle.sid").map(|id| id.to_string()) {
-                    cache_manager.invalidate(&key);
+                if let Some(cache_key) = cookie.get("shuttle.sid").map(|id| id.to_string()) {
+                    self.cache_manager.invalidate(&cache_key);
                 }
             };
         }
@@ -166,103 +169,84 @@ where
             let mut this = self.clone();
 
             Box::pin(async move {
-                let mut auth_details = None;
-                let mut cache_key = None;
-
-                if let Some(bearer) = req.headers().typed_get::<Authorization<Bearer>>() {
-                    cache_key = Some(bearer.token().trim().to_string());
-                    auth_details = Some(make_token_request("/auth/key", bearer));
-                }
-
-                if let Some(cookie) = req.headers().typed_get::<Cookie>() {
-                    if let Some(id) = cookie.get("shuttle.sid") {
-                        cache_key = Some(id.to_string());
-                        auth_details = Some(make_token_request("/auth/session", cookie));
-                    };
-                }
-
                 // Only if there is something to upgrade
-                if let Some(token_request) = auth_details {
+                if let Some((cache_key, token_request)) = cache_key_and_token_req(&req) {
                     let target_url = this.auth_uri.to_string();
 
-                    if let Some(key) = cache_key {
-                        // Check if the token is cached.
-                        if let Some(token) = this.cache_manager.get(&key) {
-                            trace!("JWT cache hit, setting token from cache on request");
+                    // Check if the token is cached.
+                    if let Some(token) = this.cache_manager.get(&cache_key) {
+                        trace!("JWT cache hit, setting token from cache on request");
 
-                            // Token is cached and not expired, return it in the response.
-                            req.headers_mut()
-                                .typed_insert(Authorization::bearer(&token).unwrap());
-                        } else {
-                            trace!("JWT cache missed, sending convert token request");
+                        // Token is cached and not expired, return it in the response.
+                        req.headers_mut()
+                            .typed_insert(Authorization::bearer(&token).unwrap());
+                    } else {
+                        trace!("JWT cache missed, sending convert token request");
 
-                            // Token is not in the cache, send a convert request.
-                            let token_response = match PROXY_CLIENT
-                                .call(Ipv4Addr::LOCALHOST.into(), &target_url, token_request)
-                                .await
-                            {
-                                Ok(res) => res,
-                                Err(error) => {
-                                    error!(?error, "failed to call authentication service");
+                        // Token is not in the cache, send a convert request.
+                        let token_response = match PROXY_CLIENT
+                            .call(Ipv4Addr::LOCALHOST.into(), &target_url, token_request)
+                            .await
+                        {
+                            Ok(res) => res,
+                            Err(error) => {
+                                error!(?error, "failed to call authentication service");
 
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::SERVICE_UNAVAILABLE)
-                                        .body(boxed(Body::empty()))
-                                        .unwrap());
-                                }
-                            };
-
-                            // Bubble up auth errors
-                            if token_response.status() != StatusCode::OK {
-                                let (parts, body) = token_response.into_parts();
-                                let body = body.map_err(axum::Error::new).boxed_unsync();
-
-                                return Ok(Response::from_parts(parts, body));
+                                return Ok(Response::builder()
+                                    .status(StatusCode::SERVICE_UNAVAILABLE)
+                                    .body(boxed(Body::empty()))
+                                    .unwrap());
                             }
+                        };
 
-                            let body = match hyper::body::to_bytes(token_response.into_body()).await
-                            {
-                                Ok(body) => body,
-                                Err(error) => {
-                                    error!(
-                                        error = &error as &dyn std::error::Error,
-                                        "failed to get response body"
-                                    );
+                        // Bubble up auth errors
+                        if token_response.status() != StatusCode::OK {
+                            let (parts, body) = token_response.into_parts();
+                            let body = body.map_err(axum::Error::new).boxed_unsync();
 
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                        .body(boxed(Body::empty()))
-                                        .unwrap());
-                                }
-                            };
-
-                            let response = match serde_json::from_slice::<ConvertResponse>(&body) {
-                                Ok(response) => response,
-                                Err(error) => {
-                                    error!(
-                                        error = &error as &dyn std::error::Error,
-                                        "failed to convert body to ConvertResponse"
-                                    );
-
-                                    return Ok(Response::builder()
-                                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                        .body(boxed(Body::empty()))
-                                        .unwrap());
-                                }
-                            };
-
-                            let bearer =
-                                Authorization::bearer(&response.token).expect("bearer token");
-
-                            this.cache_manager.insert(
-                                key.as_str(),
-                                response.token,
-                                Duration::from_secs(CACHE_MINUTES * 60),
-                            );
-
-                            trace!("token inserted in cache, request proceeding");
-                            req.headers_mut().typed_insert(bearer);
+                            return Ok(Response::from_parts(parts, body));
                         }
+
+                        let body = match hyper::body::to_bytes(token_response.into_body()).await {
+                            Ok(body) => body,
+                            Err(error) => {
+                                error!(
+                                    error = &error as &dyn std::error::Error,
+                                    "failed to get response body"
+                                );
+
+                                return Ok(Response::builder()
+                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                    .body(boxed(Body::empty()))
+                                    .unwrap());
+                            }
+                        };
+
+                        let response = match serde_json::from_slice::<ConvertResponse>(&body) {
+                            Ok(response) => response,
+                            Err(error) => {
+                                error!(
+                                    error = &error as &dyn std::error::Error,
+                                    "failed to convert body to ConvertResponse"
+                                );
+
+                                return Ok(Response::builder()
+                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                                    .body(boxed(Body::empty()))
+                                    .unwrap());
+                            }
+                        };
+
+                        let bearer = Authorization::bearer(&response.token).expect("bearer token");
+
+                        this.cache_manager.insert(
+                            cache_key.as_str(),
+                            response.token,
+                            Duration::from_secs(CACHE_MINUTES * 60),
+                        );
+
+                        trace!("token inserted in cache, request proceeding");
+                        req.headers_mut().typed_insert(bearer);
                     };
                 }
 
@@ -280,6 +264,25 @@ where
             })
         }
     }
+}
+
+fn cache_key_and_token_req(req: &Request<Body>) -> Option<(String, Request<Body>)> {
+    req.headers()
+        .typed_get::<Authorization<Bearer>>()
+        .map(|bearer| {
+            let cache_key = bearer.token().trim().to_string();
+            let token_request = make_token_request("/auth/key", bearer);
+            (cache_key, token_request)
+        })
+        .or_else(|| {
+            req.headers().typed_get::<Cookie>().and_then(|cookie| {
+                cookie.get("shuttle.sid").map(|id| {
+                    let cache_key = id.to_string();
+                    let token_request = make_token_request("/auth/session", cookie.clone());
+                    (cache_key, token_request)
+                })
+            })
+        })
 }
 
 fn make_token_request(uri: &str, header: impl Header) -> Request<Body> {

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -116,9 +116,11 @@ where
         };
 
         // If /users/reset-key is called, invalidate the cached JWT.
-        if let Some((cache_key, _)) = cache_key_and_token_req(&req) {
-            self.cache_manager.invalidate(&cache_key);
-        };
+        if req.uri().path() == "/users/reset-key" {
+            if let Some((cache_key, _)) = cache_key_and_token_req(&req) {
+                self.cache_manager.invalidate(&cache_key);
+            };
+        }
 
         // If logout is called, invalidate the cached JWT for the callers cookie.
         if req.uri().path() == "/logout" {


### PR DESCRIPTION
A user should be able to reset their api-key, this is important functionality to have in case users leak their key. This should generate a new api-key and persist it in the users table.

Fixes #838.