### PR TITLE
[scaling] deployer: added project events streaming

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -20,8 +20,8 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "io-util", "process", "rt-multi-thread"] }
-tokio-stream = { version = "0.1.14", optional = true }
-tokio-tar = { version = "0.3.0", optional = true }
+tokio-stream = { version = "0.1.14" }
+tokio-tar = { version = "0.3.0" }
 toml = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -411,7 +411,7 @@ mod tests {
     fn to_token_and_back() {
         let mut claim = Claim::new(
             "ferries".to_string(),
-            vec![Scope::DeploymentRead, Scope::Project],
+            vec![Scope::DeploymentRead, Scope::ProjectRead],
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -433,7 +433,7 @@ mod tests {
     async fn authorization_layer() {
         let claim = Claim::new(
             "ferries".to_string(),
-            vec![Scope::DeploymentRead, Scope::Project],
+            vec![Scope::DeploymentRead, Scope::ProjectRead],
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -455,7 +455,7 @@ mod tests {
                             let public_key = public_key.clone();
                             async move { public_key.clone() }
                         }))
-                        .layer(ScopedLayer::new(vec![Scope::Project])),
+                        .layer(ScopedLayer::new(vec![Scope::ProjectRead])),
                 );
 
         //////////////////////////////////////////////////////////////////////////
@@ -531,7 +531,7 @@ mod tests {
     fn hack_symmetric_alg() {
         let claim = Claim::new(
             "hacker-hs256".to_string(),
-            vec![Scope::DeploymentRead, Scope::Project],
+            vec![Scope::DeploymentRead, Scope::ProjectRead],
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -571,7 +571,7 @@ mod tests {
     fn hack_no_alg() {
         let claim = Claim::new(
             "hacker-no-alg".to_string(),
-            vec![Scope::DeploymentRead, Scope::Project],
+            vec![Scope::DeploymentRead, Scope::ProjectRead],
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -603,7 +603,7 @@ mod tests {
     fn hack_no_sig() {
         let claim = Claim::new(
             "hacker-no-sig".to_string(),
-            vec![Scope::DeploymentRead, Scope::Project],
+            vec![Scope::DeploymentRead, Scope::ProjectRead],
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -626,7 +626,7 @@ mod tests {
     fn hack_bad_iss() {
         let claim = Claim::new(
             "hacker-iss".to_string(),
-            vec![Scope::DeploymentRead, Scope::Project],
+            vec![Scope::DeploymentRead, Scope::ProjectRead],
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -50,10 +50,10 @@ pub enum Scope {
     ServiceWrite,
 
     /// Read the status of a project
-    Project,
+    ProjectRead,
 
     /// Create a new project
-    ProjectCreate,
+    ProjectWrite,
 
     /// Get the resources for a project
     Resources,
@@ -102,8 +102,8 @@ impl ScopeBuilder {
             Scope::Logs,
             Scope::ServiceRead,
             Scope::ServiceWrite,
-            Scope::Project,
-            Scope::ProjectCreate,
+            Scope::ProjectRead,
+            Scope::ProjectWrite,
             Scope::Resources,
             Scope::ResourcesWrite,
             Scope::Secret,

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -37,6 +37,7 @@ sqlx = { workspace = true, features = [
 strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "fs"] }
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/deployer/migrations/0000_init.sql
+++ b/deployer/migrations/0000_init.sql
@@ -3,6 +3,8 @@ CREATE TABLE IF NOT EXISTS services (
   name TEXT NOT NULL,                  -- The service name
   state_variant TEXT NOT NULL,         -- The service state variant
   state JSON NOT NULL                  -- The serialized docker container inspect state
+  project_id TEXT NOT NULL             -- The project id that owns the service
+  last_update INTEGER NOT NULL         -- The timestamp of the last service update
 );
 
 CREATE TABLE IF NOT EXISTS deployments (

--- a/deployer/migrations/0000_init.sql
+++ b/deployer/migrations/0000_init.sql
@@ -2,8 +2,8 @@ CREATE TABLE IF NOT EXISTS services (
   id TEXT PRIMARY KEY,                 -- The service id in ulid format
   name TEXT NOT NULL,                  -- The service name
   state_variant TEXT NOT NULL,         -- The service state variant
-  state JSON NOT NULL                  -- The serialized docker container inspect state
-  project_id TEXT NOT NULL             -- The project id that owns the service
+  state JSON NOT NULL,                 -- The serialized docker container inspect state
+  project_id TEXT NOT NULL,            -- The project id that owns the service
   last_update INTEGER NOT NULL         -- The timestamp of the last service update
 );
 

--- a/deployer/src/dal.rs
+++ b/deployer/src/dal.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use axum::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use sqlx::migrate::MigrateDatabase;
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteRow};
 use sqlx::types::Json as SqlxJson;
@@ -173,16 +173,18 @@ impl Dal for Sqlite {
             name,
             state_variant,
             state,
+            last_update,
         } = service;
 
         if self.service(&id).await.is_ok() {
             return Ok(false);
         }
 
-        sqlx::query("INSERT INTO services (id, name, state_variant, state) VALUES (?, ?, ?, ?)")
+        sqlx::query("INSERT INTO services (id, name, state_variant, state, last_update) VALUES (?, ?, ?, ?, ?)")
             .bind(id.to_string())
             .bind(name)
             .bind(state_variant)
+            .bind(last_update.timestamp())
             .bind(SqlxJson(state))
             .execute(&self.pool)
             .await?;
@@ -227,9 +229,10 @@ impl Dal for Sqlite {
         state: ServiceState,
     ) -> Result<(), DalError> {
         let state_variant = state.to_string();
-        query("UPDATE services SET state = ?1, state_variant = ?2 WHERE id = ?3")
+        query("UPDATE services SET state = ?1, state_variant = ?2, last_update = ?3 WHERE id = ?4")
             .bind(SqlxJson(state.clone()))
             .bind(state_variant)
+            .bind(Utc::now().timestamp())
             .bind(service_id.to_string())
             .execute(&self.pool)
             .await
@@ -257,6 +260,7 @@ pub struct Service {
     pub name: String,
     pub state_variant: String,
     pub state: ServiceState,
+    pub last_update: DateTime<Utc>,
 }
 
 impl FromRow<'_, SqliteRow> for Service {
@@ -267,6 +271,11 @@ impl FromRow<'_, SqliteRow> for Service {
             name: row.try_get("name")?,
             state_variant: row.try_get("state_variant")?,
             state: row.try_get::<SqlxJson<ServiceState>, _>("state")?.0,
+            last_update: DateTime::<Utc>::from_utc(
+                NaiveDateTime::from_timestamp_opt(row.try_get("last_update")?, 0)
+                    .expect("to get a naive date time out of the last_update field of the service"),
+                Utc,
+            ),
         })
     }
 }
@@ -290,7 +299,12 @@ impl FromRow<'_, SqliteRow> for Deployment {
                 .map_err(|e| sqlx::Error::Decode(Box::new(e)))?,
             service_id: Ulid::from_string(row.try_get("service_id")?)
                 .map_err(|e| sqlx::Error::Decode(Box::new(e)))?,
-            last_update: row.try_get("last_update")?,
+            last_update: DateTime::<Utc>::from_utc(
+                NaiveDateTime::from_timestamp_opt(row.try_get("last_update")?, 0).expect(
+                    "to get a naive date time out of the last_update field of the deployment",
+                ),
+                Utc,
+            ),
             is_next: row.try_get("is_next")?,
             git_commit_hash: row.try_get("git_commit_hash")?,
             git_commit_message: row.try_get("git_commit_message")?,

--- a/deployer/src/dal.rs
+++ b/deployer/src/dal.rs
@@ -185,9 +185,9 @@ impl Dal for Sqlite {
             .bind(id.to_string())
             .bind(name)
             .bind(state_variant)
+            .bind(SqlxJson(state))
             .bind(last_update.timestamp())
             .bind(project_id.to_string())
-            .bind(SqlxJson(state))
             .execute(&self.pool)
             .await?;
         Ok(true)
@@ -217,7 +217,7 @@ impl Dal for Sqlite {
                     FROM deployments AS d
                     JOIN services AS s ON s.id = d.service_id
                     WHERE s.state_variant = ?
-                    ORDER BY last_update"#,
+                    ORDER BY d.last_update"#,
         )
         .bind(ServiceRunning::name())
         .fetch_all(&self.pool)

--- a/deployer/src/deployment.rs
+++ b/deployer/src/deployment.rs
@@ -32,7 +32,7 @@ use crate::dal::DalError;
 
 type RunReceiver = mpsc::Receiver<RunnableDeployment>;
 
-const USER_SERVICE_DEFAULT_PORT: u16 = 8080;
+pub const USER_SERVICE_DEFAULT_PORT: u16 = 8080;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -233,6 +233,7 @@ impl<D: Dal + Send + Sync + 'static> DeployerService<D> {
                 name: runnable_deployment.service_name.clone(),
                 state_variant: creating.to_string(),
                 state: creating,
+                last_update: Utc::now(),
             };
             self.dal
                 .insert_service_if_absent(service)

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -443,9 +443,11 @@ impl<D: Dal + Sync + 'static> Deployer for DeployerService<D> {
     #[instrument(skip_all)]
     async fn subscribe_projects(
         &self,
-        request: tonic::Request<SubscribeProjectsRequest>,
+        _request: tonic::Request<SubscribeProjectsRequest>,
     ) -> TonicResult<tonic::Response<Self::SubscribeProjectsStream>, tonic::Status> {
-        request.verify(Scope::Admin)?;
+        // We can not authorize yet to easily these requests given they need machine-to-machine authorization.
+        // TODO: add support for this in the auth component.
+        // request.verify(Scope::Admin)?;
         let events_rx = self.project_events_channel_rx.lock().await.take();
 
         if let Some(mut events_rx) = events_rx {
@@ -501,9 +503,11 @@ impl<D: Dal + Sync + 'static> Deployer for DeployerService<D> {
     #[instrument(skip_all)]
     async fn unsubscribe_projects(
         &self,
-        request: tonic::Request<UnsubscribeProjectsRequest>,
+        _request: tonic::Request<UnsubscribeProjectsRequest>,
     ) -> TonicResult<tonic::Response<UnsubscribeProjectsResponse>, tonic::Status> {
-        request.verify(Scope::Admin)?;
+        // We can not authorize yet to easily these requests given they need machine-to-machine authorization.
+        // TODO: add support for this in the auth component.
+        // request.verify(Scope::Admin)?;
         let mut guard_rx = self.project_events_channel_rx.lock().await;
         let mut guard_tx = self.project_events_channel_tx.lock().await;
         let (tx, rx) = mpsc::unbounded_channel::<ProjectEvent>();

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -521,11 +521,10 @@ pub mod tests {
         }
 
         pub fn create_user(&self, user: &str) -> String {
-            self.auth_service
-                .lock()
-                .unwrap()
-                .users
-                .insert(user.to_string(), vec![Scope::Project, Scope::ProjectCreate]);
+            self.auth_service.lock().unwrap().users.insert(
+                user.to_string(),
+                vec![Scope::ProjectRead, Scope::ProjectWrite],
+            );
 
             user.to_string()
         }

--- a/proto/deployer.proto
+++ b/proto/deployer.proto
@@ -4,7 +4,8 @@ package deployer;
 service Deployer {
   rpc Deploy(DeployRequest) returns (DeployResponse);
   rpc DestroyDeployment(DestroyDeploymentRequest) returns (DestroyDeploymentResponse);
-  rpc TargetIp(TargetIpRequest) returns (TargetIpResponse);
+  rpc SubscribeProjects(SubscribeProjectsRequest) returns (stream ProjectEvent);
+  rpc UnsubscribeProjects(UnsubscribeProjectsRequest) returns (UnsubscribeProjectsResponse);
 }
 
 message Deployment {
@@ -34,17 +35,17 @@ message DestroyDeploymentRequest {
 }
 
 message DestroyDeploymentResponse {}
+message SubscribeProjectsRequest {}
+message UnsubscribeProjectsRequest {}
+message UnsubscribeProjectsResponse {}
 
-message TargetIpRequest {
-  // The service id we request the target ip for.
-  string service_id = 1;
-  // The project id we request the target ip for
-  string project_id = 2;
-  // If the service_id is on the stopped code path, reinstate it.
-  bool instate = 3;
+message ProjectChange {
+  string state_variant = 1;
+  optional string socket_addr = 2;
 }
 
-message TargetIpResponse {
-  // The target ip of the requested service.
-  string target_ip = 1;
+message ProjectEvent {
+  string service_id = 1;
+  string project_id = 2;
+  ProjectChange change = 3;
 }

--- a/proto/deployer.proto
+++ b/proto/deployer.proto
@@ -9,14 +9,15 @@ service Deployer {
 
 message Deployment {
   string service_id = 1;
-  string service_name = 2;
-  bool is_next = 3;
-  uint32 idle_minutes = 4;
-  string image_name = 5;
-  optional string git_commit_message = 6;
-  optional string git_commit_hash = 7;
-  optional string git_branch = 8;
-  optional bool git_dirty = 9;
+  string project_id = 2;
+  string service_name = 3;
+  bool is_next = 4;
+  uint32 idle_minutes = 5;
+  string image_name = 6;
+  optional string git_commit_message = 7;
+  optional string git_commit_hash = 8;
+  optional string git_branch = 9;
+  optional bool git_dirty = 10;
 }
 
 message DeployRequest {
@@ -35,7 +36,7 @@ message DestroyDeploymentRequest {
 message DestroyDeploymentResponse {}
 
 message TargetIpRequest {
-  // The service id we request the target ip for
+  // The service id we request the target ip for.
   string service_id = 1;
   // The project id we request the target ip for
   string project_id = 2;

--- a/proto/src/generated/deployer.rs
+++ b/proto/src/generated/deployer.rs
@@ -46,29 +46,36 @@ pub struct DestroyDeploymentRequest {
 pub struct DestroyDeploymentResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TargetIpRequest {
-    /// The service id we request the target ip for.
+pub struct SubscribeProjectsRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnsubscribeProjectsRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnsubscribeProjectsResponse {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ProjectChange {
     #[prost(string, tag = "1")]
-    pub service_id: ::prost::alloc::string::String,
-    /// The project id we request the target ip for
-    #[prost(string, tag = "2")]
-    pub project_id: ::prost::alloc::string::String,
-    /// If the service_id is on the stopped code path, reinstate it.
-    #[prost(bool, tag = "3")]
-    pub instate: bool,
+    pub state_variant: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "2")]
+    pub socket_addr: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TargetIpResponse {
-    /// The target ip of the requested service.
+pub struct ProjectEvent {
     #[prost(string, tag = "1")]
-    pub target_ip: ::prost::alloc::string::String,
+    pub service_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub project_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "3")]
+    pub change: ::core::option::Option<ProjectChange>,
 }
 /// Generated client implementations.
 pub mod deployer_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::http::Uri;
     use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct DeployerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -112,8 +119,9 @@ pub mod deployer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + Send + Sync,
         {
             DeployerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -136,12 +144,15 @@ pub mod deployer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeployRequest>,
         ) -> Result<tonic::Response<super::DeployResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/deployer.Deployer/Deploy");
             self.inner.unary(request.into_request(), path, codec).await
@@ -150,28 +161,60 @@ pub mod deployer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DestroyDeploymentRequest>,
         ) -> Result<tonic::Response<super::DestroyDeploymentResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/deployer.Deployer/DestroyDeployment");
+            let path = http::uri::PathAndQuery::from_static(
+                "/deployer.Deployer/DestroyDeployment",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
-        pub async fn target_ip(
+        pub async fn subscribe_projects(
             &mut self,
-            request: impl tonic::IntoRequest<super::TargetIpRequest>,
-        ) -> Result<tonic::Response<super::TargetIpResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::new(
-                    tonic::Code::Unknown,
-                    format!("Service was not ready: {}", e.into()),
-                )
-            })?;
+            request: impl tonic::IntoRequest<super::SubscribeProjectsRequest>,
+        ) -> Result<
+            tonic::Response<tonic::codec::Streaming<super::ProjectEvent>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/deployer.Deployer/TargetIp");
+            let path = http::uri::PathAndQuery::from_static(
+                "/deployer.Deployer/SubscribeProjects",
+            );
+            self.inner.server_streaming(request.into_request(), path, codec).await
+        }
+        pub async fn unsubscribe_projects(
+            &mut self,
+            request: impl tonic::IntoRequest<super::UnsubscribeProjectsRequest>,
+        ) -> Result<tonic::Response<super::UnsubscribeProjectsResponse>, tonic::Status> {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/deployer.Deployer/UnsubscribeProjects",
+            );
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -191,10 +234,20 @@ pub mod deployer_server {
             &self,
             request: tonic::Request<super::DestroyDeploymentRequest>,
         ) -> Result<tonic::Response<super::DestroyDeploymentResponse>, tonic::Status>;
-        async fn target_ip(
+        /// Server streaming response type for the SubscribeProjects method.
+        type SubscribeProjectsStream: futures_core::Stream<
+                Item = Result<super::ProjectEvent, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn subscribe_projects(
             &self,
-            request: tonic::Request<super::TargetIpRequest>,
-        ) -> Result<tonic::Response<super::TargetIpResponse>, tonic::Status>;
+            request: tonic::Request<super::SubscribeProjectsRequest>,
+        ) -> Result<tonic::Response<Self::SubscribeProjectsStream>, tonic::Status>;
+        async fn unsubscribe_projects(
+            &self,
+            request: tonic::Request<super::UnsubscribeProjectsRequest>,
+        ) -> Result<tonic::Response<super::UnsubscribeProjectsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct DeployerServer<T: Deployer> {
@@ -215,7 +268,10 @@ pub mod deployer_server {
                 send_compression_encodings: Default::default(),
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -243,7 +299,10 @@ pub mod deployer_server {
         type Response = http::Response<tonic::body::BoxBody>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -252,9 +311,13 @@ pub mod deployer_server {
                 "/deployer.Deployer/Deploy" => {
                     #[allow(non_camel_case_types)]
                     struct DeploySvc<T: Deployer>(pub Arc<T>);
-                    impl<T: Deployer> tonic::server::UnaryService<super::DeployRequest> for DeploySvc<T> {
+                    impl<T: Deployer> tonic::server::UnaryService<super::DeployRequest>
+                    for DeploySvc<T> {
                         type Response = super::DeployResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeployRequest>,
@@ -271,10 +334,11 @@ pub mod deployer_server {
                         let inner = inner.0;
                         let method = DeploySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -283,17 +347,23 @@ pub mod deployer_server {
                 "/deployer.Deployer/DestroyDeployment" => {
                     #[allow(non_camel_case_types)]
                     struct DestroyDeploymentSvc<T: Deployer>(pub Arc<T>);
-                    impl<T: Deployer> tonic::server::UnaryService<super::DestroyDeploymentRequest>
-                        for DestroyDeploymentSvc<T>
-                    {
+                    impl<
+                        T: Deployer,
+                    > tonic::server::UnaryService<super::DestroyDeploymentRequest>
+                    for DestroyDeploymentSvc<T> {
                         type Response = super::DestroyDeploymentResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DestroyDeploymentRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).destroy_deployment(request).await };
+                            let fut = async move {
+                                (*inner).destroy_deployment(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -304,27 +374,38 @@ pub mod deployer_server {
                         let inner = inner.0;
                         let method = DestroyDeploymentSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                "/deployer.Deployer/TargetIp" => {
+                "/deployer.Deployer/SubscribeProjects" => {
                     #[allow(non_camel_case_types)]
-                    struct TargetIpSvc<T: Deployer>(pub Arc<T>);
-                    impl<T: Deployer> tonic::server::UnaryService<super::TargetIpRequest> for TargetIpSvc<T> {
-                        type Response = super::TargetIpResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                    struct SubscribeProjectsSvc<T: Deployer>(pub Arc<T>);
+                    impl<
+                        T: Deployer,
+                    > tonic::server::ServerStreamingService<
+                        super::SubscribeProjectsRequest,
+                    > for SubscribeProjectsSvc<T> {
+                        type Response = super::ProjectEvent;
+                        type ResponseStream = T::SubscribeProjectsStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
-                            request: tonic::Request<super::TargetIpRequest>,
+                            request: tonic::Request<super::SubscribeProjectsRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).target_ip(request).await };
+                            let fut = async move {
+                                (*inner).subscribe_projects(request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -333,25 +414,70 @@ pub mod deployer_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let inner = inner.0;
-                        let method = TargetIpSvc(inner);
+                        let method = SubscribeProjectsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
-                            accept_compression_encodings,
-                            send_compression_encodings,
-                        );
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/deployer.Deployer/UnsubscribeProjects" => {
+                    #[allow(non_camel_case_types)]
+                    struct UnsubscribeProjectsSvc<T: Deployer>(pub Arc<T>);
+                    impl<
+                        T: Deployer,
+                    > tonic::server::UnaryService<super::UnsubscribeProjectsRequest>
+                    for UnsubscribeProjectsSvc<T> {
+                        type Response = super::UnsubscribeProjectsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::UnsubscribeProjectsRequest>,
+                        ) -> Self::Future {
+                            let inner = self.0.clone();
+                            let fut = async move {
+                                (*inner).unsubscribe_projects(request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = UnsubscribeProjectsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    Ok(http::Response::builder()
-                        .status(200)
-                        .header("grpc-status", "12")
-                        .header("content-type", "application/grpc")
-                        .body(empty_body())
-                        .unwrap())
-                }),
+                _ => {
+                    Box::pin(async move {
+                        Ok(
+                            http::Response::builder()
+                                .status(200)
+                                .header("grpc-status", "12")
+                                .header("content-type", "application/grpc")
+                                .body(empty_body())
+                                .unwrap(),
+                        )
+                    })
+                }
             }
         }
     }

--- a/proto/src/generated/deployer.rs
+++ b/proto/src/generated/deployer.rs
@@ -4,20 +4,22 @@ pub struct Deployment {
     #[prost(string, tag = "1")]
     pub service_id: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
+    pub project_id: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
     pub service_name: ::prost::alloc::string::String,
-    #[prost(bool, tag = "3")]
+    #[prost(bool, tag = "4")]
     pub is_next: bool,
-    #[prost(uint32, tag = "4")]
+    #[prost(uint32, tag = "5")]
     pub idle_minutes: u32,
-    #[prost(string, tag = "5")]
+    #[prost(string, tag = "6")]
     pub image_name: ::prost::alloc::string::String,
-    #[prost(string, optional, tag = "6")]
-    pub git_commit_message: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "7")]
-    pub git_commit_hash: ::core::option::Option<::prost::alloc::string::String>,
+    pub git_commit_message: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(string, optional, tag = "8")]
+    pub git_commit_hash: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "9")]
     pub git_branch: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(bool, optional, tag = "9")]
+    #[prost(bool, optional, tag = "10")]
     pub git_dirty: ::core::option::Option<bool>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -45,7 +47,7 @@ pub struct DestroyDeploymentResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TargetIpRequest {
-    /// The service id we request the target ip for
+    /// The service id we request the target ip for.
     #[prost(string, tag = "1")]
     pub service_id: ::prost::alloc::string::String,
     /// The project id we request the target ip for
@@ -65,8 +67,8 @@ pub struct TargetIpResponse {
 /// Generated client implementations.
 pub mod deployer_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
     use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
     #[derive(Debug, Clone)]
     pub struct DeployerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -110,9 +112,8 @@ pub mod deployer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             DeployerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -135,15 +136,12 @@ pub mod deployer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DeployRequest>,
         ) -> Result<tonic::Response<super::DeployResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/deployer.Deployer/Deploy");
             self.inner.unary(request.into_request(), path, codec).await
@@ -152,38 +150,28 @@ pub mod deployer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::DestroyDeploymentRequest>,
         ) -> Result<tonic::Response<super::DestroyDeploymentResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/deployer.Deployer/DestroyDeployment",
-            );
+            let path = http::uri::PathAndQuery::from_static("/deployer.Deployer/DestroyDeployment");
             self.inner.unary(request.into_request(), path, codec).await
         }
         pub async fn target_ip(
             &mut self,
             request: impl tonic::IntoRequest<super::TargetIpRequest>,
         ) -> Result<tonic::Response<super::TargetIpResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/deployer.Deployer/TargetIp",
-            );
+            let path = http::uri::PathAndQuery::from_static("/deployer.Deployer/TargetIp");
             self.inner.unary(request.into_request(), path, codec).await
         }
     }
@@ -227,10 +215,7 @@ pub mod deployer_server {
                 send_compression_encodings: Default::default(),
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -258,10 +243,7 @@ pub mod deployer_server {
         type Response = http::Response<tonic::body::BoxBody>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
-        fn poll_ready(
-            &mut self,
-            _cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
@@ -270,13 +252,9 @@ pub mod deployer_server {
                 "/deployer.Deployer/Deploy" => {
                     #[allow(non_camel_case_types)]
                     struct DeploySvc<T: Deployer>(pub Arc<T>);
-                    impl<T: Deployer> tonic::server::UnaryService<super::DeployRequest>
-                    for DeploySvc<T> {
+                    impl<T: Deployer> tonic::server::UnaryService<super::DeployRequest> for DeploySvc<T> {
                         type Response = super::DeployResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DeployRequest>,
@@ -293,11 +271,10 @@ pub mod deployer_server {
                         let inner = inner.0;
                         let method = DeploySvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -306,23 +283,17 @@ pub mod deployer_server {
                 "/deployer.Deployer/DestroyDeployment" => {
                     #[allow(non_camel_case_types)]
                     struct DestroyDeploymentSvc<T: Deployer>(pub Arc<T>);
-                    impl<
-                        T: Deployer,
-                    > tonic::server::UnaryService<super::DestroyDeploymentRequest>
-                    for DestroyDeploymentSvc<T> {
+                    impl<T: Deployer> tonic::server::UnaryService<super::DestroyDeploymentRequest>
+                        for DestroyDeploymentSvc<T>
+                    {
                         type Response = super::DestroyDeploymentResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::DestroyDeploymentRequest>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move {
-                                (*inner).destroy_deployment(request).await
-                            };
+                            let fut = async move { (*inner).destroy_deployment(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -333,11 +304,10 @@ pub mod deployer_server {
                         let inner = inner.0;
                         let method = DestroyDeploymentSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
@@ -346,13 +316,9 @@ pub mod deployer_server {
                 "/deployer.Deployer/TargetIp" => {
                     #[allow(non_camel_case_types)]
                     struct TargetIpSvc<T: Deployer>(pub Arc<T>);
-                    impl<T: Deployer> tonic::server::UnaryService<super::TargetIpRequest>
-                    for TargetIpSvc<T> {
+                    impl<T: Deployer> tonic::server::UnaryService<super::TargetIpRequest> for TargetIpSvc<T> {
                         type Response = super::TargetIpResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::TargetIpRequest>,
@@ -369,28 +335,23 @@ pub mod deployer_server {
                         let inner = inner.0;
                         let method = TargetIpSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
-                        let mut grpc = tonic::server::Grpc::new(codec)
-                            .apply_compression_config(
-                                accept_compression_encodings,
-                                send_compression_encodings,
-                            );
+                        let mut grpc = tonic::server::Grpc::new(codec).apply_compression_config(
+                            accept_compression_encodings,
+                            send_compression_encodings,
+                        );
                         let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }


### PR DESCRIPTION
## Description of change

* Added project events streaming for the deployer.
* Added project_id and last_updated to the services table.

## How has this been tested? (if applicable)

Tested locally by:
* creating user services and looking at the event stream messages, seeing how the services go through all the states
* very important, once the service is in `Running` state, it should send the service socket addr.
