### PR TITLE
Explain 413 error when a user tries to create a project larger than the limit

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::str::FromStr;
 
+use shuttle_common::models::deployment::CREATE_SERVICE_BODY_LIMIT;
 use shuttle_common::{
     claims::{ClaimService, InjectPropagation},
     models::{
@@ -1000,6 +1001,9 @@ impl Shuttle {
         }
 
         deployment_req.data = self.make_archive()?;
+        if deployment_req.data.len() > CREATE_SERVICE_BODY_LIMIT {
+            bail!("The project is too large - we have a {}MB project limit.", CREATE_SERVICE_BODY_LIMIT / 1_000_000);
+        }
 
         let deployment = client
             .deploy(self.ctx.project_name(), deployment_req)

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1002,7 +1002,10 @@ impl Shuttle {
 
         deployment_req.data = self.make_archive()?;
         if deployment_req.data.len() > CREATE_SERVICE_BODY_LIMIT {
-            bail!("The project is too large - we have a {}MB project limit.", CREATE_SERVICE_BODY_LIMIT / 1_000_000);
+            bail!(
+                "The project is too large - we have a {}MB project limit.",
+                CREATE_SERVICE_BODY_LIMIT / 1_000_000
+            );
         }
 
         let deployment = client

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -171,3 +171,4 @@ pub struct DeploymentRequest {
 
 pub const GIT_STRINGS_MAX_LENGTH: usize = 80;
 const GIT_OPTION_NONE_TEXT: &str = "N/A";
+pub const CREATE_SERVICE_BODY_LIMIT: usize = 50_000_000;

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -24,7 +24,7 @@ use shuttle_common::backends::auth::{
 use shuttle_common::backends::headers::XShuttleAccountName;
 use shuttle_common::backends::metrics::{Metrics, TraceLayer};
 use shuttle_common::claims::{Claim, Scope};
-use shuttle_common::models::deployment::{DeploymentRequest, GIT_STRINGS_MAX_LENGTH};
+use shuttle_common::models::deployment::{DeploymentRequest, GIT_STRINGS_MAX_LENGTH, CREATE_SERVICE_BODY_LIMIT};
 use shuttle_common::models::secret;
 use shuttle_common::project::ProjectName;
 use shuttle_common::storage_manager::StorageManager;
@@ -114,7 +114,7 @@ impl RouterBuilder {
                     .post(
                         create_service
                             // Set the body size limit for this endpoint to 50MB
-                            .layer(DefaultBodyLimit::max(50_000_000))
+                            .layer(DefaultBodyLimit::max(CREATE_SERVICE_BODY_LIMIT))
                             .layer(ScopedLayer::new(vec![Scope::ServiceCreate])),
                     )
                     .delete(stop_service.layer(ScopedLayer::new(vec![Scope::ServiceCreate]))),

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -24,7 +24,9 @@ use shuttle_common::backends::auth::{
 use shuttle_common::backends::headers::XShuttleAccountName;
 use shuttle_common::backends::metrics::{Metrics, TraceLayer};
 use shuttle_common::claims::{Claim, Scope};
-use shuttle_common::models::deployment::{DeploymentRequest, GIT_STRINGS_MAX_LENGTH, CREATE_SERVICE_BODY_LIMIT};
+use shuttle_common::models::deployment::{
+    DeploymentRequest, CREATE_SERVICE_BODY_LIMIT, GIT_STRINGS_MAX_LENGTH,
+};
 use shuttle_common::models::secret;
 use shuttle_common::project::ProjectName;
 use shuttle_common::storage_manager::StorageManager;


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Adds a client check for project size. If too large, informs the user about the project size limit.
Closes #1035 



## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->
Tried it locally on a large project


