### PR TITLE
fix: remove auth login endpoint

### DIFF
--- a/auth/src/api/builder.rs
+++ b/auth/src/api/builder.rs
@@ -22,8 +22,8 @@ use crate::{
 };
 
 use super::handlers::{
-    convert_cookie, convert_key, get_public_key, get_user, login, logout, post_user,
-    put_user_reset_key, refresh_token,
+    convert_cookie, convert_key, get_public_key, get_user, logout, post_user, put_user_reset_key,
+    refresh_token,
 };
 
 pub type UserManagerState = Arc<Box<dyn UserManagement>>;
@@ -64,7 +64,6 @@ impl Default for ApiBuilder {
 impl ApiBuilder {
     pub fn new() -> Self {
         let router = Router::new()
-            .route("/login", post(login))
             .route("/logout", post(logout))
             .route("/auth/session", get(convert_cookie))
             .route("/auth/key", get(convert_key))

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -56,23 +56,6 @@ pub(crate) async fn put_user_reset_key(
     user_manager.reset_key(account_name).await
 }
 
-pub(crate) async fn login(
-    mut session: WritableSession,
-    State(user_manager): State<UserManagerState>,
-    Json(request): Json<LoginRequest>,
-) -> Result<Json<user::Response>, Error> {
-    let user = user_manager.get_user(request.account_name).await?;
-
-    session
-        .insert("account_name", user.name.clone())
-        .expect("to set account name");
-    session
-        .insert("account_tier", user.account_tier)
-        .expect("to set account tier");
-
-    Ok(Json(user.into()))
-}
-
 pub(crate) async fn logout(mut session: WritableSession) {
     session.destroy();
 }

--- a/auth/tests/api/session.rs
+++ b/auth/tests/api/session.rs
@@ -6,6 +6,7 @@ use shuttle_common::claims::Claim;
 
 use crate::helpers::app;
 
+#[ignore]
 #[tokio::test]
 async fn session_flow() {
     let app = app().await;

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -1,8 +1,7 @@
 use crate::helpers::{self, app};
 use axum::body::Body;
-use axum_extra::extract::cookie::Cookie;
 use hyper::http::{header::AUTHORIZATION, Request, StatusCode};
-use serde_json::{self, json, Value};
+use serde_json::{self, Value};
 
 #[tokio::test]
 async fn post_user() {
@@ -109,7 +108,7 @@ async fn get_user() {
 async fn test_reset_key() {
     let app = app().await;
 
-    // Reset API key without cookie or API key.
+    // Reset API key without API key.
     let request = Request::builder()
         .uri("/users/reset-api-key")
         .method("PUT")
@@ -117,36 +116,6 @@ async fn test_reset_key() {
         .unwrap();
     let response = app.send_request(request).await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-
-    // Reset API key with cookie.
-    let response = app.post_user("test-user", "basic").await;
-    assert_eq!(response.status(), StatusCode::OK);
-
-    let body = serde_json::to_vec(&json! ({"account_name": "test-user"})).unwrap();
-    let request = Request::builder()
-        .uri("/login")
-        .method("POST")
-        .header("Content-Type", "application/json")
-        .body(Body::from(body))
-        .unwrap();
-    let response = app.send_request(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
-    let cookie = response
-        .headers()
-        .get("set-cookie")
-        .unwrap()
-        .to_str()
-        .unwrap();
-    let cookie = Cookie::parse(cookie).unwrap();
-
-    let request = Request::builder()
-        .uri("/users/reset-api-key")
-        .method("PUT")
-        .header("Cookie", cookie.stripped().to_string())
-        .body(Body::empty())
-        .unwrap();
-    let response = app.send_request(request).await;
-    assert_eq!(response.status(), StatusCode::OK);
 
     // Reset API key with API key.
     let request = Request::builder()


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

When working on the `auth` service we created some endpoints that would be called by the console, but that the console was not ready to use yet at the time of implementation. When we did this we missed the admin guard on one of these routes, meaning it was callable by anyone. If this endpoint was called with a users ID it would return their user data (user ID, api-key and account tier). When we realized this was the case we closed the endpoint and deployed the fix to production immediately.

This was an oversight on our part, but we have verified with our telemetry data that this vulnerability has never been exploited, as the endpoint has never been called successfully outside of our testing. We have also reviewed our `auth` service for other vulnerabilities and ensured all sensitive endpoints are guarded and covered by integration tests.

This PR plugs the leak and the fix has already been deployed to production. This PR does not remove the entire session flow, since the auth service is being refactored to a tonic gRPC service on the https://github.com/shuttle-hq/shuttle/tree/feat/shuttle-runtime-scaling branch.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested with `curl` after the fix was deployed.
