### PR TITLE
fix: crossterm/comfytable conflict

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,6 @@ jobs:
     steps:
       - checkout
       - restore-cargo-cache
-      - install-protoc
       - apply-patches
       - run: cargo fmt --all --check --manifest-path << parameters.path >>/Cargo.toml
       # TODO: this is incompatible with workspace inheritance, uncomment when
@@ -440,8 +439,6 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: "sparse"
     steps:
       - checkout
-      - install-protoc:
-          arch: osx-x86_64
       - run:
           name: Install Rust
           command: curl --proto '=https' https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.68.0 --target x86_64-apple-darwin
@@ -591,7 +588,6 @@ jobs:
     resource_class: medium
     steps:
       - checkout
-      - install-protoc
       - run:
           name: Crate publishing in order
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.4"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
+checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
 dependencies = [
  "crossterm",
  "strum",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
  "bitflags",
  "crossterm_winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ cargo_metadata = "0.15.3"
 chrono = { version = "0.4.23", default-features = false }
 clap = { version = "4.0.27", features = ["derive"] }
 crossbeam-channel = "0.5.7"
-crossterm = "0.25.0"
+crossterm = "0.26.0"
 ctor = "0.1.26"
 dirs = "5.0.0"
 flate2 = "1.0.25"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 chrono = { workspace = true }
-comfy-table = { version = "6.1.3", optional = true }
+comfy-table = { version = "6.2.0", optional = true }
 crossterm = { workspace = true, optional = true }
 headers = { workspace = true, optional = true }
 http = { workspace = true, optional = true }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

`comfy-table` exposes crossterm types publicly, and crossterm had a breaking change in 0.26, so when comfy-table updated their crossterm version in a patch release it broke the install of `cargo-shuttle`, since comfy-table was automatically updated (unless --locked is passed to install) but crossterm was not.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->
Verified that upgrading comfy-table before upgrading crossterm causes compile-error in shuttle-common, and upgrading both fixes it.

