### PR TITLE
add option to use rustls instead of native-tls in `shuttle-shared-db`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,6 +509,8 @@ workflows:
                 - services/shuttle-tower
                 - services/shuttle-warp
       - check-standalone:
+        # shuttle-shared-db has mutually exclusive features
+        # so we run checks for each feature separately
           name: "resources/shared-db: << matrix.features >>"
           matrix:
             alias: check-standalone-shared-db

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ workflows:
                 - services/shuttle-tower
                 - services/shuttle-warp
       - check-standalone:
-          name: resources/shared-db
+          name: "resources/shared-db: << matrix.features >>"
           matrix:
             alias: check-standalone-shared-db
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,10 @@ jobs:
       path:
         description: "Path to crate external from workspace"
         type: string
+      features:
+        description: "Features to enable"
+        type: string
+        default: --all-features
     executor: docker-rust
     environment:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
@@ -218,13 +222,13 @@ jobs:
       - run: |
           cargo clippy --tests \
                        --all-targets \
-                       --all-features \
+                       << parameters.features >> \
                        --manifest-path << parameters.path >>/Cargo.toml \
                        --no-deps -- \
                        --D warnings \
                        -A clippy::let-unit-value \
                        -A clippy::format-push-string
-      - run: cargo test --all-features --manifest-path << parameters.path >>/Cargo.toml -- --nocapture
+      - run: cargo test << parameters.features >> --manifest-path << parameters.path >>/Cargo.toml -- --nocapture
       - save-cargo-cache
   platform-test:
     parameters:
@@ -491,7 +495,6 @@ workflows:
                 - resources/aws-rds
                 - resources/persist
                 - resources/secrets
-                - resources/shared-db
                 - resources/static-folder
                 - services/shuttle-actix-web
                 - services/shuttle-axum
@@ -505,6 +508,16 @@ workflows:
                 - services/shuttle-tide
                 - services/shuttle-tower
                 - services/shuttle-warp
+      - check-standalone:
+          name: resources/shared-db
+          matrix:
+            alias: check-standalone-shared-db
+            parameters:
+              path: [resources/shared-db]
+              features:
+                - "-F mongodb"
+                - "-F postgres"
+                - "-F postgres-rustls"
       - platform-test:
           name: << matrix.crate >>
           requires:
@@ -527,6 +540,7 @@ workflows:
           requires:
             - platform-test
             - check-standalone
+            - check-standalone-shared-db
           filters:
             branches:
               only: production

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -11,7 +11,8 @@ async-trait = "0.1.56"
 mongodb = { version = "2.3.0", optional = true }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.15.0", default-features = false }
-sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls"], optional = true }
+sqlx = { version = "0.6.2", optional = true }
 
 [features]
-postgres = ["sqlx/postgres"]
+postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
+postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]

--- a/resources/shared-db/README.md
+++ b/resources/shared-db/README.md
@@ -4,12 +4,12 @@ This plugin manages databases that are shared with other services on [shuttle](h
 
 ## Usage
 
-Add `shuttle-shared-db` to the dependencies for your service. Every type of shareable database is behind the following feature flag and attribute path
+Add `shuttle-shared-db` to the dependencies for your service. Every type of shareable database is behind the following feature flag and attribute path (`*-rustls` uses rustls for TLS, the default uses native-tls).
 
-| Engine   | Feature flag | Attribute path              |
-|----------|--------------|-----------------------------|
-| Postgres | postgres     | shuttle_shared_db::Postgres |
-| MongoDB  | mongodb      | shuttle_shared_db::MongoDb  |
+| Engine   | Feature flags                  | Attribute path              |
+|----------|--------------------------------|-----------------------------|
+| Postgres | `postgres` / `postgres-rustls` | shuttle_shared_db::Postgres |
+| MongoDB  | `mongodb`                      | shuttle_shared_db::MongoDb  |
 
 An example using the Rocket framework can be found on [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/rocket/postgres)
 

--- a/resources/shared-db/src/lib.rs
+++ b/resources/shared-db/src/lib.rs
@@ -5,8 +5,8 @@ mod mongo;
 #[cfg(feature = "mongodb")]
 pub use mongo::MongoDb;
 
-#[cfg(feature = "postgres")]
+#[cfg(any(feature = "postgres", feature = "postgres-rustls"))]
 mod postgres;
 
-#[cfg(feature = "postgres")]
+#[cfg(any(feature = "postgres", feature = "postgres-rustls"))]
 pub use postgres::Postgres;


### PR DESCRIPTION
## Description of change

Adds feature `postgres-rustls` to `shuttle-shared-db`, allowing to use Postgres without relying on bindings to native SSL implementation.

Closes issue #690.

## How Has This Been Tested (if applicable)?

Created new example in https://github.com/shuttle-hq/shuttle-examples/pull/43, local run with both `postgres` and `postgres-rustls` feature is working:

`postgres`:
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/829944/236516408-b0f8e380-18a0-497a-90b3-e40d70c2ad35.png">

`postgres-rustls`:
<img width="1175" alt="image" src="https://user-images.githubusercontent.com/829944/236516515-1ca72a89-6935-41c0-81b8-de270d009cfc.png">
<img width="895" alt="image" src="https://user-images.githubusercontent.com/829944/236516540-8842d6eb-0668-4170-a326-0fec0d57c00a.png">

