### PR TITLE
chore: make git submodule path absolute to make life easier for forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples"]
 	path = examples
-	url = ../examples.git
+	url = https://github.com/shuttle-hq/shuttle-examples.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples"]
 	path = examples
-	url = https://github.com/shuttle-hq/shuttle-examples.git
+	url = ../shuttle-examples.git


### PR DESCRIPTION
## Description of change
I'm not an expert when it comes to git submodules, but the way they are specified at the moment made it hard for me to use the repo in a `Cargo.toml` via direct git links, i.e.

```toml
shuttle = { git = "https://github.com/shuttle-hq/shuttle" }
```

With the current implementation, I got the error

```
error: failed to get `shuttle-axum` as a dependency of package `blah v0.1.0 (/home/robw/repos/shuttle-examples/axum/diesel-postgres)`

Caused by:
  failed to load source for dependency `shuttle-axum`

Caused by:
  Unable to update https://github.com/RobWalt/shuttle?branch=feat/shared-db-diesel

Caused by:
  failed to update submodule `examples`

Caused by:
  failed to fetch submodule `examples` from https://github.com/RobWalt/examples.git

Caused by:
  failed to authenticate when downloading repository

  * attempted to find username/password via git's `credential.helper` support, but failed

  if the git CLI succeeds then `net.git-fetch-with-cli` may help here
  https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli

Caused by:
  failed to acquire username/password from local configuration
```

specifying the absolute path fixed that. If there is a reason you're doing this, then feel free to ignore and close this PR.


## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

My example in the `shuttle-examples` repo compiles with this, where it didn't before

