### PR TITLE
fix: bash bug in containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,8 +16,9 @@ COPY . .
 RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" \) -type f -exec install -D \{\} /build/\{\} \;
 # This is used to carry over in the docker images any *.pem files from shuttle root directory,
 # to be used for TLS testing, as described here in the admin README.md.
-RUN [ "$CARGO_PROFILE" != "release" ] && \
-    find ${SRC_CRATES} -name "*.pem" -type f -exec install -D \{\} /build/\{\} \;
+RUN if [ "$CARGO_PROFILE" != "release" ]; then \
+    find ${SRC_CRATES} -name "*.pem" -type f -exec install -D \{\} /build/\{\} \;; \
+    fi
 
 
 # Stores cargo chef recipe


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

There was a bug where if the bash conditional evaluated to false, it would fail, I am not sure why. Changing it away from the shorthand resolved it.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested by running `make shuttle-provisioner` with and without PROD=true and both cases work.
