### PR TITLE
feat: refactor gateway to use the new grpc auth client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "febf23ab04509bd7672e6abe76bd8277af31b679e89fa5ffc6087dc289a448a3"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tokio",
+ "tower",
+ "tower-http 0.4.0",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-server"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1298,7 @@ checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
 dependencies = [
  "base64 0.21.1",
  "hmac",
+ "percent-encoding",
  "rand",
  "sha2",
  "subtle",
@@ -5360,6 +5384,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-extra",
  "axum-server",
  "base64 0.13.1",
  "bollard",
@@ -5389,11 +5414,13 @@ dependencies = [
  "serde",
  "serde_json",
  "shuttle-common",
+ "shuttle-proto",
  "snailquote",
  "sqlx",
  "strum",
  "tempfile",
  "tokio",
+ "tonic",
  "tower",
  "tower-http 0.4.0",
  "tower-sanitize-path",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5365,6 +5365,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "shuttle-common",
+ "shuttle-proto",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5455,6 +5456,7 @@ name = "shuttle-proto"
 version = "0.18.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "home",
  "prost",

--- a/auth/src/args.rs
+++ b/auth/src/args.rs
@@ -21,7 +21,7 @@ pub enum Commands {
 #[derive(clap::Args, Debug, Clone)]
 pub struct StartArgs {
     /// Address to bind to
-    #[arg(long, default_value = "127.0.0.1:8000")]
+    #[arg(long, default_value = "127.0.0.1:8008")]
     pub address: SocketAddr,
 }
 

--- a/auth/src/dal.rs
+++ b/auth/src/dal.rs
@@ -2,11 +2,11 @@ use std::{fmt, path::Path, str::FromStr};
 
 use crate::{
     session::SessionToken,
-    user::{AccountName, AccountTier, User},
+    user::{AccountName, User},
     Error,
 };
 use async_trait::async_trait;
-use shuttle_common::ApiKey;
+use shuttle_common::{claims::AccountTier, ApiKey};
 use sqlx::{
     migrate::{MigrateDatabase, Migrator},
     sqlite::{SqliteConnectOptions, SqliteJournalMode},

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -246,7 +246,8 @@ where
         Ok(Response::new(UserResponse {
             account_name: name.to_string(),
             account_tier: account_tier.to_string(),
-            // TODO: change this to .expose() when #925 is merged.
+            // This has to be as_ref to yield the inner key, the ApiKey
+            // display impl will return REDACTED.
             key: key.as_ref().to_string(),
         }))
     }
@@ -274,7 +275,8 @@ where
         Ok(Response::new(UserResponse {
             account_name: name.to_string(),
             account_tier: account_tier.to_string(),
-            // TODO: change this to .expose() when #925 is merged.
+            // This has to be as_ref to yield the inner key, the ApiKey
+            // display impl will return REDACTED.
             key: key.as_ref().to_string(),
         }))
     }
@@ -299,7 +301,8 @@ where
 
         let mut response = Response::new(UserResponse {
             account_name: name.to_string(),
-            // TODO: change this to .expose() when #925 is merged.
+            // This has to be as_ref to yield the inner key, the ApiKey
+            // display impl will return REDACTED.
             key: key.as_ref().to_string(),
             account_tier: account_tier.to_string(),
         });

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -299,7 +299,8 @@ where
 
         let mut response = Response::new(UserResponse {
             account_name: name.to_string(),
-            key: key.to_string(),
+            // TODO: change this to .expose() when #925 is merged.
+            key: key.as_ref().to_string(),
             account_tier: account_tier.to_string(),
         });
 

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -12,9 +12,8 @@ use cookie::{Cookie, SameSite};
 use http::header::SET_COOKIE;
 use ring::rand::SystemRandom;
 use secrets::KeyManager;
-use session::{
-    sign_cookie, SessionState, SessionToken, SessionUser, COOKIE_EXPIRATION, COOKIE_NAME,
-};
+use session::{sign_cookie, SessionState, SessionToken, SessionUser, COOKIE_EXPIRATION};
+use shuttle_common::backends::auth::COOKIE_NAME;
 use shuttle_common::claims::{AccountTier, Claim};
 use shuttle_common::ApiKey;
 use shuttle_proto::auth::auth_server::Auth;

--- a/auth/src/main.rs
+++ b/auth/src/main.rs
@@ -3,13 +3,14 @@ use std::time::Duration;
 use clap::Parser;
 use shuttle_common::{
     backends::tracing::{setup_tracing, ExtractPropagationLayer},
+    claims::AccountTier,
     ApiKey,
 };
 use shuttle_proto::auth::auth_server::AuthServer;
 use tonic::transport::Server;
 use tracing::trace;
 
-use shuttle_auth::{AccountTier, Args, Commands, Dal, EdDsaManager, Service, SessionLayer, Sqlite};
+use shuttle_auth::{Args, Commands, Dal, EdDsaManager, Service, SessionLayer, Sqlite};
 
 #[tokio::main]
 async fn main() {

--- a/auth/src/session.rs
+++ b/auth/src/session.rs
@@ -8,12 +8,12 @@ use hmac::{Hmac, Mac};
 use http::header::COOKIE;
 use ring::rand::{SecureRandom, SystemRandom};
 use sha2::Sha256;
-use shuttle_common::claims::ResponseFuture;
+use shuttle_common::claims::{AccountTier, ResponseFuture};
 use tonic::body::BoxBody;
 use tower::{Layer, Service};
 use tracing::error;
 
-use crate::{secrets::KeyManager, user::AccountName, AccountTier, Dal};
+use crate::{secrets::KeyManager, user::AccountName, Dal};
 
 pub const COOKIE_NAME: &str = "shuttle.sid";
 pub const COOKIE_EXPIRATION: i64 = 60 * 60 * 24; // One day

--- a/auth/src/session.rs
+++ b/auth/src/session.rs
@@ -8,14 +8,16 @@ use hmac::{Hmac, Mac};
 use http::header::COOKIE;
 use ring::rand::{SecureRandom, SystemRandom};
 use sha2::Sha256;
-use shuttle_common::claims::{AccountTier, ResponseFuture};
+use shuttle_common::{
+    backends::auth::COOKIE_NAME,
+    claims::{AccountTier, ResponseFuture},
+};
 use tonic::body::BoxBody;
 use tower::{Layer, Service};
 use tracing::error;
 
 use crate::{secrets::KeyManager, user::AccountName, Dal};
 
-pub const COOKIE_NAME: &str = "shuttle.sid";
 pub const COOKIE_EXPIRATION: i64 = 60 * 60 * 24; // One day
 const BASE64_DIGEST_LEN: usize = 44;
 

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -1,9 +1,6 @@
 use std::{fmt::Formatter, str::FromStr};
 
-use shuttle_common::{
-    claims::{Scope, ScopeBuilder},
-    ApiKey,
-};
+use shuttle_common::{claims::AccountTier, ApiKey};
 use tonic::{metadata::MetadataMap, Status};
 
 use crate::{dal::Dal, Error};
@@ -56,45 +53,6 @@ pub async fn verify_admin<D: Dal + Send + Sync + 'static>(
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, sqlx::Type, strum::Display)]
-#[sqlx(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
-#[derive(Default)]
-pub enum AccountTier {
-    #[default]
-    Basic,
-    Pro,
-    Team,
-    Admin,
-}
-
-impl From<AccountTier> for Vec<Scope> {
-    fn from(tier: AccountTier) -> Self {
-        let mut builder = ScopeBuilder::new();
-
-        if tier == AccountTier::Admin {
-            builder = builder.with_admin()
-        }
-
-        builder.build()
-    }
-}
-
-impl TryFrom<String> for AccountTier {
-    type Error = Error;
-
-    fn try_from(value: String) -> Result<AccountTier, Error> {
-        let tier = match value.as_str() {
-            "basic" => AccountTier::Basic,
-            "pro" => AccountTier::Pro,
-            "team" => AccountTier::Team,
-            "admin" => AccountTier::Admin,
-            other => return Err(Error::InvalidAccountTier(other.to_string())),
-        };
-
-        Ok(tier)
-    }
-}
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::Type)]
 #[sqlx(transparent)]
 pub struct AccountName(String);

