### PR TITLE
chore: promote hyper-reverse-proxy to a workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,17 +2863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-reverse-proxy"
-version = "0.5.2-dev"
-source = "git+https://github.com/chesedo/hyper-reverse-proxy?branch=master#e73a76600ce9e51e962de5266b03be596e6c1d50"
-dependencies = [
- "hyper",
- "lazy_static",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5298,7 +5287,7 @@ dependencies = [
  "hex 0.4.3",
  "home",
  "hyper",
- "hyper-reverse-proxy 0.5.2-dev (git+https://github.com/chesedo/hyper-reverse-proxy?branch=master)",
+ "hyper-reverse-proxy",
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
@@ -5345,7 +5334,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "hyper-reverse-proxy 0.5.2-dev (git+https://github.com/chesedo/hyper-reverse-proxy?branch=bug/host_header)",
+ "hyper-reverse-proxy",
  "instant-acme",
  "jsonwebtoken",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ headers = "0.3.8"
 home = "0.5.4"
 http = "0.2.8"
 hyper = "0.14.23"
+# not great, but waiting for WebSocket changes to be merged
+hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "bug/host_header" }
 jsonwebtoken = { version = "8.2.0" }
 once_cell = "1.16.0"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -20,7 +20,7 @@ futures = { workspace = true }
 home = { workspace = true }
 hyper = { workspace = true, features = ["client", "http1", "http2", "tcp"] }
 # not great, but waiting for WebSocket changes to be merged
-hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "master" }
+hyper-reverse-proxy = { workspace = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -17,8 +17,7 @@ fqdn = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 hyper = { workspace = true, features = ["stream"] }
-# not great, but waiting for WebSocket changes to be merged
-hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "bug/host_header" }
+hyper-reverse-proxy = { workspace = true }
 instant-acme = "0.2.0"
 lazy_static = "1.4.0"
 num_cpus = "1.15.0"


### PR DESCRIPTION
## Description of change

I'm trying to package cargo-shuttle for nixpkgs, and this fixes `cargo vendor`

```
error: failed to sync

Caused by:
  found duplicate version of package `hyper-reverse-proxy v0.5.2-dev` vendored from two sources:

        source 1: https://github.com/chesedo/hyper-reverse-proxy?branch=bug/host_header#5f82b7df
        source 2: https://github.com/chesedo/hyper-reverse-proxy?branch=master#e73a7660
```

Be sure to reference any related issues by adding `closes issue #`.

## How Has This Been Tested (if applicable)?

Please describe the tests that you ran to verify your changes.
