### PR TITLE
deployer: add a mock POST /deploy/:project_name endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5372,7 +5372,11 @@ dependencies = [
  "clap",
  "futures",
  "http",
+ "hyper",
+ "hyper-reverse-proxy 0.5.2-dev (git+https://github.com/chesedo/hyper-reverse-proxy?branch=master)",
+ "once_cell",
  "serde",
+ "serde_json",
  "shuttle-common",
  "thiserror",
  "tokio",
@@ -7776,4 +7780,3 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5366,12 +5366,20 @@ dependencies = [
 name = "shuttle-deployer"
 version = "0.16.0"
 dependencies = [
+ "anyhow",
+ "axum",
+ "bytes",
  "clap",
+ "futures",
  "http",
+ "serde",
  "shuttle-common",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -7768,3 +7776,4 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -85,6 +85,8 @@ impl ProjectArgs {
 
 #[derive(Parser)]
 pub enum Command {
+    /// Deploy a shuttle service on the alpha deployer
+    DeployAlpha(DeployAlphaArgs),
     /// Deploy a shuttle service
     Deploy(DeployArgs),
     /// Manage deployments of a shuttle service
@@ -191,11 +193,20 @@ pub struct LoginArgs {
 }
 
 #[derive(Parser)]
-pub struct DeployArgs {
+pub struct DeployAlphaArgs {
     /// Allow deployment with uncommited files
     #[arg(long)]
     pub allow_dirty: bool,
     /// Don't run pre-deploy tests
+    #[arg(long)]
+    pub no_test: bool,
+}
+
+#[derive(Parser)]
+pub struct DeployArgs {
+    /// Allow deployment with uncommited files
+    #[arg(long)]
+    pub allow_dirty: bool,
     #[arg(long)]
     pub no_test: bool,
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -85,8 +85,6 @@ impl ProjectArgs {
 
 #[derive(Parser)]
 pub enum Command {
-    /// Deploy a shuttle service on the alpha deployer
-    DeployAlpha(DeployAlphaArgs),
     /// Deploy a shuttle service
     Deploy(DeployArgs),
     /// Manage deployments of a shuttle service
@@ -193,22 +191,10 @@ pub struct LoginArgs {
 }
 
 #[derive(Parser)]
-pub struct DeployAlphaArgs {
-    /// Allow deployment with uncommited files
-    #[arg(long)]
-    pub allow_dirty: bool,
-    /// Don't run pre-deploy tests
-    #[arg(long)]
-    pub no_test: bool,
-}
-
-#[derive(Parser)]
 pub struct DeployArgs {
     /// Allow deployment with uncommited files
     #[arg(long)]
     pub allow_dirty: bool,
-    #[arg(long)]
-    pub no_test: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -1,4 +1,4 @@
-use std::fmt::Write;
+
 
 use anyhow::{Context, Result};
 use headers::{Authorization, HeaderMapExt};
@@ -33,44 +33,7 @@ impl Client {
         self.api_key = Some(api_key);
     }
 
-    pub async fn deploy_alpha(
-        &self,
-        data: Vec<u8>,
-        project: &ProjectName,
-        no_test: bool,
-    ) -> Result<deployment::Response> {
-        let mut path = format!(
-            "/projects/{}/services/{}",
-            project.as_str(),
-            project.as_str()
-        );
-
-        if no_test {
-            let _ = write!(path, "?no-test");
-        }
-
-        let url = format!("{}{}", self.api_url, path);
-
-        let mut builder = Self::get_retry_client().post(url);
-
-        builder = self.set_builder_auth(builder);
-
-        builder
-            .body(data)
-            .header("Transfer-Encoding", "chunked")
-            .send()
-            .await
-            .context("failed to send deployment to the Shuttle server")?
-            .to_json()
-            .await
-    }
-
-    pub async fn deploy(
-        &self,
-        data: Vec<u8>,
-        project: &ProjectName,
-        _no_test: bool,
-    ) -> Result<String> {
+    pub async fn deploy(&self, data: Vec<u8>, project: &ProjectName) -> Result<String> {
         let path = format!("/deploy/{}", project.as_str(),);
         let url = format!("{}{}", self.api_url, path);
         let mut builder = Self::get_retry_client().post(url);

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -1,5 +1,3 @@
-
-
 use anyhow::{Context, Result};
 use headers::{Authorization, HeaderMapExt};
 use reqwest::Response;

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -33,7 +33,7 @@ impl Client {
         self.api_key = Some(api_key);
     }
 
-    pub async fn deploy(
+    pub async fn deploy_alpha(
         &self,
         data: Vec<u8>,
         project: &ProjectName,
@@ -61,6 +61,26 @@ impl Client {
             .send()
             .await
             .context("failed to send deployment to the Shuttle server")?
+            .to_json()
+            .await
+    }
+
+    pub async fn deploy(
+        &self,
+        data: Vec<u8>,
+        project: &ProjectName,
+        _no_test: bool,
+    ) -> Result<String> {
+        let path = format!("/deploy/{}", project.as_str(),);
+        let url = format!("{}{}", self.api_url, path);
+        let mut builder = Self::get_retry_client().post(url);
+        builder = self.set_builder_auth(builder);
+        builder
+            .body(data)
+            .header("Transfer-Encoding", "chunked")
+            .send()
+            .await
+            .context("failed to send the data to shuttle-deployer")?
             .to_json()
             .await
     }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -14,7 +14,11 @@ bytes = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
+hyper = { workspace = true, features = ["client", "http1", "http2", "tcp"] }
+hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "master" }
+once_cell = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -8,12 +8,20 @@ description = "Service to execute the deployment of projects on shuttle"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true, features = ["headers", "json", "query", "ws"] }
+bytes = { workspace = true }
 clap = { workspace = true }
+futures = { workspace = true }
 http = { workspace = true }
-tokio = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+utoipa = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["backend"]
+features = ["backend", "models", "openapi"]

--- a/deployer/README
+++ b/deployer/README
@@ -1,0 +1,31 @@
+### Local testing
+
+Start in a terminal the auth layer:
+```bash
+docker compose -f docker-compose.rendered.yml up auth
+```
+
+In another terminal create an admin user with the API key set to `test-key`:
+```bash
+AUTH_CONTAINER_ID=$(docker ps -aqf "name=shuttle-auth") \
+    docker exec $AUTH_CONTAINER_ID ./usr/local/bin/service \
+    --state=/var/lib/shuttle-auth \
+    init --name admin --key test-key
+```
+
+Create the corresponding JWT token and copy it to the shuttle config:
+```bash
+curl -s -H "Authorization: Bearer test-key" localhost:8008/auth/key \
+    | jq -r '.token' \
+    | read token; echo "api_key='$token'" > ~/.config/shuttle/config.toml
+```
+
+Start the deployer:
+```bash
+RUST_LOG=DEBUG cargo run --manifest-path deployer/Cargo.toml --bin shuttle-deployer -- --api-address 0.0.0.0:8001
+```
+
+In another terminal go to a shuttle project from the examples directory and run:
+```bash
+cargo run --manifest-path ../../../Cargo.toml --bin cargo-shuttle -- deploy
+```

--- a/deployer/README
+++ b/deployer/README
@@ -13,16 +13,9 @@ AUTH_CONTAINER_ID=$(docker ps -aqf "name=shuttle-auth") \
     init --name admin --key test-key
 ```
 
-Create the corresponding JWT token and copy it to the shuttle config:
+Start the deployer prepared for a local run:
 ```bash
-curl -s -H "Authorization: Bearer test-key" localhost:8008/auth/key \
-    | jq -r '.token' \
-    | read token; echo "api_key='$token'" > ~/.config/shuttle/config.toml
-```
-
-Start the deployer:
-```bash
-RUST_LOG=DEBUG cargo run --manifest-path deployer/Cargo.toml --bin shuttle-deployer -- --api-address 0.0.0.0:8001
+RUST_LOG=DEBUG cargo run --manifest-path deployer/Cargo.toml --bin shuttle-deployer -- --api-address 0.0.0.0:8001 --local
 ```
 
 In another terminal go to a shuttle project from the examples directory and run:

--- a/deployer/src/api/mod.rs
+++ b/deployer/src/api/mod.rs
@@ -8,7 +8,7 @@ use shuttle_common::claims::Claim;
 use std::collections::HashMap;
 use tracing::{debug, error, instrument};
 
-use super::error::Result;
+use crate::handlers::error::Result;
 
 #[instrument(skip_all, fields(%project_name))]
 #[utoipa::path(

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use clap::Parser;
 use http::Uri;
 
@@ -8,4 +10,7 @@ pub struct Args {
     /// Address to reach the authentication service at
     #[clap(long, default_value = "http://127.0.0.1:8008")]
     pub auth_uri: Uri,
+    /// Address to bind API to
+    #[clap(long, default_value = "0.0.0.0:8001")]
+    pub api_address: SocketAddr,
 }

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -10,7 +10,12 @@ pub struct Args {
     /// Address to reach the authentication service at
     #[clap(long, default_value = "http://127.0.0.1:8008")]
     pub auth_uri: Uri,
+
     /// Address to bind API to
     #[clap(long, default_value = "0.0.0.0:8001")]
     pub api_address: SocketAddr,
+
+    /// Flag used to prepare the deployer for a local run
+    #[clap(long)]
+    pub local: bool,
 }

--- a/deployer/src/handlers/deployment.rs
+++ b/deployer/src/handlers/deployment.rs
@@ -1,0 +1,41 @@
+use axum::{
+    extract::{BodyStream, Path, Query},
+    Extension, Json,
+};
+use bytes::BufMut;
+use futures::StreamExt;
+use shuttle_common::claims::Claim;
+use std::collections::HashMap;
+use tracing::{debug, error, instrument};
+
+use super::error::Result;
+
+#[instrument(skip_all, fields(%project_name))]
+#[utoipa::path(
+    post,
+    path = "/deploy/{project_name}",
+    responses(
+        (status = 200, description = "Deploys a project by receiving an associated project archive.", content_type = "application/json", body = String),
+        (status = 500, description = "Error while receiving byte stream.", body = String),
+    ),
+    params(
+        ("project_name" = String, Path, description = "Name of the project that owns the service.")
+    )
+)]
+pub async fn deploy_project(
+    Extension(_claim): Extension<Claim>,
+    Path(project_name): Path<String>,
+    Query(_params): Query<HashMap<String, String>>,
+    mut stream: BodyStream,
+) -> Result<Json<String>> {
+    let mut data = Vec::new();
+    debug!("Starting byte stream reading");
+    while let Some(buf) = stream.next().await {
+        let buf = buf.map_err(|err| error!("{:?}", err)).unwrap();
+        debug!("Received {} bytes", buf.len());
+        data.put(buf);
+    }
+    debug!("Received a total of {} bytes", data.len());
+
+    Ok(Json(format!("Received a total of {} bytes", data.len())))
+}

--- a/deployer/src/handlers/error.rs
+++ b/deployer/src/handlers/error.rs
@@ -1,0 +1,59 @@
+use std::error::Error as StdError;
+
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+
+use serde::{ser::SerializeMap, Serialize};
+use shuttle_common::models::error::ApiError;
+use tracing::error;
+use utoipa::ToSchema;
+
+#[derive(thiserror::Error, Debug, ToSchema)]
+pub enum Error {
+    #[error("Streaming error: {0}")]
+    Streaming(#[from] axum::Error),
+    #[error("{0}, try running `cargo shuttle deploy`")]
+    NotFound(String),
+    #[error("Custom error: {0}")]
+    Custom(#[from] anyhow::Error),
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", &format!("{:?}", self))?;
+        // use the error source if available, if not use display implementation
+        map.serialize_entry("msg", &self.source().unwrap_or(self).to_string())?;
+        map.end()
+    }
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        error!(error = &self as &dyn std::error::Error, "request error");
+
+        let code = match self {
+            Error::NotFound(_) => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+        (
+            code,
+            [(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            )],
+            Json(ApiError {
+                message: self.to_string(),
+                status_code: code.as_u16(),
+            }),
+        )
+            .into_response()
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/deployer/src/handlers/error.rs
+++ b/deployer/src/handlers/error.rs
@@ -13,8 +13,6 @@ use utoipa::ToSchema;
 pub enum Error {
     #[error("Streaming error: {0}")]
     Streaming(#[from] axum::Error),
-    #[error("{0}, try running `cargo shuttle deploy`")]
-    NotFound(String),
     #[error("Custom error: {0}")]
     Custom(#[from] anyhow::Error),
 }
@@ -36,10 +34,7 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         error!(error = &self as &dyn std::error::Error, "request error");
 
-        let code = match self {
-            Error::NotFound(_) => StatusCode::NOT_FOUND,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
+        let code = StatusCode::INTERNAL_SERVER_ERROR;
 
         (
             code,

--- a/deployer/src/handlers/local.rs
+++ b/deployer/src/handlers/local.rs
@@ -1,0 +1,82 @@
+use std::net::Ipv4Addr;
+
+use axum::{
+    headers::{authorization::Bearer, Authorization, Cookie, Header, HeaderMapExt},
+    http::Request,
+    middleware::Next,
+    response::Response,
+    Extension,
+};
+use hyper::{
+    client::{connect::dns::GaiResolver, HttpConnector},
+    Body, Client, StatusCode, Uri,
+};
+use hyper_reverse_proxy::ReverseProxy;
+use once_cell::sync::Lazy;
+use serde_json::Value;
+use tracing::error;
+
+static PROXY_CLIENT: Lazy<ReverseProxy<HttpConnector<GaiResolver>>> =
+    Lazy::new(|| ReverseProxy::new(Client::new()));
+
+/// This middleware proxies a request to the auth service to get a JWT, which we need to access
+/// the deployer endpoints.
+///
+/// WARNING: do not set this layer in production.
+pub async fn set_jwt_bearer<B>(
+    Extension(auth_uri): Extension<Uri>,
+    mut request: Request<B>,
+    next: Next<B>,
+) -> Result<Response, StatusCode> {
+    let mut auth_details = None;
+
+    if let Some(bearer) = request.headers().typed_get::<Authorization<Bearer>>() {
+        auth_details = Some(make_token_request("/auth/key", bearer));
+    }
+
+    if let Some(cookie) = request.headers().typed_get::<Cookie>() {
+        auth_details = Some(make_token_request("/auth/session", cookie));
+    }
+
+    if let Some(token_request) = auth_details {
+        let response = PROXY_CLIENT
+            .call(
+                Ipv4Addr::LOCALHOST.into(),
+                &auth_uri.to_string(),
+                token_request,
+            )
+            .await
+            .expect("failed to proxy request to auth service");
+
+        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let convert: Value = serde_json::from_slice(&body)
+            .expect("failed to deserialize body as JSON, did you login?");
+
+        let token = convert["token"]
+            .as_str()
+            .expect("response body should have a token");
+
+        request
+            .headers_mut()
+            .typed_insert(Authorization::bearer(token).expect("to set JWT token"));
+
+        let response = next.run(request).await;
+
+        Ok(response)
+    } else {
+        error!("No api-key bearer token or cookie found, make sure you are logged in.");
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+fn make_token_request(uri: &str, header: impl Header) -> Request<Body> {
+    let mut token_request = Request::builder().uri(uri);
+    token_request
+        .headers_mut()
+        .expect("manual request to be valid")
+        .typed_insert(header);
+
+    token_request
+        .body(Body::empty())
+        .expect("manual request to be valid")
+}

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -1,0 +1,42 @@
+use axum::{handler::Handler, headers::HeaderMapExt, routing::post, Router};
+use http::Uri;
+use shuttle_common::{
+    backends::{
+        auth::{AuthPublicKey, JwtAuthenticationLayer, ScopedLayer},
+        headers::XShuttleAccountName,
+        metrics::TraceLayer,
+    },
+    claims::Scope,
+    request_span,
+};
+
+use tracing::field;
+
+mod deployment;
+mod error;
+
+pub async fn make_router(auth_uri: Uri) -> Router {
+    Router::new()
+        .route(
+            "/deploy/:project_name",
+            post(deployment::deploy_project.layer(ScopedLayer::new(vec![Scope::DeploymentPush]))),
+        )
+        .layer(JwtAuthenticationLayer::new(AuthPublicKey::new(auth_uri)))
+        // This route should be below the auth bearer since it does not need authentication
+        .layer(
+            TraceLayer::new(|request| {
+                let account_name = request
+                    .headers()
+                    .typed_get::<XShuttleAccountName>()
+                    .unwrap_or_default();
+
+                request_span!(
+                    request,
+                    account.name = account_name.0,
+                    request.params.project_name = field::Empty,
+                )
+            })
+            .with_propagation()
+            .build(),
+        )
+}

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod args;
 pub mod handlers;
+pub mod api;

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -1,3 +1,3 @@
+pub mod api;
 pub mod args;
 pub mod handlers;
-pub mod api;

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod args;
+pub mod handlers;

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -1,13 +1,19 @@
 use clap::Parser;
 use shuttle_common::backends::tracing::setup_tracing;
 use shuttle_deployer::args::Args;
+use shuttle_deployer::handlers::make_router;
 use tracing::trace;
 
-#[tokio::main]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() {
     let args = Args::parse();
 
     trace!(args = ?args, "parsed args");
 
     setup_tracing(tracing_subscriber::registry(), "deployer");
+    let router = make_router(args.auth_uri).await;
+    axum::Server::bind(&args.api_address)
+        .serve(router.into_make_service())
+        .await
+        .unwrap_or_else(|_| panic!("Failed to bind to address: {}", args.api_address));
 }

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -17,10 +17,8 @@ async fn main() {
         router_builder = router_builder.with_local_admin_layer();
     }
 
-    let router = router_builder.into_router();
-
     axum::Server::bind(&args.api_address)
-        .serve(router.into_make_service())
+        .serve(router_builder.into_router().into_make_service())
         .await
         .unwrap_or_else(|_| panic!("Failed to bind to address: {}", args.api_address));
 }

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -4,7 +4,7 @@ use shuttle_deployer::args::Args;
 use shuttle_deployer::handlers::RouterBuilder;
 use tracing::trace;
 
-#[tokio::main(flavor = "multi_thread")]
+#[tokio::main]
 async fn main() {
     let args = Args::parse();
 


### PR DESCRIPTION
## Description of change

This endpoint is still authenticated and will require a JWT corresponding to a user API key (existing in the auth persistence). It's not guarded by an `AdminLayer`.

## How Has This Been Tested (if applicable)?

Added a README that goes through the steps.
