### PR TITLE
fix: log files packed in archive

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -49,7 +49,7 @@ use shuttle_service::builder::{build_workspace, BuiltService};
 use std::fmt::Write;
 use strum::IntoEnumIterator;
 use tar::Builder;
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
 use crate::args::{DeploymentCommand, ProjectCommand, ProjectStartArgs, ResourceCommand};
@@ -1175,7 +1175,7 @@ impl Shuttle {
 
         // Append all the entries to the archive.
         for (k, v) in entries {
-            info!("Packing {k:?}");
+            debug!("Packing {k:?}");
             tar.append_path_with_name(k, v)?;
         }
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -49,7 +49,7 @@ use shuttle_service::builder::{build_workspace, BuiltService};
 use std::fmt::Write;
 use strum::IntoEnumIterator;
 use tar::Builder;
-use tracing::{error, trace, warn};
+use tracing::{error, info, trace, warn};
 use uuid::Uuid;
 
 use crate::args::{DeploymentCommand, ProjectCommand, ProjectStartArgs, ResourceCommand};
@@ -1175,6 +1175,7 @@ impl Shuttle {
 
         // Append all the entries to the archive.
         for (k, v) in entries {
+            info!("Packing {k:?}");
             tar.append_path_with_name(k, v)?;
         }
 


### PR DESCRIPTION
## Description of change
This PR adds info level log for each file added to the archive. Users will be able to see these logs if they set the appropriate level in the RUST_LOG env var. E.g. `RUST_LOG=cargo_shuttle=info`.

closes issue #930 .

## How Has This Been Tested (if applicable)?

Ran the `cargo shuttle deploy` command locally.
