### PR TITLE
chore: cargo-shuttle v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shuttle"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shuttle"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We recently set the body size limit for archives sent with `deploy` to 50MB, but a lot of .git repositories are larger than this. We don't need to send the .git repositories, however, so it was excluded in https://github.com/shuttle-hq/shuttle/pull/1036. We will release a patch version of the cargo-shuttle CLI that implements that fix.



