### PR TITLE
build(shell.nix): add openssl package to the build dependencies

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ in
       fastmod
       pebble
       kondo
+      openssl
     ];
 
     PROTOC = "${protobuf}/bin/protoc";


### PR DESCRIPTION
## Description of change
While building the client locally, it was complaining about missing openssl. Added it back and all is good.



