### PR TITLE
fix: --name was ignored when not running from cargo folder

### DIFF
--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -269,7 +269,9 @@ impl RequestContext {
     pub fn get_local_config(
         project_args: &ProjectArgs,
     ) -> Result<Config<LocalConfigManager, ProjectConfig>> {
-        let workspace_path = project_args.workspace_path().unwrap_or(project_args.working_directory.clone());
+        let workspace_path = project_args
+            .workspace_path()
+            .unwrap_or(project_args.working_directory.clone());
 
         let local_manager = LocalConfigManager::new(workspace_path, "Shuttle.toml".to_string());
         let mut project = Config::new(local_manager);

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -269,8 +269,12 @@ impl RequestContext {
     pub fn get_local_config(
         project_args: &ProjectArgs,
     ) -> Result<Config<LocalConfigManager, ProjectConfig>> {
-        let local_manager =
-            LocalConfigManager::new(project_args.workspace_path()?, "Shuttle.toml".to_string());
+        let workspace_path = match project_args.workspace_path() {
+            Ok(workspace_path) => workspace_path,
+            Err(_) => project_args.working_directory.clone(),
+        };
+
+        let local_manager = LocalConfigManager::new(workspace_path, "Shuttle.toml".to_string());
         let mut project = Config::new(local_manager);
 
         if !project.exists() {
@@ -300,7 +304,15 @@ impl RequestContext {
             // If name key is not in project config, then we infer from crate name
             (None, None) => {
                 trace!("using crate name as project name");
-                config.name = Some(project_args.project_name()?);
+                let project_name = project_args.project_name().map_err(|_| {
+                    anyhow!(
+                        "No project name found. \
+                        Run the command from inside a cargo folder, \
+                        or a folder containing Shuttle.toml \
+                        or specify project name on the command line with the '--name' option."
+                    )
+                })?;
+                config.name = Some(project_name);
             }
         };
         Ok(project)

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -269,10 +269,7 @@ impl RequestContext {
     pub fn get_local_config(
         project_args: &ProjectArgs,
     ) -> Result<Config<LocalConfigManager, ProjectConfig>> {
-        let workspace_path = match project_args.workspace_path() {
-            Ok(workspace_path) => workspace_path,
-            Err(_) => project_args.working_directory.clone(),
-        };
+        let workspace_path = project_args.workspace_path().unwrap_or(project_args.working_directory.clone());
 
         let local_manager = LocalConfigManager::new(workspace_path, "Shuttle.toml".to_string());
         let mut project = Config::new(local_manager);

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -304,15 +304,7 @@ impl RequestContext {
             // If name key is not in project config, then we infer from crate name
             (None, None) => {
                 trace!("using crate name as project name");
-                let project_name = project_args.project_name().map_err(|_| {
-                    anyhow!(
-                        "No project name found. \
-                        Run the command from inside a cargo folder, \
-                        or a folder containing Shuttle.toml \
-                        or specify project name on the command line with the '--name' option."
-                    )
-                })?;
-                config.name = Some(project_name);
+                config.name = Some(project_args.project_name()?);
             }
         };
         Ok(project)


### PR DESCRIPTION
## Description of change

This PR allows users to run cargo shuttle commands from outside a cargo folder when the `--name` option is provided.


closes issue #927 .

## How Has This Been Tested (if applicable)?

Ran the command `cargo shuttle stop --name helloworld` locally. It no longer throws the "could not find Cargo.toml" error.
