### PR TITLE
Attempt at fixing sporadic failures of `shuttle-deployer`

### DIFF
--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -324,7 +324,7 @@ mod tests {
         DatabaseDeletionResponse, DatabaseRequest, DatabaseResponse,
     };
     use tempfile::Builder;
-    use tokio::{select, time::sleep};
+    use tokio::{select, task::JoinSet, time::sleep};
     use tonic::transport::Server;
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
     use uuid::Uuid;
@@ -585,7 +585,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_to_be_queued() {
-        let deployment_manager = get_deployment_manager().await;
+        let (_set, deployment_manager) = get_deployment_manager();
 
         let queued = get_queue("sleep-async");
         let id = queued.id;
@@ -665,7 +665,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_self_stop() {
-        let deployment_manager = get_deployment_manager().await;
+        let (_set, deployment_manager) = get_deployment_manager();
 
         let queued = get_queue("self-stop");
         let id = queued.id;
@@ -712,7 +712,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_bind_panic() {
-        let deployment_manager = get_deployment_manager().await;
+        let (_set, deployment_manager) = get_deployment_manager();
 
         let queued = get_queue("bind-panic");
         let id = queued.id;
@@ -759,7 +759,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_main_panic() {
-        let deployment_manager = get_deployment_manager().await;
+        let (_set, deployment_manager) = get_deployment_manager();
 
         let queued = get_queue("main-panic");
         let id = queued.id;
@@ -802,7 +802,7 @@ mod tests {
 
     #[tokio::test]
     async fn deployment_from_run() {
-        let deployment_manager = get_deployment_manager().await;
+        let (_set, deployment_manager) = get_deployment_manager();
 
         let id = Uuid::new_v4();
         deployment_manager
@@ -845,7 +845,7 @@ mod tests {
 
     #[tokio::test]
     async fn scope_with_nil_id() {
-        let deployment_manager = get_deployment_manager().await;
+        let (_set, deployment_manager) = get_deployment_manager();
 
         let id = Uuid::nil();
         deployment_manager
@@ -872,7 +872,7 @@ mod tests {
         );
     }
 
-    async fn get_deployment_manager() -> DeploymentManager {
+    fn get_deployment_manager() -> (JoinSet<()>, DeploymentManager) {
         DeploymentManager::builder()
             .build_log_recorder(RECORDER.clone())
             .secret_recorder(RECORDER.clone())

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -574,9 +574,14 @@ mod tests {
     async fn test_states(id: &Uuid, expected_states: Vec<StateLog>) {
         loop {
             let states = RECORDER.lock().unwrap().get_deployment_states(id);
+            if states == expected_states {
+                return;
+            }
 
-            if *states == expected_states {
-                break;
+            for (actual, expected) in states.iter().zip(&expected_states) {
+                if actual != expected {
+                    return;
+                }
             }
 
             sleep(Duration::from_millis(250)).await;

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -324,7 +324,7 @@ mod tests {
         DatabaseDeletionResponse, DatabaseRequest, DatabaseResponse,
     };
     use tempfile::Builder;
-    use tokio::{select, task::JoinSet, time::sleep};
+    use tokio::{select, time::sleep};
     use tonic::transport::Server;
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};
     use uuid::Uuid;
@@ -590,7 +590,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_to_be_queued() {
-        let (_set, deployment_manager) = get_deployment_manager();
+        let deployment_manager = get_deployment_manager();
 
         let queued = get_queue("sleep-async");
         let id = queued.id;
@@ -674,7 +674,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_self_stop() {
-        let (_set, deployment_manager) = get_deployment_manager();
+        let deployment_manager = get_deployment_manager();
 
         let queued = get_queue("self-stop");
         let id = queued.id;
@@ -721,7 +721,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_bind_panic() {
-        let (_set, deployment_manager) = get_deployment_manager();
+        let deployment_manager = get_deployment_manager();
 
         let queued = get_queue("bind-panic");
         let id = queued.id;
@@ -768,7 +768,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_main_panic() {
-        let (_set, deployment_manager) = get_deployment_manager();
+        let deployment_manager = get_deployment_manager();
 
         let queued = get_queue("main-panic");
         let id = queued.id;
@@ -811,7 +811,7 @@ mod tests {
 
     #[tokio::test]
     async fn deployment_from_run() {
-        let (_set, deployment_manager) = get_deployment_manager();
+        let deployment_manager = get_deployment_manager();
 
         let id = Uuid::new_v4();
         deployment_manager
@@ -854,7 +854,7 @@ mod tests {
 
     #[tokio::test]
     async fn scope_with_nil_id() {
-        let (_set, deployment_manager) = get_deployment_manager();
+        let deployment_manager = get_deployment_manager();
 
         let id = Uuid::nil();
         deployment_manager
@@ -881,7 +881,7 @@ mod tests {
         );
     }
 
-    fn get_deployment_manager() -> (JoinSet<()>, DeploymentManager) {
+    fn get_deployment_manager() -> DeploymentManager {
         DeploymentManager::builder()
             .build_log_recorder(RECORDER.clone())
             .secret_recorder(RECORDER.clone())

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -106,7 +106,7 @@ where
     /// executing/deploying built services. Two multi-producer, single consumer
     /// channels are also created which are for moving on-going service
     /// deployments between the aforementioned tasks.
-    pub fn build(self) -> (JoinSet<()>, DeploymentManager) {
+    pub fn build(self) -> DeploymentManager {
         let build_log_recorder = self
             .build_log_recorder
             .expect("a build log recorder to be set");
@@ -149,15 +149,13 @@ where
             storage_manager.clone(),
         ));
 
-        (
-            set,
-            DeploymentManager {
-                queue_send,
-                run_send,
-                runtime_manager,
-                storage_manager,
-            },
-        )
+        DeploymentManager {
+            queue_send,
+            run_send,
+            runtime_manager,
+            storage_manager,
+            _join_set: Arc::new(Mutex::new(set)),
+        }
     }
 }
 
@@ -167,6 +165,7 @@ pub struct DeploymentManager {
     run_send: RunSender,
     runtime_manager: Arc<Mutex<RuntimeManager>>,
     storage_manager: ArtifactsStorageManager,
+    _join_set: Arc<Mutex<JoinSet<()>>>,
 }
 
 /// ```no-test

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -29,7 +29,8 @@ pub async fn start(
     runtime_manager: Arc<Mutex<RuntimeManager>>,
     args: Args,
 ) {
-    let deployment_manager = DeploymentManager::builder()
+    // when _set is dropped once axum exits, the deployment tasks will be aborted.
+    let (_set, deployment_manager) = DeploymentManager::builder()
         .build_log_recorder(persistence.clone())
         .secret_recorder(persistence.clone())
         .active_deployment_getter(persistence.clone())

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn start(
     args: Args,
 ) {
     // when _set is dropped once axum exits, the deployment tasks will be aborted.
-    let (_set, deployment_manager) = DeploymentManager::builder()
+    let deployment_manager = DeploymentManager::builder()
         .build_log_recorder(persistence.clone())
         .secret_recorder(persistence.clone())
         .active_deployment_getter(persistence.clone())


### PR DESCRIPTION
## Description of change

The `shuttle-deployer` tests are sometimes failing when unrelated changes are made. This can be seen both during CI as well as when working locally (we faced that when working on the pagination).

It's quite hard to reproduce, but if we look at CircleCI errors (https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/3134/workflows/c461d70f-616c-416a-a1e5-148ca2afa854/jobs/59077, https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/3134/workflows/bd9ea5b5-c6bf-4262-bc58-2d82ce416341/jobs/59040, https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/3109/workflows/aeefba11-ae65-48b7-b522-30b7931e32a9/jobs/58417, among others), we often get this error:

```
2023-06-05T08:35:40.737556Z ERROR builder:build_failed{error=InputOutput(Custom { kind: Other, error: "background task failed" }) id=572c7682-bc23-48c9-b4a8-97850da7938e state=Crashed}: shuttle_deployer::deployment::queue: service build encountered an error error=Internal I/O error: background task failed error.sources=[background task failed]
```

And right before it, this line:

```
2023-06-05T08:35:40.736962Z  INFO builder:handle{id=572c7682-bc23-48c9-b4a8-97850da7938e state=Building}: shuttle_deployer::deployment::queue: Moving built executable
```

In particular, right after the log line above in the code, we have a call to `store_executable`, with a call to `tokio::fs::rename` inside. This in combination with the error message (`background task failed`) led me to [this issue](https://github.com/tokio-rs/tokio/issues/2247). One comment mentions the following:

> I eventually figured out this was a case of not keeping the top-level task waiting on the spawned tasks, resulting in the runtime shutting down and those tasks failing midway through (with the above error).

In the deployer, and more precisely in this code path, this is done twice:
- Once when we spawn `Queued::handle` (first commit) in `queue::task`, where we pull deployments to build and run.
- Once when we spawn `queue::task`, which is done when building a `DeploymentManager`. 

An other kind of bug happens in the test suite:

```
thread 'thread 'deployment::deploy_layer::tests::deployment_bind_panicdeployment::deploy_layer::tests::deployment_main_panic' panicked at '' panicked at 'states should go into 'Crashed' panicking in bind: [
    StateLog {
        id: 9e2ab92a-34d4-4439-835b-c911aab1e5ba,
        state: Queued,
    },
    StateLog {
        id: 9e2ab92a-34d4-4439-835b-c911aab1e5ba,
        state: Building,
    },
    StateLog {
        id: 9e2ab92a-34d4-4439-835b-c911aab1e5ba,
        state: Built,
    },
    StateLog {
        id: 9e2ab92a-34d4-4439-835b-c911aab1e5ba,
        state: Loading,
    },
]states should go into 'Crashed' when panicking in main: [
    StateLog {
        id: 7c030971-9f73-4ea2-9a4f-2f8c44194c2d,
        state: Queued,
    },
    StateLog {
        id: 7c030971-9f73-4ea2-9a4f-2f8c44194c2d,
        state: Building,
    },
    StateLog {
        id: 7c030971-9f73-4ea2-9a4f-2f8c44194c2d,
        state: Built,
    },
    StateLog {
        id: 7c030971-9f73-4ea2-9a4f-2f8c44194c2d,
        state: Loading,
    },
]', ', thread 'deployment::deploy_layer::tests::deployment_to_be_queueddeployer/src/deployment/deploy_layer.rs' panicked at ':states should go into 'Running' for a valid service: [
    StateLog {
        id: eca96eb6-c63d-42d3-a18e-c584f2b4309c,
        state: Queued,
    },
    StateLog {
        id: eca96eb6-c63d-42d3-a18e-c584f2b4309c,
        state: Building,
    },
    StateLog {
        id: eca96eb6-c63d-42d3-a18e-c584f2b4309c,
        state: Built,
    },
    StateLog {
        id: eca96eb6-c63d-42d3-a18e-c584f2b4309c,
        state: Loading,
    },
]deployer/src/deployment/deploy_layer.rs', deployer/src/deployment/deploy_layer.rs:754:797::1717
```

Sometimes it was just a timeout where the deployment seems to have stalled, sometimes it actually results in a crash (`state: Crashed`) instead. This was particularly painful when debugging since it would hang for several minutes, even though it was sometime clear that the states had diverged. I've added a fix for it to return early when we can.

I also got this kind of error:

```
thread 'tokio-runtime-worker' panicked at 'message from tonic stream: Status { code: Unknown, message: "error reading a body from connection: stream closed because of a broken pipe", source: Some(hyper::Error(Body, Error { kind: Io(Custom { kind: BrokenPipe, error: "stream closed because of a broken pipe" }) })) }', deployer/src/deployment/run.rs:386:49
```

I assume that similarly to the first issue, we're not properly waiting on the returned `JoinHandle`, causing the stream to be closed while a task is still running. This time it happened in the `run.rs` file of the deployer. This fixed both the error with `tonic stream` and the states of the deployment that either hang or crashed.


## How has this been tested? (if applicable)

I managed to sometime (but not often) reproduce the errors locally, which I can't seem to be able to do now with these changes. I ran the following command, which before my fixes exhibited some of the issues in a few iteration:
```
export RUST_BACKTRACE=full
for i in {0..20}; do
rm -rf deployer/**/target; rm -rf /run/user/1000/shuttle_run_test*;
if ! cargo test -p shuttle-deployer -- --nocapture; then
        break
fi
sleep 5
done
```

Now I want to try with CircleCI :)


