### PR TITLE
Match doc links with Shuttle Service current doc url

### DIFF
--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -142,7 +142,7 @@ fn check_return_type(signature: Signature) -> Option<TypePath> {
                 signature,
                 "shuttle_runtime::main functions need to return a service";
                 hint = "See the docs for services with first class support";
-                doc = "https://docs.rs/shuttle-service/latest/shuttle_runtime/attr.main.html#shuttle-supported-services"
+                doc = "https://docs.rs/shuttle-service/latest/shuttle_service/attr.main.html#shuttle-supported-services"
             );
             None
         }
@@ -153,7 +153,7 @@ fn check_return_type(signature: Signature) -> Option<TypePath> {
                     r#type,
                     "shuttle_runtime::main functions need to return a first class service or 'Result<impl Service, shuttle_runtime::Error>";
                     hint = "See the docs for services with first class support";
-                    doc = "https://docs.rs/shuttle-service/latest/shuttle_runtime/attr.main.html#shuttle-supported-services"
+                    doc = "https://docs.rs/shuttle-service/latest/shuttle_service/attr.main.html#shuttle-supported-services"
                 );
                 None
             }

--- a/codegen/tests/ui/main/missing-return.stderr
+++ b/codegen/tests/ui/main/missing-return.stderr
@@ -1,7 +1,7 @@
 error: shuttle_runtime::main functions need to return a service
 
          = help: See the docs for services with first class support
-         = note: https://docs.rs/shuttle-service/latest/shuttle_runtime/attr.main.html#shuttle-supported-services
+         = note: https://docs.rs/shuttle-service/latest/shuttle_service/attr.main.html#shuttle-supported-services
 
  --> tests/ui/main/missing-return.rs:2:1
   |

--- a/codegen/tests/ui/main/return-tuple.stderr
+++ b/codegen/tests/ui/main/return-tuple.stderr
@@ -1,7 +1,7 @@
 error: shuttle_runtime::main functions need to return a first class service or 'Result<impl Service, shuttle_runtime::Error>
 
          = help: See the docs for services with first class support
-         = note: https://docs.rs/shuttle-service/latest/shuttle_runtime/attr.main.html#shuttle-supported-services
+         = note: https://docs.rs/shuttle-service/latest/shuttle_service/attr.main.html#shuttle-supported-services
 
  --> tests/ui/main/return-tuple.rs:2:28
   |


### PR DESCRIPTION
## Description of change
Updated doc string URL to match current URL for resource.

Please write a summary of your changes and why you made them. 
URL in returned error doesn't  point to current Shuttle Service docs.

Be sure to reference any related issues by adding `closes issue #`.

## How Has This Been Tested (if applicable)?

Please describe the tests that you ran to verify your changes.
Ran `cargo clippy --tests --all-targets` and `cargo check`