### PR TITLE
feat: add new deployment metadata to table

### DIFF
--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -23,6 +23,10 @@ pub struct Response {
     pub state: State,
     #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::DateTime))]
     pub last_update: DateTime<Utc>,
+    pub git_commit_id: Option<String>,
+    pub git_commit_msg: Option<String>,
+    pub git_branch: Option<String>,
+    pub git_dirty: Option<bool>,
 }
 
 impl Display for Response {
@@ -84,9 +88,33 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, pa
                 Cell::new("Last updated")
                     .set_alignment(CellAlignment::Center)
                     .add_attribute(Attribute::Bold),
+                Cell::new("Commit ID")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
+                Cell::new("Commit Message")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
+                Cell::new("Branch")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
+                Cell::new("Dirty")
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold),
             ]);
 
         for deploy in deployments.iter() {
+            let truncated_commit_id = deploy
+                .git_commit_id
+                .as_ref()
+                .map_or(String::from("No Data"), |val| val.chars().take(7).collect());
+
+            let truncated_commit_msg = deploy
+                .git_commit_msg
+                .as_ref()
+                .map_or(String::from("No Data"), |val| {
+                    val.chars().take(24).collect::<String>()
+                });
+
             table.add_row(vec![
                 Cell::new(deploy.id),
                 Cell::new(&deploy.state)
@@ -95,6 +123,20 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, pa
                     .set_alignment(CellAlignment::Center),
                 Cell::new(deploy.last_update.format("%Y-%m-%dT%H:%M:%SZ"))
                     .set_alignment(CellAlignment::Center),
+                Cell::new(truncated_commit_id),
+                Cell::new(truncated_commit_msg),
+                Cell::new(
+                    deploy
+                        .git_branch
+                        .as_ref()
+                        .map_or("No Data", |val| val as &str),
+                ),
+                Cell::new(
+                    deploy
+                        .git_dirty
+                        .map_or(String::from("No Data"), |val| val.to_string()),
+                )
+                .set_alignment(CellAlignment::Center),
             ]);
         }
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -106,12 +106,14 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, pa
             let truncated_commit_id = deploy
                 .git_commit_id
                 .as_ref()
-                .map_or(String::from("No Data"), |val| val.chars().take(7).collect());
+                .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
+                    val.chars().take(7).collect()
+                });
 
             let truncated_commit_msg = deploy
                 .git_commit_msg
                 .as_ref()
-                .map_or(String::from("No Data"), |val| {
+                .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
                     val.chars().take(24).collect::<String>()
                 });
 
@@ -129,12 +131,12 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, pa
                     deploy
                         .git_branch
                         .as_ref()
-                        .map_or("No Data", |val| val as &str),
+                        .map_or(GIT_OPTION_NONE_TEXT, |val| val as &str),
                 ),
                 Cell::new(
                     deploy
                         .git_dirty
-                        .map_or(String::from("No Data"), |val| val.to_string()),
+                        .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| val.to_string()),
                 )
                 .set_alignment(CellAlignment::Center),
             ]);
@@ -168,3 +170,4 @@ pub struct DeploymentRequest {
 }
 
 pub const GIT_STRINGS_MAX_LENGTH: usize = 80;
+const GIT_OPTION_NONE_TEXT: &str = "N/A";

--- a/deployer/src/persistence/deployment.rs
+++ b/deployer/src/persistence/deployment.rs
@@ -60,6 +60,10 @@ impl From<Deployment> for shuttle_common::models::deployment::Response {
             service_id: deployment.service_id,
             state: deployment.state.into(),
             last_update: deployment.last_update,
+            git_commit_id: deployment.git_commit_id,
+            git_commit_msg: deployment.git_commit_msg,
+            git_branch: deployment.git_branch,
+            git_dirty: deployment.git_dirty,
         }
     }
 }


### PR DESCRIPTION
## Description of change
I added the new `git_*` fields to the table output of `cargo shuttle deployment list`. 

Closes #981 

## How has this been tested? (if applicable)
I created a new project via the rocket example and made local changes to check that the `git_dirty` field rendered correctly, and that truncating the commit ID and message worked as intended. I also created some deployments with a version prior to the addition of the new metadata to make sure the `Option` values correctly displayed `No Data` in the table.


