### PR TITLE
refactor: sanitize all path on the user's proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5360,6 +5360,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http 0.4.0",
+ "tower-sanitize-path",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -6366,6 +6367,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
+name = "tower-sanitize-path"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4accf4be86b13057d30cd97f606c707b6ec8df01c2e91ee735f89de8216f21"
+dependencies = [
+ "http",
+ "tower-layer",
+ "tower-service",
+ "url-escape",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6674,6 +6687,15 @@ checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
+ "percent-encoding",
+]
+
+[[package]]
+name = "url-escape"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e0ce4d1246d075ca5abec4b41d33e87a6054d08e2366b63205665e950db218"
+dependencies = [
  "percent-encoding",
 ]
 

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -50,6 +50,7 @@ utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 x509-parser = "0.14.0"
+tower-sanitize-path = "0.1.2"
 
 [dependencies.shuttle-common]
 workspace = true

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -25,6 +25,7 @@ use opentelemetry_http::HeaderInjector;
 use shuttle_common::backends::headers::XShuttleProject;
 use tokio::sync::mpsc::Sender;
 use tower::{Service, ServiceBuilder};
+use tower_sanitize_path::SanitizePath;
 use tracing::{debug_span, error, field, trace};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -80,6 +81,18 @@ impl<'r> AsResponderTo<&'r AddrStream> for UserProxy {
     fn as_responder_to(&self, addr_stream: &'r AddrStream) -> Self {
         let mut responder = self.clone();
         responder.remote_addr = addr_stream.remote_addr();
+        responder
+    }
+}
+
+impl<S, R> AsResponderTo<R> for SanitizePath<S>
+where
+    S: AsResponderTo<R> + Clone,
+{
+    fn as_responder_to(&self, req: R) -> Self {
+        let responder = self.clone();
+        responder.inner().as_responder_to(req);
+
         responder
     }
 }
@@ -300,12 +313,13 @@ impl UserServiceBuilder {
             .user_binds_to
             .expect("a socket address to bind to is required");
 
-        let user_proxy = UserProxy {
+        let user_proxy = SanitizePath::sanitize_paths(UserProxy {
             gateway: service.clone(),
             task_sender,
             remote_addr: "127.0.0.1:80".parse().unwrap(),
             public: public.clone(),
-        };
+        })
+        .into_make_service();
 
         let bouncer = self.bouncer_binds_to.as_ref().map(|_| Bouncer {
             gateway: service.clone(),
@@ -335,7 +349,7 @@ impl UserServiceBuilder {
 
             let user_with_tls = axum_server::Server::bind(user_binds_to)
                 .acceptor(tls_acceptor)
-                .serve(user_proxy.into_make_service())
+                .serve(user_proxy)
                 .map(|handle| ("user proxy (with TLS)", handle))
                 .boxed();
             futs.push(user_with_tls);
@@ -351,7 +365,7 @@ impl UserServiceBuilder {
             }
 
             let user_without_tls = axum_server::Server::bind(user_binds_to)
-                .serve(user_proxy.into_make_service())
+                .serve(user_proxy)
                 .map(|handle| ("user proxy (no TLS)", handle))
                 .boxed();
             futs.push(user_without_tls);


### PR DESCRIPTION
## Description of change
If users don't properly handle input paths then they can open themselves up to path traversal vulnerabilities. We can protect all our users by taking care of this at our proxy layer.

## How Has This Been Tested (if applicable)?
Using the local dev environment to ensure path traversals are removed from all proxy requests.
