### PR TITLE
feat(resources): add support for turso client w/o provisioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,6 +606,7 @@ workflows:
                 - resources/persist
                 - resources/secrets
                 - resources/static-folder
+                - resources/turso
                 - services/shuttle-actix-web
                 - services/shuttle-axum
                 - services/shuttle-next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ commands:
             shuttle-shared-db = { path = "$PWD/resources/shared-db" }
             shuttle-secrets = { path = "$PWD/resources/secrets" }
             shuttle-static-folder = { path = "$PWD/resources/static-folder" }
+            shuttle-turso = { path = "$PWD/resources/turso" }
 
             shuttle-axum = { path = "$PWD/services/shuttle-axum" }
             shuttle-actix-web = { path = "$PWD/services/shuttle-actix-web" }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,7 @@ shuttle-persist = { path = "[base]/shuttle/resources/persist" }
 shuttle-shared-db = { path = "[base]/shuttle/resources/shared-db" }
 shuttle-secrets = { path = "[base]/shuttle/resources/secrets" }
 shuttle-static-folder = { path = "[base]/shuttle/resources/static-folder" }
+shuttle-turso = { path = "[base]/shuttle/resources/turso" }
 
 shuttle-axum = { path = "[base]/shuttle/services/shuttle-axum" }
 shuttle-actix-web = { path = "[base]/shuttle/services/shuttle-actix-web" }

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -21,6 +21,7 @@ pub fn get_resources_table(resources: &Vec<Response>, service_name: &str) -> Str
                 Type::Secrets => "Secrets",
                 Type::StaticFolder => "Static Folder",
                 Type::Persist => "Persist",
+                Type::Turso => "Turso",
             };
 
             let elements = acc.entry(title).or_insert(Vec::new());

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -35,6 +35,7 @@ pub enum Type {
     Secrets,
     StaticFolder,
     Persist,
+    Turso,
 }
 
 impl Response {
@@ -58,6 +59,7 @@ impl Display for Type {
             Type::Secrets => write!(f, "secrets"),
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
+            Type::Turso => write!(f, "turso"),
         }
     }
 }

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -17,6 +17,7 @@ if [[ $PROD != "true" ]]; then
     shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" }
     shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }
     shuttle-static-folder = { path = "/usr/src/shuttle/resources/static-folder" }
+    shuttle-turso = { path = "/usr/src/shuttle/resources/turso" }
 
     shuttle-axum = { path = "/usr/src/shuttle/services/shuttle-axum" }
     shuttle-actix-web = { path = "/usr/src/shuttle/services/shuttle-actix-web" }

--- a/deployer/src/persistence/resource/mod.rs
+++ b/deployer/src/persistence/resource/mod.rs
@@ -42,6 +42,7 @@ pub enum Type {
     Secrets,
     StaticFolder,
     Persist,
+    Turso,
 }
 
 impl From<Type> for shuttle_common::resource::Type {
@@ -51,6 +52,7 @@ impl From<Type> for shuttle_common::resource::Type {
             Type::Secrets => Self::Secrets,
             Type::StaticFolder => Self::StaticFolder,
             Type::Persist => Self::Persist,
+            Type::Turso => Self::Turso,
         }
     }
 }
@@ -62,6 +64,7 @@ impl From<shuttle_common::resource::Type> for Type {
             shuttle_common::resource::Type::Secrets => Self::Secrets,
             shuttle_common::resource::Type::StaticFolder => Self::StaticFolder,
             shuttle_common::resource::Type::Persist => Self::Persist,
+            shuttle_common::resource::Type::Turso => Self::Turso,
         }
     }
 }
@@ -73,6 +76,7 @@ impl Display for Type {
             Type::Secrets => write!(f, "secrets"),
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
+            Type::Turso => write!(f, "turso"),
         }
     }
 }
