### PR TITLE
ci: download sccache instead of compiling it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,10 @@ commands:
       - run:
           name: Install sccache
           command: |
-            ls ~/.cargo/bin/sccache || cargo install sccache
+            export SCCACHE_VERSION='v0.4.2'
+            ls ~/.cargo/bin/sccache || curl -L https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz | tar -xz
+            mkdir ~/.cargo && mkdir ~/.cargo/bin
+            mv sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl/sccache ~/.cargo/bin/sccache
             # This configures Rust to use sccache.
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             sccache --version


### PR DESCRIPTION
## Description of change

sccache takes up a significant amount of CI time compiling, reducing the effectiveness of the feedback loop.

## How Has This Been Tested (if applicable)?

I ran the commands locally, but CI itself should check this.
