### PR TITLE
fix: rds deploy crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILDX_FLAGS=$(BUILDX_OP) $(PLATFORM_FLAGS) $(CACHE_FLAGS)
 # ensuring all user crates are compiled with the same rustc toolchain
 RUSTUP_TOOLCHAIN=1.70.0
 
-TAG?=$(shell git describe --tags)
+TAG?=$(shell git describe --tags --abbrev=0)
 BACKEND_TAG?=$(TAG)
 DEPLOYER_TAG?=$(TAG)
 PROVISIONER_TAG?=$(TAG)

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1034,23 +1034,9 @@ impl Shuttle {
 
                             return Ok(CommandOutcome::DeploymentFailure);
                         }
-                        shuttle_common::deployment::State::Running => {
-                            println!("got Running in logs stream");
-                            let fields: serde_json::Value =
-                                serde_json::from_slice(log_item.fields.as_slice()).unwrap();
-                            println!("log item: {:?}", fields);
-                            break;
-                        }
-                        shuttle_common::deployment::State::Completed => {
-                            println!("got Completed in logs stream");
-                            break;
-                        }
-                        shuttle_common::deployment::State::Stopped => {
-                            println!("got Stopped in logs stream");
-                            break;
-                        }
-                        shuttle_common::deployment::State::Unknown => {
-                            println!("got Unknown in logs stream");
+                        // Break on remaining end states: Running, Stopped, Completed or Unknown.
+                        end_state => {
+                            debug!(state = %end_state, "received end state, breaking deployment stream");
                             break;
                         }
                     };
@@ -1107,7 +1093,7 @@ impl Shuttle {
                     );
                 }
                 state => {
-                    println!("{state}");
+                    debug!("deployment logs stream received state: {state} when it expected to receive state: running");
                     println!(
                     "Deployment entered an unexpected state - Please create a ticket to report this."
                 );

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1031,10 +1031,20 @@ impl Shuttle {
 
                             return Ok(CommandOutcome::DeploymentFailure);
                         }
-                        shuttle_common::deployment::State::Running
-                        | shuttle_common::deployment::State::Completed
-                        | shuttle_common::deployment::State::Stopped
-                        | shuttle_common::deployment::State::Unknown => {
+                        shuttle_common::deployment::State::Running => {
+                            println!("got Running in logs stream");
+                            break;
+                        }
+                        shuttle_common::deployment::State::Completed => {
+                            println!("got Completed in logs stream");
+                            break;
+                        }
+                        shuttle_common::deployment::State::Stopped => {
+                            println!("got Stopped in logs stream");
+                            break;
+                        }
+                        shuttle_common::deployment::State::Unknown => {
+                            println!("got Unknown in logs stream");
                             break;
                         }
                     };
@@ -1090,9 +1100,12 @@ impl Shuttle {
                         "State: Crashed - Deployment crashed after startup.".red()
                     );
                 }
