### PR TITLE
feat(shuttle-axum) Make AxumService generic to be able to use state

### DIFF
--- a/services/shuttle-axum/src/lib.rs
+++ b/services/shuttle-axum/src/lib.rs
@@ -18,7 +18,7 @@ use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
 /// A wrapper type for [axum::Router] so we can implement [shuttle_runtime::Service] for it.
-pub struct AxumService(pub axum::Router);
+pub struct AxumService<S = ()>(pub axum::Router<S>);
 
 #[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for AxumService {
@@ -34,10 +34,11 @@ impl shuttle_runtime::Service for AxumService {
     }
 }
 
-impl From<axum::Router> for AxumService {
-    fn from(router: axum::Router) -> Self {
+impl<S> From<axum::Router<S>> for AxumService<S> {
+    fn from(router: axum::Router<S>) -> Self {
         Self(router)
     }
 }
+
 /// The return type that should be returned from the [shuttle_runtime::main] function.
 pub type ShuttleAxum = Result<AxumService, Error>;


### PR DESCRIPTION
## Description of change
Made `AxumService` generic to be able to use it with `axum::State` and updated the `From` impl for it. This won't have any impact on existing usages as it defaults to the unit type, e.g.:
```rust
pub struct AxumService<S = ()>(pub axum::Router<S>);
```

I also created an [`axum/with-state` example](https://github.com/morlinbrot/examples/tree/feat/axum-with-state) to test this, let me know if you want this in the examples repo.

## How Has This Been Tested (if applicable)?
Built all the axum examples with it.