### PR TITLE
 feat: add `--features` argument to `cargo shuttle run`

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -229,6 +229,9 @@ pub struct RunArgs {
     /// Use 0.0.0.0 instead of localhost (for usage with local external devices)
     #[arg(long)]
     pub external: bool,
+    /// Set the list of features to activate
+    #[arg(long)]
+    pub features: Vec<String>,
     /// Use release mode for building the project
     #[arg(long, short = 'r')]
     pub release: bool,

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -793,7 +793,14 @@ impl Shuttle {
         );
 
         // Compile all the alpha or shuttle-next services in the workspace.
-        build_workspace(working_directory, run_args.release, tx, false).await
+        build_workspace(
+            working_directory,
+            run_args.features.clone(),
+            run_args.release,
+            tx,
+            false,
+        )
+        .await
     }
 
     async fn setup_local_provisioner(

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -343,7 +343,7 @@ async fn build_deployment(
     project_path: &Path,
     tx: crossbeam_channel::Sender<Message>,
 ) -> Result<BuiltService> {
-    let runtimes = build_workspace(project_path, true, tx, true)
+    let runtimes = build_workspace(project_path, vec![], true, tx, true)
         .await
         .map_err(|e| Error::Build(e.into()))?;
 

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -74,6 +74,7 @@ fn extract_shuttle_toml_name(path: PathBuf) -> anyhow::Result<String> {
 /// Given a project directory path, builds the crate
 pub async fn build_workspace(
     project_path: &Path,
+    features: Vec<String>,
     release_mode: bool,
     tx: Sender<Message>,
     deployment: bool,
@@ -108,6 +109,7 @@ pub async fn build_workspace(
     if !alpha_packages.is_empty() {
         let mut service = compile(
             alpha_packages,
+            features.clone(),
             release_mode,
             false,
             project_path.clone(),
@@ -124,6 +126,7 @@ pub async fn build_workspace(
     if !next_packages.is_empty() {
         let mut service = compile(
             next_packages,
+            features,
             release_mode,
             true,
             project_path,
@@ -213,6 +216,7 @@ fn is_cdylib(target: &Target) -> bool {
 
 async fn compile(
     packages: Vec<&Package>,
+    features: Vec<String>,
     release_mode: bool,
     wasm: bool,
     project_path: PathBuf,
@@ -251,6 +255,10 @@ async fn compile(
 
     if wasm {
         cargo.arg("--target").arg("wasm32-wasi");
+    }
+
+    if !features.is_empty() {
+        cargo.arg("--features").arg(features.join(","));
     }
 
     let mut handle = cargo.spawn()?;

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -7,7 +7,7 @@ use shuttle_service::builder::{build_workspace, BuiltService};
 async fn not_shuttle() {
     let (tx, _) = crossbeam_channel::unbounded();
     let project_path = format!("{}/tests/resources/not-shuttle", env!("CARGO_MANIFEST_DIR"));
-    build_workspace(Path::new(&project_path), false, tx, false)
+    build_workspace(Path::new(&project_path), vec![], false, tx, false)
         .await
         .unwrap();
 }
@@ -17,7 +17,7 @@ async fn not_shuttle() {
 async fn not_bin() {
     let (tx, _) = crossbeam_channel::unbounded();
     let project_path = format!("{}/tests/resources/not-bin", env!("CARGO_MANIFEST_DIR"));
-    match build_workspace(Path::new(&project_path), false, tx, false).await {
+    match build_workspace(Path::new(&project_path), vec![], false, tx, false).await {
         Ok(_) => {}
         Err(e) => panic!("{}", e.to_string()),
     }
@@ -29,7 +29,7 @@ async fn is_bin() {
     let project_path = format!("{}/tests/resources/is-bin", env!("CARGO_MANIFEST_DIR"));
 
     assert_eq!(
-        build_workspace(Path::new(&project_path), false, tx, false)
+        build_workspace(Path::new(&project_path), vec![], false, tx, false)
             .await
             .unwrap(),
         vec![BuiltService::new(
@@ -50,7 +50,7 @@ async fn not_found() {
         "{}/tests/resources/non-existing",
         env!("CARGO_MANIFEST_DIR")
     );
-    build_workspace(Path::new(&project_path), false, tx, false)
+    build_workspace(Path::new(&project_path), vec![], false, tx, false)
         .await
         .unwrap();
 }
@@ -62,7 +62,7 @@ async fn workspace() {
     let project_path = format!("{}/tests/resources/workspace", env!("CARGO_MANIFEST_DIR"));
 
     assert_eq!(
-        build_workspace(Path::new(&project_path), false, tx, false)
+        build_workspace(Path::new(&project_path), vec![], false, tx, false)
             .await
             .unwrap(),
         vec![


### PR DESCRIPTION
## Description of change

This PR adds `--features` argument to `run` subcommand for activating cargo features.

See #913 for more detail.

## How Has This Been Tested (if applicable)?

I ran it locally, worked fine.