-                _ => println!(
-                    "Deployment encountered an unexpected error - Please create a ticket to report this."
-                ),
+                state => {
+                    println!("{state}");
+                    println!(
+                    "Deployment entered an unexpected state - Please create a ticket to report this."
+                );
+                }
             }
 
             println!();

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1033,6 +1033,9 @@ impl Shuttle {
                         }
                         shuttle_common::deployment::State::Running => {
                             println!("got Running in logs stream");
+                            let fields: serde_json::Value =
+                                serde_json::from_slice(log_item.fields.as_slice()).unwrap();
+                            println!("log item: {:?}", fields);
                             break;
                         }
                         shuttle_common::deployment::State::Completed => {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1093,7 +1093,7 @@ impl Shuttle {
                     );
                 }
                 state => {
-                    debug!("deployment logs stream received state: {state} when it expected to receive state: running");
+                    debug!("deployment logs stream received state: {state} when it expected to receive running state");
                     println!(
                     "Deployment entered an unexpected state - Please create a ticket to report this."
                 );

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -108,6 +108,8 @@ pub enum ParseError {
     Timestamp(#[from] prost_types::TimestampError),
     #[error("failed to parse serde: {0}")]
     Serde(#[from] serde_json::Error),
+    #[error("failed to parse state: {0}")]
+    State(String),
 }
 
 /// Holds the input for a DB resource

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -118,7 +118,7 @@ impl TryFrom<runtime::LogItem> for Log {
     fn try_from(log: runtime::LogItem) -> Result<Self, Self::Error> {
         Ok(Self {
             id: Default::default(),
-            state: State::Running,
+            state: State::from_str(&log.state).map_err(|err| ParseError::State(err.to_string()))?,
             level: runtime::LogLevel::from_i32(log.level)
                 .unwrap_or_default()
                 .into(),

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -333,10 +333,10 @@ async fn load(
         load_request.extensions_mut().insert(claim);
     }
 
-    debug!("loading service");
+    debug!(service_name = %service_name, "loading service");
     let response = runtime_client.load(load_request).await;
 
-    info!("resources have been loaded");
+    debug!(service_name = %service_name, "service loaded");
     match response {
         Ok(response) => {
             let response = response.into_inner();

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -314,6 +314,7 @@ async fn load(
     debug!("loading service");
     let response = runtime_client.load(load_request).await;
 
+    info!("resources have been loaded");
     match response {
         Ok(response) => {
             let response = response.into_inner();

--- a/proto/runtime.proto
+++ b/proto/runtime.proto
@@ -90,6 +90,7 @@ message LogItem {
   optional uint32 line = 6;
   string target = 7;
   bytes fields = 8;
+  string state = 9;
 }
 
 enum LogLevel {

--- a/proto/src/generated/runtime.rs
+++ b/proto/src/generated/runtime.rs
@@ -85,6 +85,8 @@ pub struct LogItem {
     pub target: ::prost::alloc::string::String,
     #[prost(bytes = "vec", tag = "8")]
     pub fields: ::prost::alloc::vec::Vec<u8>,
+    #[prost(string, tag = "9")]
+    pub state: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -179,6 +179,8 @@ pub mod runtime {
                 line,
                 target: log.target,
                 fields: log.fields,
+                // We can safely assume the state received from shuttle-next to be running,
+                // it will not currently load any resources.
                 state: State::Running.to_string(),
             }
         }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -106,6 +106,7 @@ pub mod runtime {
     use prost_types::Timestamp;
     use shuttle_common::{
         claims::{ClaimLayer, ClaimService, InjectPropagation, InjectPropagationLayer},
+        deployment::State,
         ParseError,
     };
     use tokio::process;
@@ -178,6 +179,7 @@ pub mod runtime {
                 line,
                 target: log.target,
                 fields: log.fields,
+                state: State::Running.to_string(),
             }
         }
     }

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -41,7 +41,7 @@ use tonic::{
     Request, Response, Status,
 };
 use tower::ServiceBuilder;
-use tracing::{error, info, instrument, trace, warn};
+use tracing::{error, info, trace, warn};
 
 use crate::{provisioner_factory::ProvisionerFactory, Logger, ResourceTracker};
 
@@ -302,7 +302,6 @@ where
         Ok(Response::new(message))
     }
 
-    #[instrument(skip_all)]
     async fn start(
         &self,
         request: Request<StartRequest>,

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -41,7 +41,7 @@ use tonic::{
     Request, Response, Status,
 };
 use tower::ServiceBuilder;
-use tracing::{error, info, trace, warn};
+use tracing::{error, info, instrument, trace, warn};
 
 use crate::{provisioner_factory::ProvisionerFactory, Logger, ResourceTracker};
 
@@ -300,6 +300,7 @@ where
         Ok(Response::new(message))
     }
 
+    #[instrument(skip_all)]
     async fn start(
         &self,
         request: Request<StartRequest>,

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -68,7 +68,11 @@ where
                     .target
                     .unwrap_or_else(|| metadata.target().to_string()),
                 fields: serde_json::to_vec(&visitor.fields).unwrap(),
-                state: self.state.lock().unwrap().to_string(),
+                state: self
+                    .state
+                    .lock()
+                    .expect("state lock should not be poisoned")
+                    .to_string(),
             }
         };
 
@@ -81,7 +85,10 @@ where
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         if event.metadata().name() == "start" {
-            *self.state.lock().unwrap() = State::Running;
+            *self
+                .state
+                .lock()
+                .expect("state lock should not be poisoned") = State::Running;
         }
         let datetime = Utc::now();
 
@@ -100,7 +107,11 @@ where
                     .target
                     .unwrap_or_else(|| metadata.target().to_string()),
                 fields: serde_json::to_vec(&visitor.fields).unwrap(),
-                state: self.state.lock().unwrap().to_string(),
+                state: self
+                    .state
+                    .lock()
+                    .expect("state lock should not be poisoned")
+                    .to_string(),
             }
         };
 

--- a/runtime/src/logger.rs
+++ b/runtime/src/logger.rs
@@ -1,8 +1,11 @@
-use std::time::SystemTime;
+use std::{
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
 
 use chrono::Utc;
 use prost_types::Timestamp;
-use shuttle_common::tracing::JsonVisitor;
+use shuttle_common::{deployment::State, tracing::JsonVisitor};
 use shuttle_proto::runtime::{LogItem, LogLevel};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{
@@ -13,11 +16,15 @@ use tracing_subscriber::Layer;
 
 pub struct Logger {
     tx: UnboundedSender<LogItem>,
+    state: Arc<Mutex<State>>,
 }
 
 impl Logger {
     pub fn new(tx: UnboundedSender<LogItem>) -> Self {
-        Self { tx }
+        Self {
+            tx,
+            state: Arc::new(Mutex::new(State::Loading)),
+        }
     }
 }
 
@@ -61,6 +68,7 @@ where
                     .target
                     .unwrap_or_else(|| metadata.target().to_string()),
                 fields: serde_json::to_vec(&visitor.fields).unwrap(),
+                state: self.state.lock().unwrap().to_string(),
             }
         };
 
@@ -72,6 +80,9 @@ where
         event: &tracing::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
+        if event.metadata().name() == "start" {
+            *self.state.lock().unwrap() = State::Running;
+        }
         let datetime = Utc::now();
 
         let item = {
@@ -89,6 +100,7 @@ where
                     .target
                     .unwrap_or_else(|| metadata.target().to_string()),
                 fields: serde_json::to_vec(&visitor.fields).unwrap(),
+                state: self.state.lock().unwrap().to_string(),
             }
         };
 


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We were incorrectly assuming the state to be running in the logs received from a deployment, but they could also be loading (and they will be loading for a while in the case of rds). This lead to the client reporting that the deployment crashed since it received the running state in the logs stream, but the deployment was still loading (an unexpected state since we received running in logs). 

Closes #1029 

TODO: 
- We're not getting the logs from runtime during loading, although I think we used to (I remember seeing the "deploying <db_type>, this could take a while..." output). :thinking:  This means we get "loading service" from the deployer run function, and then nothing until loading is complete.
- Should we use rwlock for the logger state? Does it matter?

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested by deploying tide rds example to unstable, as well as some other examples (axum hello world, poem postgres).