### PR TITLE
chore: upgrade salvo in shuttle-salvo

### DIFF
--- a/services/shuttle-salvo/Cargo.toml
+++ b/services/shuttle-salvo/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "salvo"]
 [workspace]
 
 [dependencies]
-salvo = { version = "0.37.5" }
+salvo = { version = "0.41.0" }
 shuttle-runtime = { path = "../../runtime", version = "0.16.0" }
 
 [dev-dependencies]

--- a/services/shuttle-salvo/src/lib.rs
+++ b/services/shuttle-salvo/src/lib.rs
@@ -16,6 +16,7 @@
 //! }
 //!
 //! ```
+use salvo::Listener;
 use shuttle_runtime::Error;
 use std::net::SocketAddr;
 
@@ -27,9 +28,9 @@ impl shuttle_runtime::Service for SalvoService {
     /// Takes the router that is returned by the user in their [shuttle_runtime::main] function
     /// and binds to an address passed in by shuttle.
     async fn bind(mut self, addr: SocketAddr) -> Result<(), Error> {
-        salvo::Server::new(salvo::listener::TcpListener::bind(addr))
-            .serve(self.0)
-            .await;
+        let listener = salvo::conn::TcpListener::new(addr).bind().await;
+
+        salvo::Server::new(listener).serve(self.0).await;
 
         Ok(())
     }


### PR DESCRIPTION
## Description of change

Salvo had breaking changes in a recent release, so the latest version fetched with init is no longer compatible with shuttle-salvo. This PR updates it.

## How Has This Been Tested (if applicable)?

Local run.