### PR TITLE
docs: add installation instructions for Arch Linux

### DIFF
--- a/cargo-shuttle/README.md
+++ b/cargo-shuttle/README.md
@@ -41,6 +41,23 @@
 cargo install cargo-shuttle
 ```
 
+### Distro Packages
+
+<details>
+  <summary>Packaging status</summary>
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/cargo-shuttle.svg)](https://repology.org/project/cargo-shuttle/versions)
+
+</details>
+
+#### Arch Linux
+
+`cargo-shuttle` can be installed from the [community repository](https://archlinux.org/packages/community/x86_64/cargo-shuttle) using [pacman](https://wiki.archlinux.org/title/Pacman):
+
+```sh
+pacman -S cargo-shuttle
+```
+
 ---
 
 <!-- markdownlint-disable-next-line -->


### PR DESCRIPTION
## Description of change

This PR updates the README.md of `cargo-shuttle` for expanding the installation section.

I recently packaged `cargo-shuttle` for Arch Linux and now it can be installed via `pacman`: https://archlinux.org/packages/community/x86_64/cargo-shuttle/

Also, I added a [repology](https://repology.org/) badge for viewing the other distribution packages.

## How Has This Been Tested (if applicable)?

\-