@@ -91,6 +95,7 @@ impl FromStr for Type {
                 "secrets" => Ok(Self::Secrets),
                 "static_folder" => Ok(Self::StaticFolder),
                 "persist" => Ok(Self::Persist),
+                "turso" => Ok(Self::Turso),
                 _ => Err(format!("'{s}' is an unknown resource type")),
             }
         }
@@ -139,6 +144,7 @@ mod tests {
             Type::Secrets,
             Type::StaticFolder,
             Type::Persist,
+            Type::Turso,
         ];
 
         for input in inputs {

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-turso"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to obtain a client connected to a Turso database"

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -12,3 +12,8 @@ libsql-client = { version = "0.27" }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.18.0", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }
+
+
+[dev-dependencies]
+tempfile = "3.3.0"
+tokio = "1.28.2"

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shuttle-turso"
+version = "0.18.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Plugin to obtain a client connected to a Turso database"
+keywords = ["shuttle-service", "turso"]
+
+[dependencies]
+async-trait = "0.1.56"
+libsql-client = { version = "0.27" }
+serde = { version = "1.0.148", features = ["derive"] }
+shuttle-service = { path = "../../service", version = "0.18.0", default-features = false }
+url = { version = "2.3.1", features = ["serde"] }

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["shuttle-service", "turso"]
 
 [dependencies]
 async-trait = "0.1.56"
-libsql-client = { version = "0.27" }
+libsql-client = { version = "=0.30.1" }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.19.0", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-turso"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to obtain a client connected to a Turso database"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "turso"]
 async-trait = "0.1.56"
 libsql-client = { version = "0.27" }
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.18.0", default-features = false }
+shuttle-service = { path = "../../service", version = "0.19.0", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }
 
 

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "turso"]
 async-trait = "0.1.56"
 libsql-client = { version = "=0.30.1" }
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.19.0", default-features = false }
+shuttle-service = { path = "../../service", version = "0.20.0", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }
 
 

--- a/resources/turso/README.md
+++ b/resources/turso/README.md
@@ -9,19 +9,23 @@ This plugin allows services to connect to a Turso database. Turso is an edge-hos
 Add `shuttle-turso` to the dependencies for your service.
 This resource will be provided by adding the `shuttle_turso::Turso` attribute to your Shuttle `main` decorated function.
 
-It returns a `libsql_client::Client`. When running locally it will instantiate a local SQLite database of the name of your service instead of connecting to your edge database.
+It returns a `libsql_client::Client`. When running in production, the token used to connect to your database will be read from `TURSO_DB_TOKEN` in your `Secrets.toml` file. This can be overridden with the `token_secret` parameter. When running locally it will instantiate a local SQLite database of the name of your service instead of connecting to your edge database.
+
+If you want to connect to a remote database when running locally, you can specify the `local_addr` parameter. In that case, the token will be read from your `Secrets.dev.toml` file.
 
 ### Example
 
 ```rust
+use libsql_client::client::Client;
+
 #[shuttle_runtime::main]
-async fn app(#[shuttle_turso::Turso(addr="advanced-lightspeed.turso.io", auth_token=Some("token")] client: Client) -> __ { }
+async fn app(#[shuttle_turso::Turso(addr="libsql://advanced-lightspeed.turso.io")] client: Client) -> __ { }
 ```
 
 ### Parameters
 
-| Parameter  | Type        | Default | Description                                                                                                                   |
-| ---------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| addr       | str         | `""`    | URL of the database to connect to, without the `libsql://` part at the beginning.                                             |
-| token      | str         | `""`    | The auth token created with the CLI to connect to the database.                                                               |
-| local_addr | Option<str> | `None`  | The URL to use when running your service locally. If not provided, this will default to a local file name `<service name>.db` |
+| Parameter    | Type        | Default          | Description                                                                                                                   |
+| ------------ | ----------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| addr         | str         | `""`             | URL of the database to connect to. If `libsql://` is missing at the beginning, it will be automatically added.                |
+| token_secret | str         | `TURSO_DB_TOKEN` | The name of the secret to read to get token created with the CLI to connect to the database.                                  |
+| local_addr   | Option<str> | `None`           | The URL to use when running your service locally. If not provided, this will default to a local file name `<service name>.db` |

