### PR TITLE
Add helpful error message on docker container error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ checksum = "e11c675378efb449ed3ce8de78d75d0d80542fc98487c26aba28eb3b82feac72"
 dependencies = [
  "semver 1.0.18",
  "serde",
- "toml 0.7.6",
+ "toml 0.7.8",
  "url",
 ]
 
@@ -5458,7 +5458,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.5.11",
+ "toml 0.7.8",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -8125,3 +8125,75 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "shuttle-actix-web"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-aws-rds"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-axum"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-next"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-persist"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-poem"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-poise"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-rocket"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-salvo"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-secrets"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-serenity"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-shared-db"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-static-folder"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-thruster"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-tide"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-tower"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-turso"
+version = "0.26.0"
+
+[[patch.unused]]
+name = "shuttle-warp"
+version = "0.26.0"

--- a/cargo-shuttle/src/provisioner_server.rs
+++ b/cargo-shuttle/src/provisioner_server.rs
@@ -116,9 +116,10 @@ impl LocalProvisioner {
                     .expect("container to be created")
             }
             Err(error) => {
+                error!("Got unexpected error while inspecting docker container: {error}.");
                 error!(
-                    "got unexpected error while inspecting docker container: {error}. If you're \
-                    using Podman, view these instructions: \
+                    "Make sure Docker is installed and running. \
+                    If you're using Podman, view these instructions: \
                     https://docs.rs/shuttle-runtime/latest/shuttle_runtime/#using-podman-instead-of-docker"
                 );
                 return Err(Status::internal(error.to_string()));

--- a/cargo-shuttle/src/provisioner_server.rs
+++ b/cargo-shuttle/src/provisioner_server.rs
@@ -116,7 +116,11 @@ impl LocalProvisioner {
                     .expect("container to be created")
             }
             Err(error) => {
-                error!("got unexpected error while inspecting docker container: {error}");
+                error!(
+                    "got unexpected error while inspecting docker container: {error}. If you're \
+                    using Podman, view these instructions: \
+                    https://docs.rs/shuttle-runtime/latest/shuttle_runtime/#using-podman-instead-of-docker"
+                );
                 return Err(Status::internal(error.to_string()));
             }
         };


### PR DESCRIPTION
## Description of change

I was fiddling with shuttle and got this error message: 

```
2023-05-28T14:00:28.144975Z ERROR cargo_shuttle::provisioner_server: got unexpected error while inspecting docker container: error trying to connect: No such file or directory (os error 2)
2023-05-28T14:00:28.146904Z ERROR cargo_shuttle: failed to load your service error="Custom error: failed to provision shuttle_aws_rds :: Postgres"
```

Which isn't super helpful. But after googling, I managed to see that it's explained in the docs. This commit just links the docs so that future travelers will know where to go to look for help.