### PR TITLE
chore: bump tower-sanitize-path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6323,9 +6323,9 @@ checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-sanitize-path"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d4accf4be86b13057d30cd97f606c707b6ec8df01c2e91ee735f89de8216f21"
+checksum = "4f8277387194ad48739f3516a54ef4486927ba53b8d889871f3715fb8f99f5aa"
 dependencies = [
  "http",
  "tower-layer",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -52,7 +52,7 @@ utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 x509-parser = "0.14.0"
 tonic = { workspace = true }
-tower-sanitize-path = "0.1.2"
+tower-sanitize-path = "0.2.0"
 
 [dependencies.shuttle-common]
 workspace = true


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This bumps tower-sanitize-path to an updated version that does not normalize away trailing slashes, closing https://github.com/shuttle-hq/shuttle/issues/1028 once this change is deployed on Monday.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested in https://github.com/shuttle-hq/tower-sanitize-path/pull/6
