### PR TITLE
feat: remove /hello from tests/ci

### DIFF
--- a/.circleci/qa-wasm.sh
+++ b/.circleci/qa-wasm.sh
@@ -16,7 +16,7 @@ cargo shuttle run &
 sleep 70
 
 echo "Testing local wasm endpoint"
-output=$(curl --silent localhost:8000/hello)
+output=$(curl --silent localhost:8000)
 [ "$output" != "Hello, World!" ] && ( echo "Did not expect output: $output"; exit 1 )
 
 killall cargo-shuttle

--- a/.circleci/qa.sh
+++ b/.circleci/qa.sh
@@ -14,7 +14,7 @@ cargo shuttle run &
 sleep 150
 
 echo "Testing local hello endpoint"
-output=$(curl --silent localhost:8000/hello)
+output=$(curl --silent localhost:8000)
 [ "$output" != "Hello, world!" ] && ( echo "Did not expect output: $output"; exit 1 )
 
 killall cargo-shuttle
@@ -24,7 +24,7 @@ cargo shuttle project start
 cargo shuttle deploy --allow-dirty
 
 echo "Testing remote hello endpoint"
-output=$(curl --silent https://qa-$1.unstable.shuttleapp.rs/hello)
+output=$(curl --silent https://qa-$1.unstable.shuttleapp.rs)
 [ "$output" != "Hello, world!" ] && ( echo "Did not expect output: $output"; exit 1 )
 
 cargo shuttle project stop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Test if the deployment is working:
 
 ```bash
 # the Host header should match the Host from the deploy output
-curl --header "Host: {app}.unstable.shuttleapp.rs" localhost:8000/hello
+curl --header "Host: {app}.unstable.shuttleapp.rs" localhost:8000
 ```
 
 View logs from the current deployment:

--- a/cargo-shuttle/README.md
+++ b/cargo-shuttle/README.md
@@ -124,7 +124,7 @@ fn index() -> &'static str {
 
 #[shuttle_runtime::main]
 async fn rocket() -> shuttle_rocket::ShuttleRocket {
-    let rocket = rocket::build().mount("/hello", routes![index]);
+    let rocket = rocket::build().mount("/", routes![index]);
 
     Ok(rocket.into())
 }
@@ -142,7 +142,7 @@ cargo shuttle run
 This will compile your shuttle project and start it on the default port `8000`. Test it by:
 
 ```sh
-$ curl http://localhost:8000/hello
+$ curl http://localhost:8000
 Hello, world!
 ```
 
@@ -173,7 +173,7 @@ cargo shuttle deploy
 Your service will immediately be available at `{crate_name}.shuttleapp.rs`. For instance:
 
 ```sh
-$ curl https://my-rocket-app.shuttleapp.rs/hello
+$ curl https://my-rocket-app.shuttleapp.rs
 Hello, world!
 ```
 

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -101,7 +101,7 @@ impl ShuttleInit for ShuttleInitActixWeb {
         use actix_web::{get, web::ServiceConfig};
         use shuttle_actix_web::ShuttleActixWeb;
 
-        #[get("/hello")]
+        #[get("/")]
         async fn hello_world() -> &'static str {
             "Hello World!"
         }
@@ -166,7 +166,7 @@ impl ShuttleInit for ShuttleInitAxum {
 
         #[shuttle_runtime::main]
         async fn axum() -> shuttle_axum::ShuttleAxum {
-            let router = Router::new().route("/hello", get(hello_world));
+            let router = Router::new().route("/", get(hello_world));
 
             Ok(router.into())
         }"#}
@@ -223,7 +223,7 @@ impl ShuttleInit for ShuttleInitRocket {
 
         #[shuttle_runtime::main]
         async fn rocket() -> shuttle_rocket::ShuttleRocket {
-            let rocket = rocket::build().mount("/hello", routes![index]);
+            let rocket = rocket::build().mount("/", routes![index]);
 
             Ok(rocket.into())
         }"#}
@@ -275,7 +275,7 @@ impl ShuttleInit for ShuttleInitTide {
             let mut app = tide::new();
             app.with(tide::log::LogMiddleware::new());
 
-            app.at("/hello").get(|_| async { Ok("Hello, world!") });
+            app.at("/").get(|_| async { Ok("Hello, world!") });
 
             Ok(app.into())
         }"#}
@@ -332,7 +332,7 @@ impl ShuttleInit for ShuttleInitPoem {
 
         #[shuttle_runtime::main]
         async fn poem() -> ShuttlePoem<impl poem::Endpoint> {
-            let app = Route::new().at("/hello", get(hello_world));
+            let app = Route::new().at("/", get(hello_world));
 
             Ok(app.into())
         }"#}
@@ -839,7 +839,7 @@ impl ShuttleInit for ShuttleInitThruster {
         #[shuttle_runtime::main]
         async fn thruster() -> shuttle_thruster::ShuttleThruster<HyperServer<Ctx, ()>> {
             let server = HyperServer::new(
-                App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/hello", m![hello]),
+                App::<HyperRequest, Ctx, ()>::create(generate_context, ()).get("/", m![hello]),
             );
             
             Ok(server.into())

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -183,7 +183,7 @@ fn assert_valid_rocket_project(path: &Path, name_prefix: &str) {
 
     #[shuttle_runtime::main]
     async fn rocket() -> shuttle_rocket::ShuttleRocket {
-        let rocket = rocket::build().mount("/hello", routes![index]);
+        let rocket = rocket::build().mount("/", routes![index]);
 
         Ok(rocket.into())
     }"#};

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -149,14 +149,7 @@ async fn shuttle_next() {
     let url = cargo_shuttle_run("../examples/next/hello-world", false).await;
     let client = reqwest::Client::new();
 
-    let request_text = client
-        .get(&url)
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
+    let request_text = client.get(&url).send().await.unwrap().text().await.unwrap();
 
     assert_eq!(request_text, "Hello, World!");
 

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -63,7 +63,7 @@ async fn rocket_hello_world() {
     let url = cargo_shuttle_run("../examples/rocket/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -150,7 +150,7 @@ async fn shuttle_next() {
     let client = reqwest::Client::new();
 
     let request_text = client
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -236,7 +236,7 @@ async fn actix_web_hello_world() {
     let url = cargo_shuttle_run("../examples/actix-web/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -253,7 +253,7 @@ async fn axum_hello_world() {
     let url = cargo_shuttle_run("../examples/axum/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -270,7 +270,7 @@ async fn tide_hello_world() {
     let url = cargo_shuttle_run("../examples/tide/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -287,7 +287,7 @@ async fn tower_hello_world() {
     let url = cargo_shuttle_run("../examples/tower/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -304,7 +304,7 @@ async fn warp_hello_world() {
     let url = cargo_shuttle_run("../examples/warp/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -321,7 +321,7 @@ async fn poem_hello_world() {
     let url = cargo_shuttle_run("../examples/poem/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -402,7 +402,7 @@ async fn salvo_hello_world() {
     let url = cargo_shuttle_run("../examples/salvo/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -419,7 +419,7 @@ async fn thruster_hello_world() {
     let url = cargo_shuttle_run("../examples/thruster/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()
@@ -435,7 +435,7 @@ async fn rocket_hello_world_with_router_ip() {
     let url = cargo_shuttle_run("../examples/rocket/hello-world", true).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}/hello"))
+        .get(format!("{url}"))
         .send()
         .await
         .unwrap()

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -63,7 +63,7 @@ async fn rocket_hello_world() {
     let url = cargo_shuttle_run("../examples/rocket/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -150,7 +150,7 @@ async fn shuttle_next() {
     let client = reqwest::Client::new();
 
     let request_text = client
-        .get(format!("{url}"))
+        .get(&url)
         .send()
         .await
         .unwrap()
@@ -236,7 +236,7 @@ async fn actix_web_hello_world() {
     let url = cargo_shuttle_run("../examples/actix-web/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -253,7 +253,7 @@ async fn axum_hello_world() {
     let url = cargo_shuttle_run("../examples/axum/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -270,7 +270,7 @@ async fn tide_hello_world() {
     let url = cargo_shuttle_run("../examples/tide/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -287,7 +287,7 @@ async fn tower_hello_world() {
     let url = cargo_shuttle_run("../examples/tower/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -304,7 +304,7 @@ async fn warp_hello_world() {
     let url = cargo_shuttle_run("../examples/warp/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -321,7 +321,7 @@ async fn poem_hello_world() {
     let url = cargo_shuttle_run("../examples/poem/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -402,7 +402,7 @@ async fn salvo_hello_world() {
     let url = cargo_shuttle_run("../examples/salvo/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -419,7 +419,7 @@ async fn thruster_hello_world() {
     let url = cargo_shuttle_run("../examples/thruster/hello-world", false).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()
@@ -435,7 +435,7 @@ async fn rocket_hello_world_with_router_ip() {
     let url = cargo_shuttle_run("../examples/rocket/hello-world", true).await;
 
     let request_text = reqwest::Client::new()
-        .get(format!("{url}"))
+        .get(url)
         .send()
         .await
         .unwrap()


### PR DESCRIPTION
## Description of change

These are changes related to changing the /hello to '/' route in the examples repo

Issue: https://github.com/shuttle-hq/shuttle/issues/841

Related PR in the examples repo: https://github.com/shuttle-hq/shuttle-examples/pull/41

## How Has This Been Tested (if applicable)?

Each framework sample was manually deployed and tested (using curl and hitting the root route)

We wanted to test it with e2e tests but there seems to be an issue there, see https://github.com/shuttle-hq/shuttle/issues/849

Going to watch CI tests below as well

We may need to merge the examples repo into main first since this is a multiple repo change
