### PR TITLE
feat: pre-installed build environment in deployer

### DIFF
--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -68,5 +68,6 @@ done
 # cargo fetch
 
 # Install common build tools for external crates
+# The image should already have these: https://github.com/docker-library/buildpack-deps/blob/65d69325ad741cea6dee20781c1faaab2e003d87/debian/buster/Dockerfile
 apt update
-apt install -y llvm-dev libclang-dev gcc clang cmake make automake autoconf libtool
+apt install -y llvm-dev libclang-dev clang cmake

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -66,3 +66,7 @@ done
 # TODO: restore when we know how to prefetch from our mirror
 # cd /usr/src/shuttle/service
 # cargo fetch
+
+# Install common build tools for external crates
+apt update
+apt install -y llvm-dev libclang-dev gcc clang cmake make automake autoconf libtool


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Closes #807.

Added some common (C) build tools when installing deployer.
This allows crates such as `audiopus` to build.

If there are more tools needed, they can be suggested or added in subsequent PRs.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Deployed a crate with `audiopus v0.2.0` locally. https://crates.io/crates/audiopus/
