### PR TITLE
chore: bump common to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5247,7 +5247,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-common"
-version = "0.16.1"
+version = "0.16.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-common"
-version = "0.16.0"
+version = "0.16.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description of change

Bump and publish common 0.16.2 with scopebuilder fix.
