### PR TITLE
ci: incorrect path to turso resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -816,8 +816,8 @@ workflows:
                   "resources/persist",
                   "resources/secrets",
                   "resources/shared-db",
-                  "resources/shuttle-turso",
                   "resources/static-folder",
+                  "resources/turso",
                 ]
           name: publish-<< matrix.path >>
           requires:


### PR DESCRIPTION
This corrects the incorrect path to the turso resource in the publish crates job.

