### PR TITLE
fix(gateway): handle certificate expiration as well

### DIFF
--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -642,15 +642,22 @@ impl GatewayService {
             .unwrap_or_else(|_| panic!("Malformed existing PEM certificate for the gateway."));
         let (_, x509_cert) = parse_x509_certificate(pem.contents.as_bytes())
             .unwrap_or_else(|_| panic!("Malformed existing X509 certificate for the gateway."));
-        let diff = x509_cert.validity().not_after.sub(ASN1Time::now()).unwrap();
-        if diff.whole_days() <= RENEWAL_VALIDITY_THRESHOLD_IN_DAYS {
+        let diff = x509_cert.validity().not_after.sub(ASN1Time::now());
+        if diff.is_none()
+            || diff
+                .expect("to be Some given we checked for None previously")
+                .whole_days()
+                <= RENEWAL_VALIDITY_THRESHOLD_IN_DAYS
+        {
             let tls_path = self.state_location.join("ssl.pem");
             let certs = self.create_certificate(acme, account.credentials()).await;
             resolver
                 .serve_default_der(certs.clone())
                 .await
                 .expect("Failed to serve the default certs");
-            certs.save_pem(&tls_path).unwrap();
+            certs
+                .save_pem(&tls_path)
+                .expect("to save the certificate locally");
         }
     }
 


### PR DESCRIPTION
## Description of change

Gateway certificate renewal API checks whether the certificate entered its last 30 days of validity before actually processing the renewal. However, the check doesn't account for an expired certificate and the logic breaks the renewal even if it's the case to renew.

## How Has This Been Tested (if applicable)?

N/A
