### PR TITLE
fix: Don't deploy .git folder to save space

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1224,6 +1224,8 @@ impl Shuttle {
 
         // Make sure the target folder is excluded at all times
         let overrides = OverrideBuilder::new(working_directory)
+            .add("!.git/")
+            .context("add `!.git/` override")?
             .add("!target/")
             .context("add `!target/` override")?
             .build()

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1222,7 +1222,7 @@ impl Shuttle {
             .parent()
             .context("get parent directory of crate")?;
 
-        // Make sure the target folder is excluded at all times
+        // Make sure the target  and .git folders are excluded at all times
         let overrides = OverrideBuilder::new(working_directory)
             .add("!.git/")
             .context("add `!.git/` override")?


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Moved this to a separate PR instead of together with unrelated stuff in #1012 

Original comment:

Hardcode to not upload the .git folder at deploy (the metadata is gathered before upload). This can shrink the upload size by a bit. If a project uses the local repo at build time for inserting, say, commit ID or something, this will break it. So perhaps add an option to include it? Or make a bunch of metadata available as a resource, like https://github.com/shuttle-hq/shuttle/issues/562

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->


