### PR TITLE
feat: added support for s3 bucket in provisioner (#668)

### DIFF
--- a/proto/provisioner.proto
+++ b/proto/provisioner.proto
@@ -48,16 +48,12 @@ message DatabaseDeletionResponse {}
 message StorageRequest {
   string project_name = 1;
 
-  oneof type {
+  oneof storage_type {
     Bucket Bucket = 10;
   };
 }
 
-message Bucket {
-  oneof type {
-    string s3 = 1;
-  }
-}
+message Bucket {}
 
 message StorageResponse {
   string bucket_name = 1;

--- a/proto/provisioner.proto
+++ b/proto/provisioner.proto
@@ -4,6 +4,8 @@ package provisioner;
 service Provisioner {
   rpc ProvisionDatabase(DatabaseRequest) returns (DatabaseResponse);
   rpc DeleteDatabase(DatabaseRequest) returns (DatabaseDeletionResponse);
+  rpc ProvisionStorage(StorageRequest) returns (StorageResponse);
+  rpc DeleteStorage(StorageRequest) returns (StorageDeletionResponse);
 }
 
 message DatabaseRequest {
@@ -42,3 +44,27 @@ message DatabaseResponse {
 }
 
 message DatabaseDeletionResponse {}
+
+message StorageRequest {
+  string project_name = 1;
+
+  oneof type {
+    Bucket Bucket = 10;
+  };
+}
+
+message Bucket {
+  oneof type {
+    string s3 = 1;
+  }
+}
+
+message StorageResponse {
+  string bucket_name = 1;
+  string username = 2;
+  string access_key = 3;
+  string secret_key = 4;
+}
+
+
+message StorageDeletionResponse {}

--- a/proto/src/generated/provisioner.rs
+++ b/proto/src/generated/provisioner.rs
@@ -82,33 +82,21 @@ pub struct DatabaseDeletionResponse {}
 pub struct StorageRequest {
     #[prost(string, tag = "1")]
     pub project_name: ::prost::alloc::string::String,
-    #[prost(oneof = "storage_request::Type", tags = "10")]
-    pub r#type: ::core::option::Option<storage_request::Type>,
+    #[prost(oneof = "storage_request::StorageType", tags = "10")]
+    pub storage_type: ::core::option::Option<storage_request::StorageType>,
 }
 /// Nested message and enum types in `StorageRequest`.
 pub mod storage_request {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Type {
+    pub enum StorageType {
         #[prost(message, tag = "10")]
         Bucket(super::Bucket),
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Bucket {
-    #[prost(oneof = "bucket::Type", tags = "1")]
-    pub r#type: ::core::option::Option<bucket::Type>,
-}
-/// Nested message and enum types in `Bucket`.
-pub mod bucket {
-    #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Type {
-        #[prost(string, tag = "1")]
-        S3(::prost::alloc::string::String),
-    }
-}
+pub struct Bucket {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StorageResponse {

--- a/proto/src/generated/provisioner.rs
+++ b/proto/src/generated/provisioner.rs
@@ -77,6 +77,53 @@ pub struct DatabaseResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DatabaseDeletionResponse {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StorageRequest {
+    #[prost(string, tag = "1")]
+    pub project_name: ::prost::alloc::string::String,
+    #[prost(oneof = "storage_request::Type", tags = "10")]
+    pub r#type: ::core::option::Option<storage_request::Type>,
+}
+/// Nested message and enum types in `StorageRequest`.
+pub mod storage_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Type {
+        #[prost(message, tag = "10")]
+        Bucket(super::Bucket),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Bucket {
+    #[prost(oneof = "bucket::Type", tags = "1")]
+    pub r#type: ::core::option::Option<bucket::Type>,
+}
+/// Nested message and enum types in `Bucket`.
+pub mod bucket {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Type {
+        #[prost(string, tag = "1")]
+        S3(::prost::alloc::string::String),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StorageResponse {
+    #[prost(string, tag = "1")]
+    pub bucket_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub username: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub access_key: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub secret_key: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StorageDeletionResponse {}
 /// Generated client implementations.
 pub mod provisioner_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
@@ -184,6 +231,44 @@ pub mod provisioner_client {
             );
             self.inner.unary(request.into_request(), path, codec).await
         }
+        pub async fn provision_storage(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StorageRequest>,
+        ) -> Result<tonic::Response<super::StorageResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/provisioner.Provisioner/ProvisionStorage",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
+        pub async fn delete_storage(
+            &mut self,
+            request: impl tonic::IntoRequest<super::StorageRequest>,
+        ) -> Result<tonic::Response<super::StorageDeletionResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/provisioner.Provisioner/DeleteStorage",
+            );
+            self.inner.unary(request.into_request(), path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -201,6 +286,14 @@ pub mod provisioner_server {
             &self,
             request: tonic::Request<super::DatabaseRequest>,
         ) -> Result<tonic::Response<super::DatabaseDeletionResponse>, tonic::Status>;
+        async fn provision_storage(
+            &self,
+            request: tonic::Request<super::StorageRequest>,
+        ) -> Result<tonic::Response<super::StorageResponse>, tonic::Status>;
+        async fn delete_storage(
+            &self,
+            request: tonic::Request<super::StorageRequest>,
+        ) -> Result<tonic::Response<super::StorageDeletionResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ProvisionerServer<T: Provisioner> {
@@ -330,6 +423,86 @@ pub mod provisioner_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = DeleteDatabaseSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/provisioner.Provisioner/ProvisionStorage" => {
+                    #[allow(non_camel_case_types)]
+                    struct ProvisionStorageSvc<T: Provisioner>(pub Arc<T>);
+                    impl<
+                        T: Provisioner,
+                    > tonic::server::UnaryService<super::StorageRequest>
+                    for ProvisionStorageSvc<T> {
+                        type Response = super::StorageResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StorageRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).provision_storage(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ProvisionStorageSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/provisioner.Provisioner/DeleteStorage" => {
+                    #[allow(non_camel_case_types)]
+                    struct DeleteStorageSvc<T: Provisioner>(pub Arc<T>);
+                    impl<
+                        T: Provisioner,
+                    > tonic::server::UnaryService<super::StorageRequest>
+                    for DeleteStorageSvc<T> {
+                        type Response = super::StorageDeletionResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::StorageRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).delete_storage(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = DeleteStorageSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/provisioner/Cargo.toml
+++ b/provisioner/Cargo.toml
@@ -9,6 +9,8 @@ publish = false
 [dependencies]
 aws-config = "0.51.0"
 aws-sdk-rds = "0.21.0"
+aws-config-s3 = { package = "aws-config", version = "0.55.2" }
+aws-sdk-s3 = "0.27.0"
 clap = { workspace = true, features = ["env"] }
 fqdn = { workspace = true }
 mongodb = "2.4.0"
@@ -20,6 +22,9 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tonic = { workspace = true }
 tracing = { workspace = true, features = ["default"] }
 tracing-subscriber = { workspace = true, features = ["default", "fmt"] }
+aws-sdk-iam = "0.27.0"
+uuid.workspace = true
+serde_json.workspace = true
 
 [dependencies.shuttle-common]
 workspace = true

--- a/provisioner/src/error.rs
+++ b/provisioner/src/error.rs
@@ -17,6 +17,12 @@ pub enum Error {
     #[error("failed to drop role: {0}")]
     DeleteRole(String),
 
+    #[error("failed to create user: {0}")]
+    CreateUser(String),
+
+    #[error("failed to create s3 bucket: {0}")]
+    CreateBucket(String),
+
     #[error("failed to create DB: {0}")]
     CreateDB(String),
 

--- a/provisioner/src/lib.rs
+++ b/provisioner/src/lib.rs
@@ -543,6 +543,8 @@ impl Provisioner for MyProvisioner {
         &self,
         request: Request<StorageRequest>,
     ) -> Result<Response<StorageResponse>, Status> {
+        verify_claim(&request)?;
+        
         let request = request.into_inner();
         let reply = self.request_s3_bucket(&request.project_name).await?;
         Ok(Response::new(reply))


### PR DESCRIPTION
* feat: update provisioner.proto to add methods for provisioning storage

* feat: implemented provision_storage to create a bucket and return user credentials to access the bucket

This is a provisioner side change for  task /attempt #668, Steps for provisioning storage look like -

- Create a S3 bucket by appending an uuid to project_name to make it globally unique.
- Create a User to interact with the bucket
- Create a Policy and attach that to User
- Return access keys for the user, so that resource builder can access the bucket.