### PR TITLE
fix: Ignore span logs below WARN

### DIFF
--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -112,18 +112,17 @@ mod tests {
 
         let _guard = tracing_subscriber::registry().with(logger).set_default();
 
-        let span = tracing::debug_span!("this is a span");
+        let span = tracing::warn_span!("this is a warn span");
         span.in_scope(|| {
             tracing::debug!("this is");
             tracing::info!("hi");
+        });
+        let span = tracing::info_span!("this is an info span");
+        span.in_scope(|| {
             tracing::warn!("from");
             tracing::error!("logger");
         });
 
-        assert_eq!(
-            r.blocking_recv().map(to_tuple),
-            Some(("[span] this is a span".to_string(), LogLevel::Debug as i32))
-        );
         assert_eq!(
             r.blocking_recv().map(to_tuple),
             Some(("this is".to_string(), LogLevel::Debug as i32))
@@ -131,6 +130,10 @@ mod tests {
         assert_eq!(
             r.blocking_recv().map(to_tuple),
             Some(("hi".to_string(), LogLevel::Info as i32))
+        );
+        assert_eq!(
+            r.blocking_recv().map(to_tuple),
+            Some(("[span] this is an info span".to_string(), LogLevel::Debug as i32))
         );
         assert_eq!(
             r.blocking_recv().map(to_tuple),

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -45,8 +45,16 @@ where
                 format!("[span] {}", metadata.name()).into(),
             );
 
+            let level = LogLevel::from(metadata.level()) as i32;
+
+            // Ignore span logs from the default level for #[instrument] (INFO) and below.
+            // TODO: make this configurable
+            if level < LogLevel::Warn as i32 {
+                return;
+            }
+
             LogItem {
-                level: LogLevel::from(metadata.level()) as i32,
+                level,
                 timestamp: Some(Timestamp::from(SystemTime::from(datetime))),
                 file: visitor.file.or_else(|| metadata.file().map(str::to_string)),
                 line: visitor.line.or_else(|| metadata.line()),

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -7,7 +7,7 @@ use shuttle_proto::runtime::{LogItem, LogLevel};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{
     span::{Attributes, Id},
-    Subscriber,
+    Subscriber, Level,
 };
 use tracing_subscriber::Layer;
 
@@ -35,12 +35,11 @@ where
 
         let item = {
             let metadata = attrs.metadata();
-
-            let level = LogLevel::from(metadata.level()) as i32;
+            let level = metadata.level();
 
             // Ignore span logs from the default level for #[instrument] (INFO) and below.
             // TODO: make this configurable
-            if level < LogLevel::Warn as i32 {
+            if level < &Level::WARN {
                 return;
             }
 
@@ -54,7 +53,7 @@ where
             );
 
             LogItem {
-                level,
+                level: LogLevel::from(level) as i32,
                 timestamp: Some(Timestamp::from(SystemTime::from(datetime))),
                 file: visitor.file.or_else(|| metadata.file().map(str::to_string)),
                 line: visitor.line.or_else(|| metadata.line()),

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -133,7 +133,10 @@ mod tests {
         );
         assert_eq!(
             r.blocking_recv().map(to_tuple),
-            Some(("[span] this is an info span".to_string(), LogLevel::Debug as i32))
+            Some((
+                "[span] this is an info span".to_string(),
+                LogLevel::Debug as i32
+            ))
         );
         assert_eq!(
             r.blocking_recv().map(to_tuple),

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -37,9 +37,9 @@ where
             let metadata = attrs.metadata();
             let level = metadata.level();
 
-            // Ignore span logs from the default level for #[instrument] (INFO) and below.
+            // Ignore span logs from the default level for #[instrument] (INFO) and below (greater than).
             // TODO: make this configurable
-            if level < &Level::WARN {
+            if level >= &Level::INFO {
                 return;
             }
 

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -7,7 +7,7 @@ use shuttle_proto::runtime::{LogItem, LogLevel};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{
     span::{Attributes, Id},
-    Subscriber, Level,
+    Level, Subscriber,
 };
 use tracing_subscriber::Layer;
 


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Closes #955

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested on my serenity bot (0.12) and hello world example (0.11) - no more spam, back to normal amount of logs as before
Tide hello world gives the same amount of logs before and after