### PR TITLE
Clarify persist.save semantics (not requiring move)

### DIFF
--- a/resources/persist/src/lib.rs
+++ b/resources/persist/src/lib.rs
@@ -31,14 +31,14 @@ pub struct PersistInstance {
 }
 
 impl PersistInstance {
-    pub fn save<T: Serialize>(&self, key: &str, struc: T) -> Result<(), PersistError> {
+    pub fn save<T: Serialize>(&self, key: &str, struc: &T) -> Result<(), PersistError> {
         let storage_folder = self.get_storage_folder();
         fs::create_dir_all(storage_folder).map_err(PersistError::CreateFolder)?;
 
         let file_path = self.get_storage_file(key);
         let file = File::create(file_path).map_err(PersistError::Open)?;
         let mut writer = BufWriter::new(file);
-        Ok(serialize_into(&mut writer, &struc).map_err(PersistError::Serialize))?
+        Ok(serialize_into(&mut writer, struc).map_err(PersistError::Serialize))?
     }
 
     pub fn load<T>(&self, key: &str) -> Result<T, PersistError>


### PR DESCRIPTION
## Description of change
Previously, `PersistInstance.save` required that the value to save will be moved into the function.

Even though this doesn't change any functionality, as passing in a reference worked previously, this PR does clear up the semantics of only needing a reference for persist serialisation.

Use case: in my application, i have a rather big piece of data i want to save when its changed, but which is also read from a lot. I spent a long time struggling before finding out i can just pass a reference to .save anyway.

## How has this been tested? (if applicable)

i've tested it in the main function of a fresh axum template, using this snippet:
```rust
    let mut b = String::from("hello");
    persist.save("test", &b).unwrap();
    b += " world";

    dbg!(b, persist.load::<String>("test"));
```

this is a breaking change, requiring users to add a & to their .save calls.