--- a/resources/turso/README.md
+++ b/resources/turso/README.md
@@ -19,6 +19,7 @@ In the case of an Axum server, your main function will look like this:
 
 ```rust
 use libsql_client::client::Client;
+use shuttle_axum::ShuttleAxum;
 
 #[shuttle_runtime::main]
 async fn app(#[shuttle_turso::Turso(addr="libsql://my-turso-db-name.turso.io", token="{secrets.DB_TURSO_TOKEN}")] client: Client) -> ShuttleAxum { }

--- a/resources/turso/README.md
+++ b/resources/turso/README.md
@@ -1,31 +1,33 @@
 # Shuttle Turso
 
-This plugin allows services to connect to a Turso database. Turso is an edge-hosted distributed database based on libSQL.
+This plugin allows services to connect to a Turso database. Turso is an edge-hosted distributed database based on libSQL, a SQLite fork.
 
 ## Usage
 
 **IMPORTANT**: Currently Shuttle isn't able to provision a database for you (yet). This means you will have to create an account on their [website](https://turso.tech/) and follow the few steps required to create a database and create a token to access it.
 
-Add `shuttle-turso` to the dependencies for your service.
+Add `shuttle-turso` to the dependencies for your service by running `cargo add shuttle-turso`.
 This resource will be provided by adding the `shuttle_turso::Turso` attribute to your Shuttle `main` decorated function.
 
-It returns a `libsql_client::Client`. When running in production, the token used to connect to your database will be read from `TURSO_DB_TOKEN` in your `Secrets.toml` file. This can be overridden with the `token_secret` parameter. When running locally it will instantiate a local SQLite database of the name of your service instead of connecting to your edge database.
+It returns a `libsql_client::Client`. When running locally it will instantiate a local SQLite database of the name of your service instead of connecting to your edge database.
 
 If you want to connect to a remote database when running locally, you can specify the `local_addr` parameter. In that case, the token will be read from your `Secrets.dev.toml` file.
 
 ### Example
 
+In the case of an Axum server, your main function will look like this:
+
 ```rust
 use libsql_client::client::Client;
 
 #[shuttle_runtime::main]
