### PR TITLE
feat: implement `ResourceBuilder` for `diesel::postgres::Pool`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples"]
 	path = examples
-	url = ../examples.git
+	url = https://github.com/shuttle-hq/shuttle-examples.git

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -8,11 +8,12 @@ keywords = ["shuttle-service", "database"]
 
 [dependencies]
 async-trait = "0.1.56"
+deadpool-diesel = { version = "0.4.1", features = ["postgres"], optional = true }
 mongodb = { version = "2.3.0", optional = true }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.19.0" }
 sqlx = { version = "0.6.2", optional = true }
 
 [features]
-postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
-postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]
+postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls", "deadpool-diesel"]
+postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls", "deadpool-diesel"]

--- a/resources/shared-db/src/lib.rs
+++ b/resources/shared-db/src/lib.rs
@@ -9,4 +9,4 @@ pub use mongo::MongoDb;
 mod postgres;
 
 #[cfg(any(feature = "postgres", feature = "postgres-rustls"))]
-pub use postgres::Postgres;
+pub use postgres::{PostgresDiesel, PostgresSQLX};

--- a/resources/shared-db/src/postgres/mod.rs
+++ b/resources/shared-db/src/postgres/mod.rs
@@ -1,0 +1,5 @@
+mod pgdiesel;
+mod pgsqlx;
+
+pub use pgdiesel::PostgresDiesel;
+pub use pgsqlx::PostgresSQLX;

--- a/resources/shared-db/src/postgres/pgdiesel.rs
+++ b/resources/shared-db/src/postgres/pgdiesel.rs
@@ -1,0 +1,81 @@
+use async_trait::async_trait;
+use serde::Serialize;
+use shuttle_service::{
+    database, error::CustomError, DbInput, DbOutput, Error, Factory, ResourceBuilder, Type,
+};
+
+#[derive(Serialize)]
+pub struct PostgresDiesel {
+    config: DbInput,
+}
+
+/// Get an `sqlx::PgPool` from any factory
+#[async_trait]
+impl ResourceBuilder<deadpool_diesel::postgres::Pool> for PostgresDiesel {
+    const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::Postgres));
+
+    type Config = DbInput;
+
+    type Output = DbOutput;
+
+    fn new() -> Self {
+        Self {
+            config: Default::default(),
+        }
+    }
+
+    fn config(&self) -> &Self::Config {
+        &self.config
+    }
+
+    async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, Error> {
+        let info = match factory.get_environment() {
+            shuttle_service::Environment::Production => DbOutput::Info(
+                factory
+                    .get_db_connection(database::Type::Shared(database::SharedEngine::Postgres))
+                    .await?,
+            ),
+            shuttle_service::Environment::Local => {
+                if let Some(local_uri) = self.config.local_uri {
+                    DbOutput::Local(local_uri)
+                } else {
+                    DbOutput::Info(
+                        factory
+                            .get_db_connection(database::Type::Shared(
+                                database::SharedEngine::Postgres,
+                            ))
+                            .await?,
+                    )
+                }
+            }
+        };
+
+        Ok(info)
+    }
+
+    async fn build(build_data: &Self::Output) -> Result<deadpool_diesel::postgres::Pool, Error> {
+        let connection_string = match build_data {
+            DbOutput::Local(local_uri) => local_uri.clone(),
+            DbOutput::Info(info) => info.connection_string_private(),
+        };
+
+        let manager = deadpool_diesel::postgres::Manager::new(
+            connection_string,
+            deadpool_diesel::Runtime::Tokio1,
+        );
+        let pool = deadpool_diesel::postgres::Pool::builder(manager)
+            .build()
+            .map_err(CustomError::new)?;
+
+        Ok(pool)
+    }
+}
+
+impl PostgresDiesel {
+    /// Use a custom connection string for local runs
+    pub fn local_uri(mut self, local_uri: &str) -> Self {
+        self.config.local_uri = Some(local_uri.to_string());
+
+        self
+    }
+}

--- a/resources/shared-db/src/postgres/pgsqlx.rs
+++ b/resources/shared-db/src/postgres/pgsqlx.rs
@@ -5,13 +5,13 @@ use shuttle_service::{
 };
 
 #[derive(Serialize)]
-pub struct Postgres {
+pub struct PostgresSQLX {
     config: DbInput,
 }
 
 /// Get an `sqlx::PgPool` from any factory
 #[async_trait]
-impl ResourceBuilder<sqlx::PgPool> for Postgres {
+impl ResourceBuilder<sqlx::PgPool> for PostgresSQLX {
     const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::Postgres));
 
     type Config = DbInput;
@@ -70,7 +70,7 @@ impl ResourceBuilder<sqlx::PgPool> for Postgres {
     }
 }
 
-impl Postgres {
+impl PostgresSQLX {
     /// Use a custom connection string for local runs
     pub fn local_uri(mut self, local_uri: &str) -> Self {
         self.config.local_uri = Some(local_uri.to_string());


### PR DESCRIPTION
## Description of change

This change also slightly restructures the `postgres` module by splitting it up into two modules, one for each `sqlx` and `diesel`.

The rough design as well as the use of the `deadpool_diesel` crate were inspired by the [`diesel-postgres` example in the `axum` crate](https://github.com/tokio-rs/axum/blob/main/examples/diesel-postgres/src/main.rs)

## Breaking changes

This commit also includes a breaking change. Since the existing struct named `Postgres` would be ambiguous in the face of two possible postgres database connection pool type, it was renamed to `PostgresSQLX` to make that clearer. I need you to make a decision and pick one of the two following:

1. We keep the change. Then I'm going to apply it to all code existing in the `shuttle` and `shuttle-examples` repo.
2. We discard the change. In this case the `sqlx::PgPool` related struct will keep its name `Postgres` and I need you to provide a possible name for the `diesel` version.

## How has this been tested? (if applicable)

I'll also provide an example which implements a very basic example (axum-diesel-postgres). You'll find the link to the example [here](https://github.com/shuttle-hq/shuttle-examples/pull/66) (It currently uses the patched `shuttle` crate as a `path` dependencies which needs to be fixed but the code is there. I only tested the example locally on my own machine (NixOS 23.05)