--- a/auth/tests/api/helpers.rs
+++ b/auth/tests/api/helpers.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use portpicker::pick_unused_port;
-use shuttle_auth::{AccountTier, Dal, EdDsaManager, Service, SessionLayer, Sqlite};
-use shuttle_common::ApiKey;
+use shuttle_auth::{Dal, EdDsaManager, Service, SessionLayer, Sqlite};
+use shuttle_common::{claims::AccountTier, ApiKey};
 use shuttle_proto::auth::{
     auth_client::AuthClient, auth_server::AuthServer, NewUser, UserRequest, UserResponse,
 };

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -56,7 +56,7 @@ backend = [
     "tower-http",
     "tracing-subscriber/env-filter",
     "tracing-subscriber/fmt",
-    "ttl_cache"
+    "ttl_cache",
 ]
 claims = [
     "bytes",

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -23,7 +23,7 @@ use super::{
     headers::XShuttleAdminSecret,
 };
 
-const PUBLIC_KEY_CACHE_KEY: &str = "shuttle.public-key";
+pub const PUBLIC_KEY_CACHE_KEY: &str = "shuttle.public-key";
 pub const COOKIE_NAME: &str = "shuttle.sid";
 
 /// Layer to check the admin secret set by deployer is correct

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -24,6 +24,7 @@ use super::{
 };
 
 const PUBLIC_KEY_CACHE_KEY: &str = "shuttle.public-key";
+pub const COOKIE_NAME: &str = "shuttle.sid";
 
 /// Layer to check the admin secret set by deployer is correct
 #[derive(Clone)]

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -19,6 +19,8 @@ use strum::EnumMessage;
 use tower::{Layer, Service};
 use tracing::{error, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
 
 /// Minutes before a claim expires
 ///
@@ -135,6 +137,7 @@ impl Default for ScopeBuilder {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, strum::Display, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[cfg_attr(feature = "persist", derive(sqlx::Type))]
 #[cfg_attr(feature = "persist", sqlx(rename_all = "lowercase"))]
 #[strum(serialize_all = "lowercase")]

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -15,7 +15,7 @@ use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
 use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
-use strum::EnumMessage;
+use strum::{EnumMessage, EnumString};
 use tower::{Layer, Service};
 use tracing::{error, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
@@ -136,7 +136,7 @@ impl Default for ScopeBuilder {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, strum::Display, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, strum::Display, Deserialize, EnumString)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[cfg_attr(feature = "persist", derive(sqlx::Type))]
 #[cfg_attr(feature = "persist", sqlx(rename_all = "lowercase"))]
@@ -160,22 +160,6 @@ impl From<AccountTier> for Vec<Scope> {
         }
 
         builder.build()
-    }
-}
-
-impl TryFrom<&str> for AccountTier {
-    type Error = Box<dyn std::error::Error + Send + Sync>;
-
-    fn try_from(value: &str) -> Result<AccountTier, Self::Error> {
-        let tier = match value {
-            "basic" => AccountTier::Basic,
-            "pro" => AccountTier::Pro,
-            "team" => AccountTier::Team,
-            "admin" => AccountTier::Admin,
-            other => return Err(format!("{other} is not a valid account tier").into()),
-        };
-
-        Ok(tier)
     }
 }
 

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -134,6 +134,48 @@ impl Default for ScopeBuilder {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, strum::Display, Deserialize)]
+#[cfg_attr(feature = "persist", derive(sqlx::Type))]
+#[cfg_attr(feature = "persist", sqlx(rename_all = "lowercase"))]
+#[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+#[derive(Default)]
+pub enum AccountTier {
+    #[default]
+    Basic,
+    Pro,
+    Team,
+    Admin,
+}
+
+impl From<AccountTier> for Vec<Scope> {
+    fn from(tier: AccountTier) -> Self {
+        let mut builder = ScopeBuilder::new();
+
+        if tier == AccountTier::Admin {
+            builder = builder.with_admin()
+        }
+
+        builder.build()
+    }
+}
+
+impl TryFrom<&str> for AccountTier {
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn try_from(value: &str) -> Result<AccountTier, Self::Error> {
+        let tier = match value {
+            "basic" => AccountTier::Basic,
+            "pro" => AccountTier::Pro,
+            "team" => AccountTier::Team,
+            "admin" => AccountTier::Admin,
+            other => return Err(format!("{other} is not a valid account tier").into()),
+        };
+
+        Ok(tier)
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Claim {
     /// Expiration time (as UTC timestamp).

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -33,8 +33,10 @@ impl std::error::Error for ApiError {}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
 pub enum ErrorKind {
     KeyMissing,
+    CookieMissing,
     BadHost,
     KeyMalformed,
+    CookieMalformed,
     Unauthorized,
     Forbidden,
     UserNotFound,
@@ -102,6 +104,10 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized"),
             ErrorKind::Forbidden => (StatusCode::FORBIDDEN, "forbidden"),
             ErrorKind::NotReady => (StatusCode::INTERNAL_SERVER_ERROR, "service not ready"),
+            ErrorKind::CookieMissing => (StatusCode::UNAUTHORIZED, "request is missing a cookie"),
+            ErrorKind::CookieMalformed => {
+                (StatusCode::UNAUTHORIZED, "request has an invalid cookie")
+            }
         };
         Self {
             message: error_message.to_string(),

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -173,6 +173,7 @@ impl State {
 
 /// Config when creating a new project
 #[derive(Deserialize, Serialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Config {
     pub idle_minutes: u64,
 }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -42,3 +42,6 @@ uuid = { workspace = true, features = ["v4"] }
 [dependencies.shuttle-common]
 workspace = true
 features = ["backend", "models", "openapi"]
+
+[dependencies.shuttle-proto]
+workspace = true

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+###############################################################################
+# This file is used by our common Containerfile incase the container for this #
+# service might need some extra preparation steps for its final image         #
+###############################################################################
+
+# Nothing to prepare in container image here

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
     setup_tracing(tracing_subscriber::registry(), "deployer");
 
     // Configure the deployer router.
-    let mut router_builder = RouterBuilder::new(&args.auth_uri);
+    let mut router_builder = RouterBuilder::new(&args.auth_uri).await;
     if args.local {
         router_builder = router_builder.with_local_admin_layer();
     }

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["default", "headers"] }
+axum-extra = { version = "0.7.4", features = ["cookie"] }
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 base64 = { workspace = true }
 bollard = "0.14.0"
@@ -40,6 +41,7 @@ sqlx = { workspace = true, features = [
 ] }
 strum = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tonic = { workspace = true }
 tower = { workspace = true, features = ["steer"] }
 tower-http = { workspace = true }
 tracing = { workspace = true, features = ["default"] }
@@ -55,6 +57,9 @@ tower-sanitize-path = "0.1.2"
 [dependencies.shuttle-common]
 workspace = true
 features = ["backend", "models", "openapi"]
+
+[dependencies.shuttle-proto]
+workspace = true
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -105,16 +105,14 @@ where
             });
         }
 
-        // Enrich the current key | session
-
         // TODO: read this page to get rid of this clone
         // https://github.com/tower-rs/tower/blob/master/guides/building-a-middleware-from-scratch.md
         let mut this = self.clone();
 
+        // Enrich the current key | session
         Box::pin(async move {
             // Only if there is something to upgrade
             if let Some((cache_key, token_request)) = cache_key_and_token_req(req.headers()) {
-                // let target_url = this.auth_uri.to_string();
                 // Check if the token is cached.
                 if let Some(token) = this.cache_manager.get(&cache_key) {
                     trace!("JWT cache hit, setting token from cache on request");

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -175,8 +175,9 @@ where
     }
 }
 
-/// Return a [ConvertCookieRequest] or a [ApiKeyRequest] depending on the request headers,
-/// and return a future that we can .await if the cache is missed.
+/// If the request headers contain a cookie or a bearer token, return a cache key as well as a future
+/// that we can .await if the cache is missed. The future will send a convert request to the auth
+/// service and resolve to a [TokenResponse] containing our JWT.
 fn cache_key_and_token_req<'a>(
     headers: &HeaderMap,
     auth_client: &'a mut AuthClient<InjectPropagation<Channel>>,

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -1,27 +1,22 @@
-use std::{convert::Infallible, fmt::Debug, net::Ipv4Addr, sync::Arc, time::Duration};
+use std::{convert::Infallible, fmt::Debug, sync::Arc, time::Duration};
 
 use axum::{
-    body::{boxed, HttpBody},
-    headers::{authorization::Bearer, Authorization, Cookie, Header, HeaderMapExt},
+    body::boxed,
+    headers::{authorization::Bearer, Authorization, HeaderMapExt},
     response::Response,
 };
+use axum_extra::extract::CookieJar;
 use futures::future::BoxFuture;
-use http::{Request, StatusCode, Uri};
-use hyper::{
-    client::{connect::dns::GaiResolver, HttpConnector},
-    Body, Client,
-};
-use hyper_reverse_proxy::ReverseProxy;
-use once_cell::sync::Lazy;
-use opentelemetry::global;
-use opentelemetry_http::HeaderInjector;
-use shuttle_common::backends::{auth::ConvertResponse, cache::CacheManagement};
+use http::{header::COOKIE, HeaderMap, Request, StatusCode};
+use hyper::Body;
+use opentelemetry::{global, propagation::Injector};
+use shuttle_common::backends::cache::CacheManagement;
+use shuttle_proto::auth::{auth_client::AuthClient, ApiKeyRequest, ConvertCookieRequest};
+use tonic::{metadata::MetadataKey, Request as TonicRequest};
+use tonic::{metadata::MetadataValue, transport::Channel};
 use tower::{Layer, Service};
 use tracing::{error, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
-
-static PROXY_CLIENT: Lazy<ReverseProxy<HttpConnector<GaiResolver>>> =
-    Lazy::new(|| ReverseProxy::new(Client::new()));
 
 /// Time to cache tokens for. Currently tokens take 15 minutes to expire (see [EXP_MINUTES]) which leaves a 10 minutes
 /// buffer (EXP_MINUTES - CACHE_MINUTES). We want the buffer to be atleast as long as the longest builds which has
@@ -35,18 +30,18 @@ const CACHE_MINUTES: u64 = 5;
 /// and inserting it in the cache if it isn't there.
 #[derive(Clone)]
 pub struct ShuttleAuthLayer {
-    auth_uri: Uri,
     cache_manager: Arc<Box<dyn CacheManagement<Value = String>>>,
+    auth_client: AuthClient<Channel>,
 }
 
 impl ShuttleAuthLayer {
     pub fn new(
-        auth_uri: Uri,
         cache_manager: Arc<Box<dyn CacheManagement<Value = String>>>,
+        auth_client: AuthClient<Channel>,
     ) -> Self {
         Self {
-            auth_uri,
             cache_manager,
+            auth_client,
         }
     }
 }
@@ -57,8 +52,8 @@ impl<S> Layer<S> for ShuttleAuthLayer {
     fn layer(&self, inner: S) -> Self::Service {
         ShuttleAuthService {
             inner,
-            auth_uri: self.auth_uri.clone(),
             cache_manager: self.cache_manager.clone(),
+            auth_client: self.auth_client.clone(),
         }
     }
 }
@@ -66,8 +61,8 @@ impl<S> Layer<S> for ShuttleAuthLayer {
 #[derive(Clone)]
 pub struct ShuttleAuthService<S> {
     inner: S,
-    auth_uri: Uri,
     cache_manager: Arc<Box<dyn CacheManagement<Value = String>>>,
+    auth_client: AuthClient<Channel>,
 }
 
 impl<S> Service<Request<Body>> for ShuttleAuthService<S>
@@ -110,200 +105,148 @@ where
             });
         }
 
-        let forward_to_auth = match req.uri().path() {
-            "/login" | "/logout" => true,
-            other => other.starts_with("/users"),
-        };
+        // Enrich the current key | session
 
-        // If /users/reset-api-key is called, invalidate the cached JWT.
-        if req.uri().path() == "/users/reset-api-key" {
-            if let Some((cache_key, _)) = cache_key_and_token_req(&req) {
-                self.cache_manager.invalidate(&cache_key);
-            };
-        }
+        // TODO: read this page to get rid of this clone
+        // https://github.com/tower-rs/tower/blob/master/guides/building-a-middleware-from-scratch.md
+        let mut this = self.clone();
 
-        // If logout is called, invalidate the cached JWT for the callers cookie.
-        if req.uri().path() == "/logout" {
-            if let Ok(Some(cookie)) = req.headers().typed_try_get::<Cookie>() {
-                if let Some(cache_key) = cookie.get("shuttle.sid").map(|id| id.to_string()) {
-                    self.cache_manager.invalidate(&cache_key);
-                }
-            };
-        }
+        Box::pin(async move {
+            // Only if there is something to upgrade
+            if let Some((cache_key, token_request)) = cache_key_and_token_req(req.headers()) {
+                // let target_url = this.auth_uri.to_string();
+                // Check if the token is cached.
+                if let Some(token) = this.cache_manager.get(&cache_key) {
+                    trace!("JWT cache hit, setting token from cache on request");
 
-        if forward_to_auth {
-            let target_url = self.auth_uri.to_string();
+                    // Token is cached and not expired, return it in the response.
+                    req.headers_mut()
+                        .typed_insert(Authorization::bearer(&token).unwrap());
+                } else {
+                    trace!("JWT cache missed, sending convert token request");
 
-            let cx = Span::current().context();
-
-            global::get_text_map_propagator(|propagator| {
-                propagator.inject_context(&cx, &mut HeaderInjector(req.headers_mut()))
-            });
-
-            Box::pin(async move {
-                let response = PROXY_CLIENT
-                    .call(Ipv4Addr::LOCALHOST.into(), &target_url, req)
-                    .await;
-
-                match response {
-                    Ok(res) => {
-                        let (parts, body) = res.into_parts();
-                        let body =
-                            <Body as HttpBody>::map_err(body, axum::Error::new).boxed_unsync();
-
-                        Ok(Response::from_parts(parts, body))
-                    }
-                    Err(error) => {
-                        error!(?error, "failed to call authentication service");
-
-                        Ok(Response::builder()
-                            .status(StatusCode::SERVICE_UNAVAILABLE)
-                            .body(boxed(Body::empty()))
-                            .unwrap())
-                    }
-                }
-            })
-        } else {
-            // Enrich the current key | session
-
-            // TODO: read this page to get rid of this clone
-            // https://github.com/tower-rs/tower/blob/master/guides/building-a-middleware-from-scratch.md
-            let mut this = self.clone();
-
-            Box::pin(async move {
-                // Only if there is something to upgrade
-                if let Some((cache_key, token_request)) = cache_key_and_token_req(&req) {
-                    let target_url = this.auth_uri.to_string();
-
-                    // Check if the token is cached.
-                    if let Some(token) = this.cache_manager.get(&cache_key) {
-                        trace!("JWT cache hit, setting token from cache on request");
-
-                        // Token is cached and not expired, return it in the response.
-                        req.headers_mut()
-                            .typed_insert(Authorization::bearer(&token).unwrap());
-                    } else {
-                        trace!("JWT cache missed, sending convert token request");
-
-                        // Token is not in the cache, send a convert request.
-                        let token_response = match PROXY_CLIENT
-                            .call(Ipv4Addr::LOCALHOST.into(), &target_url, token_request)
-                            .await
-                        {
-                            Ok(res) => res,
-                            Err(error) => {
-                                error!(?error, "failed to call authentication service");
-
-                                return Ok(Response::builder()
-                                    .status(StatusCode::SERVICE_UNAVAILABLE)
-                                    .body(boxed(Body::empty()))
-                                    .unwrap());
-                            }
-                        };
-
-                        // Bubble up auth errors
-                        if token_response.status() != StatusCode::OK {
-                            let (parts, body) = token_response.into_parts();
-                            let body = body.map_err(axum::Error::new).boxed_unsync();
-
-                            return Ok(Response::from_parts(parts, body));
+                    // Token is not in the cache, send a convert request.
+                    let result = match token_request {
+                        ConvertRequestType::Cookie(cookie_request) => {
+                            this.auth_client.convert_cookie(cookie_request).await
                         }
-
-                        let body = match hyper::body::to_bytes(token_response.into_body()).await {
-                            Ok(body) => body,
-                            Err(error) => {
-                                error!(
-                                    error = &error as &dyn std::error::Error,
-                                    "failed to get response body"
-                                );
-
-                                return Ok(Response::builder()
-                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                    .body(boxed(Body::empty()))
-                                    .unwrap());
-                            }
-                        };
-
-                        let response = match serde_json::from_slice::<ConvertResponse>(&body) {
-                            Ok(response) => response,
-                            Err(error) => {
-                                error!(
-                                    error = &error as &dyn std::error::Error,
-                                    "failed to convert body to ConvertResponse"
-                                );
-
-                                return Ok(Response::builder()
-                                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                    .body(boxed(Body::empty()))
-                                    .unwrap());
-                            }
-                        };
-
-                        let bearer = Authorization::bearer(&response.token).expect("bearer token");
-
-                        this.cache_manager.insert(
-                            cache_key.as_str(),
-                            response.token,
-                            Duration::from_secs(CACHE_MINUTES * 60),
-                        );
-
-                        trace!("token inserted in cache, request proceeding");
-                        req.headers_mut().typed_insert(bearer);
+                        ConvertRequestType::Bearer(bearer_request) => {
+                            this.auth_client.convert_api_key(bearer_request).await
+                        }
                     };
-                }
 
-                match this.inner.call(req).await {
-                    Ok(response) => Ok(response),
-                    Err(error) => {
-                        error!(?error, "unexpected internal error from gateway");
+                    let token_response = match result {
+                        Ok(res) => res,
+                        Err(error) => {
+                            error!(?error, "failed to call authentication service");
 
-                        Ok(Response::builder()
-                            .status(StatusCode::SERVICE_UNAVAILABLE)
-                            .body(boxed(Body::empty()))
-                            .unwrap())
+                            return Ok(Response::builder()
+                                .status(StatusCode::SERVICE_UNAVAILABLE)
+                                .body(boxed(Body::empty()))
+                                .unwrap());
+                        }
                     }
+                    .into_inner();
+
+                    let bearer =
+                        Authorization::bearer(&token_response.token).expect("bearer token");
+
+                    this.cache_manager.insert(
+                        cache_key.as_str(),
+                        token_response.token,
+                        Duration::from_secs(CACHE_MINUTES * 60),
+                    );
+
+                    trace!("token inserted in cache, request proceeding");
+                    req.headers_mut().typed_insert(bearer);
+                };
+            }
+
+            match this.inner.call(req).await {
+                Ok(response) => Ok(response),
+                Err(error) => {
+                    error!(?error, "unexpected internal error from gateway");
+
+                    Ok(Response::builder()
+                        .status(StatusCode::SERVICE_UNAVAILABLE)
+                        .body(boxed(Body::empty()))
+                        .unwrap())
                 }
-            })
-        }
+            }
+        })
     }
 }
 
-fn cache_key_and_token_req(req: &Request<Body>) -> Option<(String, Request<Body>)> {
-    req.headers()
-        .typed_get::<Authorization<Bearer>>()
-        .map(|bearer| {
-            let cache_key = bearer.token().trim().to_string();
-            let token_request = make_token_request("/auth/key", bearer);
-            (cache_key, token_request)
-        })
-        .or_else(|| {
-            req.headers().typed_get::<Cookie>().and_then(|cookie| {
-                cookie.get("shuttle.sid").map(|id| {
-                    let cache_key = id.to_string();
-                    let token_request = make_token_request("/auth/session", cookie.clone());
-                    (cache_key, token_request)
-                })
-            })
-        })
+/// Return a [ConvertCookieRequest] or a [ApiKeyRequest] depending on the request headers.
+fn cache_key_and_token_req(headers: &HeaderMap) -> Option<(String, ConvertRequestType)> {
+    convert_cookie_request(headers).or_else(|| convert_api_key_request(headers))
 }
 
-fn make_token_request(uri: &str, header: impl Header) -> Request<Body> {
-    let mut token_request = Request::builder().uri(uri);
-    token_request
-        .headers_mut()
-        .expect("manual request to be valid")
-        .typed_insert(header);
+enum ConvertRequestType {
+    Cookie(TonicRequest<ConvertCookieRequest>),
+    Bearer(TonicRequest<ApiKeyRequest>),
+}
+
+fn convert_cookie_request(headers: &HeaderMap) -> Option<(String, ConvertRequestType)> {
+    let jar = CookieJar::from_headers(headers);
+
+    let Some(cookie) = jar.get("shuttle.sid") else {
+        return None;
+    };
+
+    let Ok(metadata_value) = MetadataValue::try_from(&cookie.to_string()) else {
+        return None;
+    };
+
+    let mut request = TonicRequest::new(ConvertCookieRequest::default());
+
+    let cache_key = cookie.value().to_string();
+
+    // TODO: deduplicate this.
+    request
+        .metadata_mut()
+        .insert(COOKIE.as_str(), metadata_value);
 
     let cx = Span::current().context();
 
     global::get_text_map_propagator(|propagator| {
-        propagator.inject_context(
-            &cx,
-            &mut HeaderInjector(token_request.headers_mut().expect("request to be valid")),
-        )
+        propagator.inject_context(&cx, &mut GrpcHeaderInjector(request.metadata_mut()))
     });
 
-    token_request
-        .body(Body::empty())
-        .expect("manual request to be valid")
+    Some((cache_key, ConvertRequestType::Cookie(request)))
+}
+
+fn convert_api_key_request(headers: &HeaderMap) -> Option<(String, ConvertRequestType)> {
+    let Some(bearer) = headers
+        .typed_get::<Authorization<Bearer>>()
+        .map(|bearer| bearer.token().trim().to_string()) else {
+            return None;
+        };
+
+    let mut request = TonicRequest::new(ApiKeyRequest {
+        api_key: bearer.clone(),
+    });
+
+    // TODO: deduplicate this.
+    let cx = Span::current().context();
+
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, &mut GrpcHeaderInjector(request.metadata_mut()))
+    });
+
+    Some((bearer, ConvertRequestType::Bearer(request)))
+}
+
+struct GrpcHeaderInjector<'a>(pub &'a mut tonic::metadata::MetadataMap);
+
+// TODO: test this.
+impl<'a> Injector for GrpcHeaderInjector<'a> {
+    /// Set a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs.
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(name) = MetadataKey::from_bytes(key.as_bytes()) {
+            if let Ok(val) = MetadataValue::try_from(&value) {
+                self.0.insert(name, val);
+            }
+        }
+    }
 }

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -10,7 +10,7 @@ use futures::future::BoxFuture;
 use http::{header::COOKIE, HeaderMap, Request, StatusCode};
 use hyper::Body;
 use opentelemetry::{global, propagation::Injector};
-use shuttle_common::backends::cache::CacheManagement;
+use shuttle_common::backends::{auth::COOKIE_NAME, cache::CacheManagement};
 use shuttle_proto::auth::{auth_client::AuthClient, ApiKeyRequest, ConvertCookieRequest};
 use tonic::{metadata::MetadataKey, Request as TonicRequest};
 use tonic::{metadata::MetadataValue, transport::Channel};
@@ -188,7 +188,7 @@ enum ConvertRequestType {
 fn convert_cookie_request(headers: &HeaderMap) -> Option<(String, ConvertRequestType)> {
     let jar = CookieJar::from_headers(headers);
 
-    let Some(cookie) = jar.get("shuttle.sid") else {
+    let Some(cookie) = jar.get(COOKIE_NAME) else {
         return None;
     };
 

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -12,12 +12,15 @@ use futures::{
 };
 use http::{header::COOKIE, HeaderMap, Request, StatusCode};
 use hyper::Body;
-use shuttle_common::{backends::{auth::COOKIE_NAME, cache::CacheManagement}, claims::InjectPropagation};
+use shuttle_common::{
+    backends::{auth::COOKIE_NAME, cache::CacheManagement},
+    claims::InjectPropagation,
+};
 use shuttle_proto::auth::{
     auth_client::AuthClient, ApiKeyRequest, ConvertCookieRequest, TokenResponse,
 };
-use tonic::{Request as TonicRequest, Status};
 use tonic::{metadata::MetadataValue, transport::Channel};
+use tonic::{Request as TonicRequest, Status};
 use tower::{Layer, Service};
 use tracing::{error, trace};
 
@@ -184,9 +187,7 @@ fn cache_key_and_token_req<'a>(
         impl Future<Output = Result<tonic::Response<TokenResponse>, Status>> + 'a,
     >,
 )> {
-    let Some((cache_key, request)) = 
-        convert_cookie_request(headers).or_else(|| convert_api_key_request(headers)) else {
-        
+    let Some((cache_key, request)) = convert_cookie_request(headers).or_else(|| convert_api_key_request(headers)) else {
         // The headers contain neither a bearer token nor a cookie.
         return None;
     };
@@ -245,4 +246,3 @@ fn convert_api_key_request(headers: &HeaderMap) -> Option<(String, ConvertReques
 
     Some((bearer, ConvertRequestType::Bearer(request)))
 }
-

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -984,7 +984,11 @@ impl Modify for SecurityAddon {
         destroy_projects,
         get_load_admin,
         delete_load_admin,
-        login
+        login,
+        logout,
+        get_user,
+        post_user,
+        reset_api_key
     ),
     modifiers(&SecurityAddon),
     components(schemas(
@@ -992,7 +996,9 @@ impl Modify for SecurityAddon {
         shuttle_common::models::stats::LoadResponse,
         shuttle_common::models::project::AdminResponse,
         shuttle_common::models::stats::LoadResponse,
-        shuttle_common::models::project::State
+        shuttle_common::models::project::State,
+        crate::AccountName,
+        shuttle_common::claims::AccountTier
     ))
 )]
 pub struct ApiDoc;

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -169,6 +169,7 @@ async fn get_projects_list(
 #[utoipa::path(
     post,
     path = "/projects/{project_name}",
+    request_body = shuttle_common::models::project::Config,
     responses(
         (status = 200, description = "Successfully created a specific project.", body = shuttle_common::models::project::Response),
         (status = 500, description = "Server internal error.")
@@ -998,7 +999,8 @@ impl Modify for SecurityAddon {
         shuttle_common::models::stats::LoadResponse,
         shuttle_common::models::project::State,
         crate::AccountName,
-        shuttle_common::claims::AccountTier
+        shuttle_common::claims::AccountTier,
+        shuttle_common::models::project::Config
     ))
 )]
 pub struct ApiDoc;

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -647,7 +647,7 @@ async fn get_projects(
         (status = 503, description = "Server not reachable.")
     ),
     params(
-        ("account_name" = AccountName, Path, description = "The account name of the user to log in."),
+        ("account_name" = String, Path, description = "The account name of the user to log in."),
     ),
     security(
         ("api_key" = [])

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -9,7 +9,8 @@ use axum::TypedHeader;
 use serde::{Deserialize, Serialize};
 use shuttle_common::claims::{Claim, Scope};
 use shuttle_common::ApiKey;
-use tracing::{debug, trace, Span};
+use tonic::metadata::{MetadataMap, MetadataValue};
+use tracing::{debug, error, trace, Span};
 
 use crate::api::latest::RouterState;
 use crate::{AccountName, Error, ErrorKind, ProjectName};
@@ -125,4 +126,44 @@ where
 
         Ok(Key(key))
     }
+}
+
+/// Utility function to extract a "set-cookie" cookie from a tonic [MetadataMap], that also takes
+/// a request name for debug logging.
+pub(crate) fn extract_metadata_cookie<'a>(
+    metadata: &'a MetadataMap,
+    request_name: &str,
+) -> Result<&'a str, Error> {
+    metadata.get("set-cookie")
+    .ok_or({
+        debug!("failed to get set-cookie cookie from {request_name} request");
+        Error::from_kind(ErrorKind::Internal)
+    })?
+    .to_str()
+    .map_err(|error| {
+        debug!(error = ?error, "set-cookie received from {request_name} request has invalid metadata characters");
+        Error::from_kind(ErrorKind::Internal)
+    })
+}
+
+/// Utility function that inserts a bearer token in a tonic request [MetadataMap], useful for
+/// endpoints that expect a bearer token in the following format:
+///
+/// `authorization Bearer <api-key>`
+pub(crate) fn insert_metadata_bearer_token(
+    metadata: &mut MetadataMap,
+    key: Key,
+) -> Result<(), Error> {
+    let bearer: MetadataValue<_> = format!("Bearer {}", shuttle_common::ApiKey::from(key).as_ref())
+        .parse()
+        .map_err(|error| {
+            // This should be impossible since an ApiKey can only contain valid valid characters.
+            error!(error = ?error, "api-key contains invalid metadata characters");
+
+            Error::from_kind(ErrorKind::Internal)
+        })?;
+
+    metadata.insert("authorization", bearer);
+
+    Ok(())
 }

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -95,6 +95,8 @@ where
 }
 
 /// A wrapper around [ApiKey] so we can implement [FromRequestParts] for it.
