### PR TITLE
fix: mysql provisioning bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,21 +2069,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3517,24 +3502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,32 +3668,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.16",
-]
 
 [[package]]
 name = "openssl-probe"

--- a/provisioner/src/lib.rs
+++ b/provisioner/src/lib.rs
@@ -262,6 +262,14 @@ impl MyProvisioner {
                 if let ModifyDBInstanceError::DbInstanceNotFoundFault(_) = err.err() {
                     debug!("creating new AWS RDS {instance_name}");
 
+                    // The engine display impl is used for both the engine and the database name,
+                    // but for "mysql" the engine name is an invalid database name.
+                    let db_name = if let aws_rds::Engine::Mysql(_) = engine {
+                        "msql".to_string()
+                    } else {
+                        engine.to_string()
+                    };
+
                     client
                         .create_db_instance()
                         .db_instance_identifier(&instance_name)
@@ -272,7 +280,7 @@ impl MyProvisioner {
                         .allocated_storage(20)
                         .backup_retention_period(0) // Disable backups
                         .publicly_accessible(true)
-                        .db_name(engine.to_string())
+                        .db_name(db_name)
                         .set_db_subnet_group_name(Some(RDS_SUBNET_GROUP.to_string()))
                         .send()
                         .await?

--- a/provisioner/src/lib.rs
+++ b/provisioner/src/lib.rs
@@ -263,7 +263,7 @@ impl MyProvisioner {
                     debug!("creating new AWS RDS {instance_name}");
 
                     // The engine display impl is used for both the engine and the database name,
-                    // but for "mysql" the engine name is an invalid database name.
+                    // but for mysql the engine name is an invalid database name.
                     let db_name = if let aws_rds::Engine::Mysql(_) = engine {
                         "msql".to_string()
                     } else {


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

When we provision an rds database we use the engine name for the database name, this does not work for mysql. As a quick fix I changed it so mysql uses "msql" instead, because we currently don't have any mysql databases (it has not been possible). If we were to change the naming for all databases, we'd have to rename all the existing databases, which we don't want to prioritize right now.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Deployed the changes to unstable and deployed a mysql project. I might have uncovered a newer bug where a deployment with an rds database crashes (or incorrectly returns crashed) when it starts waiting for the rds instance to be ready, but looking at aws and provisioner logs the database did get successfully provisioned.

We need to renew the unstable certificate so we should do that and double check this PR works before merging.
