### PR TITLE
[scaling] misc: run services locally in an independent fashion

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,47 @@
 version: "3"
 
 services:
+  auth:
+    ports:
+      - 8008:8000
+  builder:
+    ports:
+      - 8010:8000
+    command:
+      - "--auth-uri=http://host.docker.internal:8008"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  deployer:
+    ports:
+      - 8009:8000
+    command:
+      - "--auth-uri=http://host.docker.internal:8008"
+      - "--state=/var/lib"
+      - "--provisioner-uri=http://host.docker.internal:3000"
+      - "--prefix=${STACK}"
+      - "--users-network-name=${STACK}_user-net"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  gateway:
+    ports:
+      - 7999:7999
+      - 8000:8000
+      - 8001:8001
+    command:
+      - "--state=/var/lib"
+      - "--auth-uri=http://host.docker.internal:8008"
+      - "--proxy-fqdn=shuttle.local"
+      - "--use-tls=disable"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  logger:
+    ports:
+      - 8020:8000
+    command:
+      - "--auth-uri=http://host.docker.internal:8008"
+      - "--state=/var/lib"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   provisioner:
     entrypoint:
       - /bin/bash
@@ -23,6 +64,25 @@ services:
         exec /usr/local/bin/service "$${@:0}"
     ports:
       - 3000:8000
+    command:
+      - "--ip=0.0.0.0"
+      - "--port=8000"
+      - "--shared-pg-uri=postgres://postgres:${POSTGRES_PASSWORD}@postgres:5432/postgres"
+      - "--shared-mongodb-uri=mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@mongodb:27017/admin"
+      - "--internal-mongodb-address=mongodb"
+      - "--internal-pg-address=postgres"
+      - "--fqdn=127.0.0.1"
+      - "--auth-uri=http://host.docker.internal:8008"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  resource-recorder:
+    ports:
+      - 8012:8000
+    command:
+      - "--auth-uri=http://host.docker.internal:8008"
+      - "--state=/var/lib"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   deck-chores:
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,6 @@ services:
       - "--address=0.0.0.0:8000"
   builder:
     image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"
-    depends_on:
-      - auth
     deploy:
       restart_policy:
         condition: on-failure
@@ -75,11 +73,6 @@ services:
       - "--auth-uri=http://auth:8000"
   deployer:
     image: "${CONTAINER_REGISTRY}/deployer:${DEPLOYER_TAG}"
-    depends_on:
-      - auth
-      - builder
-      - provisioner
-      - resource-recorder
     deploy:
       restart_policy:
         condition: on-failure
@@ -112,9 +105,6 @@ services:
       - "--docker-host=/var/run/docker.sock"
   gateway:
     image: "${CONTAINER_REGISTRY}/gateway:${GATEWAY_TAG}"
-    depends_on:
-      - auth
-      - deployer
     ports:
       - 7999:7999
       - 8000:8000
@@ -154,8 +144,6 @@ services:
       #start_period: 30s
   logger:
     image: "${CONTAINER_REGISTRY}/logger:${LOGGER_TAG}"
-    depends_on:
-      - auth
     deploy:
       restart_policy:
         condition: on-failure
@@ -184,7 +172,6 @@ services:
     depends_on:
       - postgres
       - mongodb
-      - auth
     environment:
       - RUST_LOG=${RUST_LOG}
     networks:
@@ -215,8 +202,6 @@ services:
       - "--auth-uri=http://auth:8000"
   resource-recorder:
     image: "${CONTAINER_REGISTRY}/resource-recorder:${RESOURCE_RECORDER_TAG}"
-    depends_on:
-      - auth
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
## Description of change
Trying to find a way to run any of our service locally while the rest is in containers

### Steps
First, make all the images
```
make images
```

Then make a rendered compose file
```
USE_PANAMAX=disable TAG=latest make docker-compose.rendered.yml
```

Now start all the services (terminal 1)
```
docker compose --file docker-compose.rendered.yml up
```

Now stop a single service like deployer (terminal 2)
```
docker compose --file docker-compose.rendered.yml stop deployer
```

Now start that service locally and be sure to bind it to the IP `0.0.0.0` and on the port the stopped container binded to (terminal 3)
```
RUST_LOG=shuttle=trace,debug cargo run --package shuttle-deployer -- --address 0.0.0.0:8009 --auth-url http://localhost:8008 --provisioner-uri http://localhost:3000
```

Start any other containers that stopped (terminal 2)
```
docker compose --file docker-compose.rendered.yml start gateway
```

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->