+/// This extractor expects an [ApiKey], so if used after the ShuttleAuthLayer
+/// is applied it will fail, since the bearer token will become a JWT.
 pub struct Key(ApiKey);
 
 impl From<Key> for ApiKey {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -773,7 +773,7 @@ pub mod tests {
             .with_service(Arc::clone(&service))
             .with_sender(log_out.clone())
             .with_default_routes()
-            .with_auth_service(world.context().auth_uri)
+            .with_auth_service(&world.context().auth_uri)
             .await
             .binding_to(world.args.control);
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -201,11 +201,6 @@ impl<'de> Deserialize<'de> for AccountName {
     }
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct LoginRequest {
-    account_name: AccountName,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectDetails {
     pub project_name: ProjectName,

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -201,6 +201,11 @@ impl<'de> Deserialize<'de> for AccountName {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct LoginRequest {
+    account_name: AccountName,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectDetails {
     pub project_name: ProjectName,

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -778,6 +778,7 @@ pub mod tests {
             .with_sender(log_out.clone())
             .with_default_routes()
             .with_auth_service(world.context().auth_uri)
+            .await
             .binding_to(world.args.control);
 
         let user = UserServiceBuilder::new()

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -18,6 +18,7 @@ use service::ContainerSettings;
 use shuttle_common::models::error::{ApiError, ErrorKind};
 use tokio::sync::mpsc::error::SendError;
 use tracing::error;
+use utoipa::ToSchema;
 
 pub mod acme;
 pub mod api;
@@ -172,7 +173,7 @@ impl std::fmt::Display for ProjectName {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type, Serialize, ToSchema)]
 #[sqlx(transparent)]
 pub struct AccountName(String);
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -192,6 +192,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
     let api_handle = api_builder
         .with_default_routes()
         .with_auth_service(args.context.auth_uri)
+        .await
         .with_default_traces()
         .serve();
 

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -191,7 +191,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
 
     let api_handle = api_builder
         .with_default_routes()
-        .with_auth_service(args.context.auth_uri)
+        .with_auth_service(&args.context.auth_uri)
         .await
         .with_default_traces()
         .serve();

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -18,7 +18,7 @@ tracing = { workspace = true }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["claims", "error", "service", "wasm"]
+features = ["claims", "error", "service", "wasm", "models"]
 
 [dev-dependencies]
 tonic-build = { workspace = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -7,6 +7,7 @@ description = "Library for all the gRPC definitions used by shuttle"
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 chrono = { workspace = true }
 home = { workspace = true }
 prost = { workspace = true }
@@ -18,7 +19,7 @@ tracing = { workspace = true }
 
 [dependencies.shuttle-common]
 workspace = true
-features = ["claims", "error", "service", "wasm", "models"]
+features = ["claims", "error", "service", "wasm", "models", "backend"]
 
 [dev-dependencies]
 tonic-build = { workspace = true }

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -61,8 +61,6 @@ message PublicKeyResponse {
 
 message PublicKeyRequest {}
 
-message Request {}
-
 message ConvertCookieRequest {}
 
 message LogoutRequest {}

--- a/proto/src/generated/auth.rs
+++ b/proto/src/generated/auth.rs
@@ -53,9 +53,6 @@ pub struct PublicKeyResponse {
 pub struct PublicKeyRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Request {}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConvertCookieRequest {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -278,5 +278,17 @@ pub mod resource_recorder {
 }
 
 pub mod auth {
+    use shuttle_common::models::user::Response;
+
     include!("generated/auth.rs");
+
+    impl From<UserResponse> for Response {
+        fn from(value: UserResponse) -> Self {
+            Response {
+                name: value.account_name,
+                key: value.key,
+                account_tier: value.account_tier,
+            }
+        }
+    }
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -278,15 +278,24 @@ pub mod resource_recorder {
 }
 
 pub mod auth {
-    use anyhow::Context;
-    use shuttle_common::models::user::Response;
+    use std::sync::Arc;
     use std::time::Duration;
+
+    use anyhow::Context;
+    use async_trait::async_trait;
+    use shuttle_common::backends::auth::{PublicKeyFn, PublicKeyFnError, PUBLIC_KEY_CACHE_KEY};
+    use shuttle_common::backends::cache::{CacheManagement, CacheManager};
+    use shuttle_common::claims::InjectPropagation;
+    use shuttle_common::claims::InjectPropagationLayer;
+    use shuttle_common::models::user::Response;
+    use tonic::transport::Channel;
+    use tonic::transport::Endpoint;
     use tonic::transport::Uri;
+    use tonic::Request;
+    use tower::ServiceBuilder;
+    use tracing::trace;
 
     use self::auth_client::AuthClient;
-    use shuttle_common::claims::{InjectPropagation, InjectPropagationLayer};
-    use tonic::transport::{Channel, Endpoint};
-    use tower::ServiceBuilder;
 
     include!("generated/auth.rs");
 
@@ -315,5 +324,53 @@ pub mod auth {
             .service(channel);
 
         Ok(AuthClient::new(channel))
+    }
+
+    #[derive(Clone)]
+    pub struct AuthPublicKey {
+        auth_client: AuthClient<InjectPropagation<Channel>>,
+        cache_manager: Arc<Box<dyn CacheManagement<Value = Vec<u8>>>>,
+    }
+
+    impl AuthPublicKey {
+        pub fn new(auth_client: AuthClient<InjectPropagation<Channel>>) -> Self {
+            let public_key_cache_manager = CacheManager::new(1);
+            Self {
+                auth_client,
+                cache_manager: Arc::new(Box::new(public_key_cache_manager)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PublicKeyFn for AuthPublicKey {
+        type Error = PublicKeyFnError;
+
+        async fn public_key(&self) -> Result<Vec<u8>, Self::Error> {
+            if let Some(public_key) = self.cache_manager.get(PUBLIC_KEY_CACHE_KEY) {
+                trace!("found public key in the cache, returning it");
+
+                Ok(public_key)
+            } else {
+                let request = Request::new(PublicKeyRequest::default());
+
+                let mut client = self.auth_client.clone();
+
+                let response = client
+                    .public_key(request)
+                    .await
+                    .context("failed to retrieve public key from auth service")?
+                    .into_inner();
+
+                trace!("inserting public key from auth service into cache");
+                self.cache_manager.insert(
+                    PUBLIC_KEY_CACHE_KEY,
+                    response.public_key.clone(),
+                    std::time::Duration::from_secs(60),
+                );
+
+                Ok(response.public_key)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This PR refactors gateway to use the new grpc auth client, passing the client into the axum state and using it to call new auth endpoints in gateway that used to be redirected in the auth layer. The auth layer will now only convert cookies or keys (if they are not cached). We need the new auth client in all services that implement the jwt auth layer, so I have added it to them and re-implemented PublicKeyFn in shuttle-proto (we cannot depend on proto in common so we can't have the client there).

TODO:

- [x] Final testing
- [x] Error handling
- [x] Deduplication and cleanups in handlers and auth layer, and shared functionality between auth and gateway
- [x] Openapi
- [x] public key function should use auth client

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Testing this with the gateway tests is tricky since they expect a deployer, and we currently only have a minimal one on this branch. The one on main can't be used either since it doesn't have the new auth service. I added a new test that does work that tests all the new endpoints, though. I also updated the openapi attributes and used that for testing, and everything seems to be working as expected. 

To test with gateway tests:
Run gateway tests as instructed in gateway readme after following contributing.md flow.

To test with openapi:
Start the auth service on port 8008 (first init an admin user and copy the key).
Move the swagger endpoint out of the admin_routes to unguarded routes.
Go to `http://localhost:8001/swagger-ui/#` and test out the routes, hit the padlock on the right to enter your API-key you inserted into auth. The login flow also works in swagger.