-async fn app(#[shuttle_turso::Turso(addr="libsql://advanced-lightspeed.turso.io")] client: Client) -> __ { }
+async fn app(#[shuttle_turso::Turso(addr="libsql://my-turso-db-name.turso.io", token="{secrets.DB_TURSO_TOKEN}")] client: Client) -> ShuttleAxum { }
 ```
 
 ### Parameters
 
-| Parameter    | Type        | Default          | Description                                                                                                                   |
-| ------------ | ----------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| addr         | str         | `""`             | URL of the database to connect to. If `libsql://` is missing at the beginning, it will be automatically added.                |
-| token_secret | str         | `TURSO_DB_TOKEN` | The name of the secret to read to get token created with the CLI to connect to the database.                                  |
-| local_addr   | Option<str> | `None`           | The URL to use when running your service locally. If not provided, this will default to a local file name `<service name>.db` |
+| Parameter  | Type        | Default | Description                                                                                                                                        |
+| ---------- | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| addr       | str         | `""`    | URL of the database to connect to. If `libsql://` is missing at the beginning, it will be automatically added.                                     |
+| token      | str         | `""`    | The value of the token to authenticate against the Turso database. You can use string interpolation to read a secret from your `Secret.toml` file. |
+| local_addr | Option<str> | `None`  | The URL to use when running your service locally. If not provided, this will default to a local file named `<service name>.db`                     |

--- a/resources/turso/README.md
+++ b/resources/turso/README.md
@@ -1,0 +1,27 @@
+# Shuttle Turso
+
+This plugin allows services to connect to a Turso database. Turso is an edge-hosted distributed database based on libSQL.
+
+## Usage
+
+**IMPORTANT**: Currently Shuttle isn't able to provision a database for you (yet). This means you will have to create an account on their [website](https://turso.tech/) and follow the few steps required to create a database and create a token to access it.
+
+Add `shuttle-turso` to the dependencies for your service.
+This resource will be provided by adding the `shuttle_turso::Turso` attribute to your Shuttle `main` decorated function.
+
+It returns a `libsql_client::Client`. When running locally it will instantiate a local SQLite database of the name of your service instead of connecting to your edge database.
+
+### Example
+
+```rust
+#[shuttle_runtime::main]
+async fn app(#[shuttle_turso::Turso(addr="advanced-lightspeed.turso.io", auth_token=Some("token")] client: Client) -> __ { }
+```
+
+### Parameters
+
+| Parameter  | Type        | Default | Description                                                                                                                   |
+| ---------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| addr       | str         | `""`    | URL of the database to connect to, without the `libsql://` part at the beginning.                                             |
+| token      | str         | `""`    | The auth token created with the CLI to connect to the database.                                                               |
+| local_addr | Option<str> | `None`  | The URL to use when running your service locally. If not provided, this will default to a local file name `<service name>.db` |

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -64,7 +64,7 @@ impl Turso {
             .get(&self.token_secret)
         {
             Some(token) => Ok(TursoOutput {
-                conn_url: Url::parse(&addr).map_err(Error::UrlParseError)?,
+                conn_url: Url::parse(addr).map_err(Error::UrlParseError)?,
                 token: Some(token.to_string()),
             }),
             None => Err(ShuttleError::Custom(CustomError::msg(format!(

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use libsql_client::{client::Client, new_client_from_config, Config};
+use libsql_client::{Client, Config};
 use serde::{Deserialize, Serialize};
 use shuttle_service::{
     error::{CustomError, Error as ShuttleError},
@@ -126,7 +126,7 @@ impl ResourceBuilder<Client> for Turso {
     }
 
     async fn build(config: &Self::Output) -> Result<Client, shuttle_service::Error> {
-        let client = new_client_from_config(Config {
+        let client = Client::from_config(Config {
             url: config.conn_url.clone(),
             auth_token: config.token.clone(),
         })

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -53,7 +53,7 @@ impl ResourceBuilder<Client> for Turso {
     }
 
     fn config(&self) -> &Self::Config {
-        &self
+        self
     }
 
     async fn output(
@@ -112,9 +112,7 @@ mod test {
     use std::{fs, str::FromStr};
 
     use async_trait::async_trait;
-    use shuttle_service::{
-        CustomError, DatabaseReadyInfo, Environment, Factory, ResourceBuilder, ServiceName,
-    };
+    use shuttle_service::{DatabaseReadyInfo, Environment, Factory, ResourceBuilder, ServiceName};
     use tempfile::{Builder, TempDir};
     use url::Url;
 

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -79,7 +79,6 @@ impl ResourceBuilder<Client> for Turso {
             }
             shuttle_service::Environment::Local => {
                 // Default to a local db of the name of the service.
-                // XXX: should we check that the file doesn't exist before using that name ?
                 let default_db_path = factory
                     .get_build_path()?
                     .join(format!("{}.db", factory.get_service_name()));

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -14,7 +14,7 @@ pub struct Turso {
     local_addr: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TursoOutput {
     conn_url: Url,
     token: Option<String>,
@@ -63,8 +63,6 @@ impl ResourceBuilder<Client> for Turso {
         match factory.get_environment() {
             shuttle_service::Environment::Production => {
                 if self.addr.is_empty() {
-                    // XXX: should we raise an error even not running in a production
-                    // environment ?
                     Err(ShuttleError::Custom(CustomError::msg("missing addr")))
                 } else {
                     Ok(TursoOutput {
@@ -104,5 +102,149 @@ impl ResourceBuilder<Client> for Turso {
         })
         .await?;
         Ok(client)
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use std::path::PathBuf;
+    use std::{fs, str::FromStr};
+
+    use async_trait::async_trait;
+    use shuttle_service::{
+        CustomError, DatabaseReadyInfo, Environment, Factory, ResourceBuilder, ServiceName,
+    };
+    use tempfile::{Builder, TempDir};
+    use url::Url;
+
+    use crate::{Turso, TursoOutput};
+
+    struct MockFactory {
+        temp_dir: TempDir,
+        pub service_name: String,
+        pub environment: Environment,
+    }
+
+    impl MockFactory {
+        fn new() -> Self {
+            Self {
+                temp_dir: Builder::new().prefix("shuttle-turso").tempdir().unwrap(),
+                service_name: "shuttle-turso".to_string(),
+                environment: Environment::Local,
+            }
+        }
+
+        fn build_path(&self) -> PathBuf {
+            self.get_path("build")
+        }
+
+        fn get_path(&self, folder: &str) -> PathBuf {
+            let path = self.temp_dir.path().join(folder);
+
+            if !path.exists() {
+                fs::create_dir(&path).unwrap();
+            }
+
+            path
+        }
+    }
+
+    #[async_trait]
+    impl Factory for MockFactory {
+        async fn get_db_connection(
+            &mut self,
+            _db_type: shuttle_service::database::Type,
+        ) -> Result<DatabaseReadyInfo, shuttle_service::Error> {
+            panic!("no turso test should try to get a db connection string")
+        }
+
+        async fn get_secrets(
+            &mut self,
+        ) -> Result<std::collections::BTreeMap<String, String>, shuttle_service::Error> {
+            panic!("no turso test should try to get secrets")
+        }
+
+        fn get_service_name(&self) -> shuttle_service::ServiceName {
+            ServiceName::from_str(&self.service_name).unwrap()
+        }
+
+        fn get_environment(&self) -> shuttle_service::Environment {
+            self.environment
+        }
+
+        fn get_build_path(&self) -> Result<std::path::PathBuf, shuttle_service::Error> {
+            Ok(self.build_path())
+        }
+
+        fn get_storage_path(&self) -> Result<std::path::PathBuf, shuttle_service::Error> {
+            panic!("no turso test should try to get the storage path")
+        }
+    }
+
+    #[tokio::test]
+    async fn local_database_default() {
+        let mut factory = MockFactory::new();
+
+        let turso = Turso::new();
+        let output = turso.output(&mut factory).await.unwrap();
+        assert_eq!(
+            output,
+            TursoOutput {
+                conn_url: Url::parse(&format!(
+                    "file:///{}/shuttle-turso.db",
+                    factory.get_build_path().unwrap().to_str().unwrap()
+                ))
+                .unwrap(),
+                token: None
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn local_database_user_supplied() {
+        let mut factory = MockFactory::new();
+
+        let mut turso = Turso::new();
+        let local_addr = "libsql://test-addr.turso.io";
+        turso = turso.local_addr(local_addr);
+
+        let output = turso.output(&mut factory).await.unwrap();
+        assert_eq!(
+            output,
+            TursoOutput {
+                conn_url: Url::parse(local_addr).unwrap(),
+                token: None
+            }
+        )
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "missing addr")]
+    async fn remote_database_empty_addr() {
+        let mut factory = MockFactory::new();
+        factory.environment = Environment::Production;
+
+        let turso = Turso::new();
+        turso.output(&mut factory).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn remote_database() {
+        let mut factory = MockFactory::new();
+        factory.environment = Environment::Production;
+
+        let mut turso = Turso::new();
+        let addr = "my-turso-addr.turso.io".to_string();
+        turso.addr = addr.clone();
+        let output = turso.output(&mut factory).await.unwrap();
+
+        assert_eq!(
+            output,
+            TursoOutput {
+                conn_url: Url::parse(&format!("libsql://{}", addr)).unwrap(),
+                token: Some("".to_string())
+            }
+        )
     }
 }

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -1,0 +1,109 @@
+use async_trait::async_trait;
+use libsql_client::{client::Client, new_client_from_config, Config};
+use serde::{Deserialize, Serialize};
+use shuttle_service::{
+    error::{CustomError, Error as ShuttleError},
+    Factory, ResourceBuilder, Type,
+};
+use url::Url;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Turso {
+    addr: String,
+    token: String,
+    local_addr: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TursoOutput {
+    conn_url: Url,
+    token: Option<String>,
+}
+
+impl Turso {
+    pub fn local_addr(mut self, local_addr: &str) -> Self {
+        self.local_addr = Some(local_addr.to_string());
+        self
+    }
+}
+
+pub enum Error {
+    UrlParseError(url::ParseError),
+}
+
+impl From<Error> for shuttle_service::Error {
+    fn from(error: Error) -> Self {
+        let msg = match error {
+            Error::UrlParseError(err) => format!("Cannot parse Turso Url: {}", err),
+        };
+
+        ShuttleError::Custom(CustomError::msg(msg))
+    }
+}
+
+#[async_trait]
+impl ResourceBuilder<Client> for Turso {
+    const TYPE: Type = Type::Turso;
+
+    type Config = Self;
+    type Output = TursoOutput;
+
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn config(&self) -> &Self::Config {
+        &self
+    }
+
+    async fn output(
+        self,
+        factory: &mut dyn Factory,
+    ) -> Result<Self::Output, shuttle_service::Error> {
+        match factory.get_environment() {
+            shuttle_service::Environment::Production => {
+                if self.addr.is_empty() {
+                    // XXX: should we raise an error even not running in a production
+                    // environment ?
+                    Err(ShuttleError::Custom(CustomError::msg("missing addr")))
+                } else {
+                    Ok(TursoOutput {
+                        // XXX: should we allow for other kind of connection string ? Not having libsql at
+                        // the start of the url even though the Turso CLI is printing it might be confusing
+                        // instead of just giving the responsability to the user.
+                        conn_url: Url::parse(&format!("libsql://{}", self.addr))
+                            .map_err(Error::UrlParseError)?,
+                        token: Some(self.token),
+                    })
+                }
+            }
+            shuttle_service::Environment::Local => {
+                // Default to a local db of the name of the service.
+                // XXX: should we check that the file doesn't exist before using that name ?
+                let default_db_path = factory
+                    .get_build_path()?
+                    .join(format!("{}.db", factory.get_service_name()));
+
+                let conn_url = self.local_addr.unwrap_or(format!(
+                    "file://{}",
+                    default_db_path
+                        .to_str()
+                        .expect("local db should be a valid unicode string")
+                ));
+                Ok(TursoOutput {
+                    conn_url: Url::parse(&conn_url).map_err(Error::UrlParseError)?,
+                    token: None,
+                })
+            }
+        }
+    }
+
+    async fn build(config: &Self::Output) -> Result<Client, shuttle_service::Error> {
+        let client = new_client_from_config(Config {
+            url: config.conn_url.clone(),
+            auth_token: config.token.clone(),
+        })
+        .await?;
+        Ok(client)
+    }
+}

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -7,7 +7,7 @@ use shuttle_service::{
 };
 use url::Url;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default)]
 pub struct Turso {
     addr: String,
     token: String,
@@ -75,11 +75,7 @@ impl ResourceBuilder<Client> for Turso {
     type Output = TursoOutput;
 
     fn new() -> Self {
-        Self {
-            addr: "".to_string(),
-            token: "".to_string(),
-            local_addr: None,
-        }
+        Self::default()
     }
 
     fn config(&self) -> &Self::Config {

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -99,7 +99,7 @@ pub trait Factory: Send + Sync {
 ///     }
 ///
 ///     fn config(&self) -> &Self::Config {
-///         &self
+///         self
 ///     }
 ///
 ///     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, shuttle_service::Error> {


### PR DESCRIPTION
## Description of change

This adds support for Turso but without provisioning.

Close #986.

## How has this been tested? (if applicable)

Locally yes, both with a local and a remote database.

## TODO

- Clarify the few `XXX` in the code.


