### PR TITLE
fix/release(prod): unstable AWS creds clashed with prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   docker-buildx: sensu/docker-buildx@1.1.1
-  aws-ecr: circleci/aws-ecr@8.1.2
+  aws-ecr: circleci/aws-ecr@8.2.1
   win: circleci/windows@5.0
 
 executors:
@@ -316,6 +316,9 @@ jobs:
           aws-access-key-id: << parameters.aws-access-key-id >>
           aws-secret-access-key: << parameters.aws-secret-access-key >>
           public-registry: << parameters.public-registry >>
+          # `registry-id`` field is required, although we don't need it (used for private registry).
+          # We give it a non-empty env variable name to bypass the `ecr-login` empty check.
+          registry-id: TAG
       - run:
           name: Make and push images
           command: |
@@ -338,17 +341,17 @@ jobs:
         default: shuttle.internal
       postgres-password:
         description: "Shuttle shared postgres password"
-        type: string
+        type: env_var_name
       mongodb-password:
         description: "Shuttle shared mongodb password"
-        type: string
+        type: env_var_name
       production:
         description: "Push and deploy to production"
         type: boolean
         default: false
     steps:
     - checkout
-    - run: 
+    - run:
         name: Set git tag in bash_env
         command: |
           echo TAG=$(git describe --tags --abbrev=0) >> $BASH_ENV
@@ -362,15 +365,25 @@ jobs:
         name: Deploy images
         command: |
           DOCKER_HOST=ssh://ec2-user@master.<< parameters.ssh-host >> USE_TLS=enable PROD=<< parameters.production >> DD_API_KEY=$DD_API_KEY \
-          POSTGRES_PASSWORD=<< parameters.postgres-password >> \
-          MONGO_INITDB_ROOT_PASSWORD=<< parameters.mongodb-password >> \
+          POSTGRES_PASSWORD=${<< parameters.postgres-password >>} \
+          MONGO_INITDB_ROOT_PASSWORD=${<< parameters.mongodb-password >>} \
           TAG=$TAG \
           make deploy
-    - run:
-        name: Pull new deployer image
-        command: |
-          [[ << parameters.production >> == true ]] && ssh ec2-user@controller.<< parameters.ssh-host >> "docker pull public.ecr.aws/shuttle-prod/deployer:$TAG" || \
-          ssh ec2-user@controller.<< parameters.ssh-host >> "docker pull public.ecr.aws/shuttle-dev/deployer:$TAG"
+    - when:
+        condition: << parameters.production >>
+        steps:
+          - run:
+              name: Pull new deployer image on prod
+              command: |
+                ssh ec2-user@controller.<< parameters.ssh-host >> "docker pull public.ecr.aws/shuttle/deployer:$TAG"
+    - when:
+        condition:
+          not: << parameters.production >>
+        steps:
+          - run:
+              name: Pull new deployer image on dev
+              command: |
+                ssh ec2-user@controller.<< parameters.ssh-host >> "docker pull public.ecr.aws/shuttle-dev/deployer:$TAG"
   build-binaries-linux:
     machine:
       image: << parameters.image >>
@@ -592,7 +605,6 @@ jobs:
           name: Crate publishing in order
           command: |
             cargo publish --manifest-path << parameters.path >>/Cargo.toml
-
 workflows:
   ci:
     jobs:
@@ -663,8 +675,8 @@ workflows:
               only: main
       - build-and-push:
           name: build-and-push-unstable
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          aws-access-key-id: DEV_AWS_ACCESS_KEY_ID
+          aws-secret-access-key: DEV_AWS_SECRET_ACCESS_KEY
           production: false
           requires:
             - approve-push-unstable


### PR DESCRIPTION
## Description of change

Our dev AWS creds were set for the `.circleci` machine when deploying Shuttle to prod because the environment variables names are the standard AWS environment variables names for credentials and are picked up by `aws-ecr/ecr-login` step, which conflicts with how we set the ecr-login in our `.circleci/config.yaml` file. At the same time, the PROD variables' names used in the `.circleci/config.yaml` had a typo 🙈  (which might have been the main reason why the ecr-login failed, besides the standard env variable names issue). To fix everything this PR changed the dev environment variables' names to non-standard names, so as to not be picked up by the `aws-ecr/ecr-login` step and double-checked the env vars used in the `.circleci/config.yaml` to be the ones from the circleci project settings.

## How has this been tested? (if applicable)

Tested the AWS creds on this PR, checking if we can list the prod/dev public ECR repos. Tested the creation of a postgres project on `unstable` as well.


