### PR TITLE
Add commands cookbook to cargo-shuttle --help

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -87,21 +87,8 @@ impl ProjectArgs {
 
 /// A cargo command for the shuttle platform (https://www.shuttle.rs/)
 ///
-/// # Commonly used commands:
-///
-/// cargo shuttle run                   Run the project locally so you can test your changes.
-///
-/// cargo shuttle project start         Initialize an environment for this project on shuttle.
-///
-/// cargo shuttle deploy                Deploy the current state of the project to the public internet though shuttle.
-///
-/// cargo shuttle deploy --allow-dirty  Deploy the project to shuttle (including files not committed to git).
-///
-/// cargo shuttle deployment            Either list existing deployments or get the status of a particular deployment.
-///
-/// cargo shuttle logs --follow         Fetch the logs of the deployed service and stream them to your terminal.
-///
-/// See the [docs](https://docs.shuttle.rs) for more information.
+/// See the CLI docs (https://docs.shuttle.rs/introduction/shuttle-commands)
+/// for more information.
 #[derive(Parser)]
 pub enum Command {
     /// Create a new shuttle project

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -85,6 +85,23 @@ impl ProjectArgs {
     }
 }
 
+/// A cargo command for the shuttle platform (https://www.shuttle.rs/)
+///
+/// # Commonly used commands:
+///
+/// cargo shuttle run                   Run the project locally so you can test your changes.
+///
+/// cargo shuttle project start         Initialize an environment for this project on shuttle.
+///
+/// cargo shuttle deploy                Deploy the current state of the project to the public internet though shuttle.
+///
+/// cargo shuttle deploy --allow-dirty  Deploy the project to shuttle (including files not committed to git).
+///
+/// cargo shuttle deployment            Either list existing deployments or get the status of a particular deployment.
+///
+/// cargo shuttle logs --follow         Fetch the logs of the deployed service and stream them to your terminal.
+///
+/// See the [docs](https://docs.shuttle.rs) for more information.
 #[derive(Parser)]
 pub enum Command {
     /// Create a new shuttle project

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -20,7 +20,6 @@ use crate::init::Template;
 #[derive(Parser)]
 #[command(
     version,
-    about,
     // Cargo passes in the subcommand name to the invoked executable. Use a
     // hidden, optional positional argument to deal with it.
     arg(clap::Arg::new("dummy")


### PR DESCRIPTION
This commit adds a couple of example `cookbook` style commands to the `--help` subcommand of `cargo-shuttle`. 


## Description of change
It took some time for me to realise the difference between `deploy` and `deployments`, or to discover that I could watch my logs in real time via `logs --follow`. My hope is that this extended help assists newcomers in figuring out what cargo-shuttle can do.

As a side note, I understand that this adds a bit of bloat to the help command, and maybe this sort of information is better off somewhere in the docs or in the descriptions for each of the subcommands, so feel free to close this PR if it does not fit in with the overall goals of where information should be.