### PR TITLE
fix: remove vendored-openssl from CI and broken axum test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,8 +401,7 @@ jobs:
           command: |
             # From https://github.com/briansmith/ring/issues/1414#issuecomment-1055177218
             export CC_aarch64_unknown_linux_musl=clang
-            # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
-            cargo build --release --package cargo-shuttle --features vendored-openssl --target << parameters.target >>
+            cargo build --release --package cargo-shuttle --target << parameters.target >>
       - make-artifact:
           target: << parameters.target >>
   build-binaries-windows:
@@ -427,8 +426,7 @@ jobs:
             # From https://github.com/alexcrichton/openssl-src-rs/issues/45
             # Because of https://github.com/openssl/openssl/issues/9048
             $env:OPENSSL_SRC_PERL="C:\Strawberry\perl\bin\perl.exe"
-            # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
-            ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --features vendored-openssl --target x86_64-pc-windows-msvc
+            ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --target x86_64-pc-windows-msvc
           shell: powershell.exe
       - make-artifact:
           target: x86_64-pc-windows-msvc
@@ -445,8 +443,7 @@ jobs:
       - run:
           name: Build
           command: |
-            # "vendored-openssl" is from https://github.com/cross-rs/cross/issues/229#issuecomment-597898074
-            cargo build --release --package cargo-shuttle --features vendored-openssl --target x86_64-apple-darwin
+            cargo build --release --package cargo-shuttle --target x86_64-apple-darwin
       - make-artifact:
           target: x86_64-apple-darwin
   publish-github-release:

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -154,7 +154,7 @@ async fn axum_static_files() {
     let client = reqwest::Client::new();
 
     let request_text = client
-        .get(format!("{url}/hello"))
+        .get(url.clone())
         .send()
         .await
         .unwrap()
@@ -164,7 +164,14 @@ async fn axum_static_files() {
 
     assert_eq!(request_text, "Hello, world!");
 
-    let request_text = client.get(url).send().await.unwrap().text().await.unwrap();
+    let request_text = client
+        .get(format!("{url}/assets"))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
 
     assert!(
         request_text.contains("This is an example of serving static files with axum and shuttle.")


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We forgot to remove this before merging the rustls PR, so it caused production CI binary builds to fail. A cleanup PR was also merged in the examples that changed an endpoint we used for testing in cargo-shuttle.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->


