### PR TITLE
release(prod): gate against local crates.io patch

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -52,6 +52,7 @@ COPY --from=cache /build/ /usr/src/shuttle/
 FROM shuttle-common
 ARG folder
 ARG prepare_args
+ARG PROD
 COPY ${folder}/prepare.sh /prepare.sh
 RUN /prepare.sh "${prepare_args}"
 ARG CARGO_PROFILE

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ shuttle-%: ${SRC} Cargo.lock
 		--build-arg PROTOC_ARCH=$(PROTOC_ARCH) \
 		--build-arg folder=$(*) \
 		--build-arg prepare_args=$(PREPARE_ARGS) \
+		--build-arg PROD=$(PROD)
 		--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
 		--build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
 		--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -6,29 +6,33 @@
 ###############################################################################
 
 # Patch crates to be on same versions
-mkdir -p $CARGO_HOME; \
-echo '[patch.crates-io]
-shuttle-service = { path = "/usr/src/shuttle/service" }
-shuttle-runtime = { path = "/usr/src/shuttle/runtime" }
+mkdir -p $CARGO_HOME
+if [[ $PROD != "true" ]]; then
+    echo '[patch.crates-io]
+    shuttle-service = { path = "/usr/src/shuttle/service" }
+    shuttle-runtime = { path = "/usr/src/shuttle/runtime" }
 
-shuttle-aws-rds = { path = "/usr/src/shuttle/resources/aws-rds" }
-shuttle-persist = { path = "/usr/src/shuttle/resources/persist" }
-shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" }
-shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }
-shuttle-static-folder = { path = "/usr/src/shuttle/resources/static-folder" }
+    shuttle-aws-rds = { path = "/usr/src/shuttle/resources/aws-rds" }
+    shuttle-persist = { path = "/usr/src/shuttle/resources/persist" }
+    shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" }
+    shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }
+    shuttle-static-folder = { path = "/usr/src/shuttle/resources/static-folder" }
 
-shuttle-axum = { path = "/usr/src/shuttle/services/shuttle-axum" }
-shuttle-actix-web = { path = "/usr/src/shuttle/services/shuttle-actix-web" }
-shuttle-next = { path = "/usr/src/shuttle/services/shuttle-next" }
-shuttle-poem = { path = "/usr/src/shuttle/services/shuttle-poem" }
-shuttle-poise = { path = "/usr/src/shuttle/services/shuttle-poise" }
-shuttle-rocket = { path = "/usr/src/shuttle/services/shuttle-rocket" }
-shuttle-salvo = { path = "/usr/src/shuttle/services/shuttle-salvo" }
-shuttle-serenity = { path = "/usr/src/shuttle/services/shuttle-serenity" }
-shuttle-thruster = { path = "/usr/src/shuttle/services/shuttle-thruster" }
-shuttle-tide = { path = "/usr/src/shuttle/services/shuttle-tide" }
-shuttle-tower = { path = "/usr/src/shuttle/services/shuttle-tower" }
-shuttle-warp = { path = "/usr/src/shuttle/services/shuttle-warp" }' > $CARGO_HOME/config.toml
+    shuttle-axum = { path = "/usr/src/shuttle/services/shuttle-axum" }
+    shuttle-actix-web = { path = "/usr/src/shuttle/services/shuttle-actix-web" }
+    shuttle-next = { path = "/usr/src/shuttle/services/shuttle-next" }
+    shuttle-poem = { path = "/usr/src/shuttle/services/shuttle-poem" }
+    shuttle-poise = { path = "/usr/src/shuttle/services/shuttle-poise" }
+    shuttle-rocket = { path = "/usr/src/shuttle/services/shuttle-rocket" }
+    shuttle-salvo = { path = "/usr/src/shuttle/services/shuttle-salvo" }
+    shuttle-serenity = { path = "/usr/src/shuttle/services/shuttle-serenity" }
+    shuttle-thruster = { path = "/usr/src/shuttle/services/shuttle-thruster" }
+    shuttle-tide = { path = "/usr/src/shuttle/services/shuttle-tide" }
+    shuttle-tower = { path = "/usr/src/shuttle/services/shuttle-tower" }
+    shuttle-warp = { path = "/usr/src/shuttle/services/shuttle-warp" }' > $CARGO_HOME/config.toml
+else
+    touch $CARGO_HOME/config.toml
+fi
 
 # Add the wasm32-wasi target
 rustup target add wasm32-wasi


### PR DESCRIPTION
## Description of change

We'll need to remove the crates.io patches for the local repository when deploying to production. The idea of the change is to forward the `PROD` argument from `make images` command to the `deployer/prepare.sh`. The script will account for patching the `crates.io` or not depending on how the images are built. When building the production images in `.circleci`  we set the `PROD` argument to `true` when building `make images`.

## How Has This Been Tested (if applicable)?

Tested the bash `if .. else` branch on my zsh terminal and works well.
