### PR TITLE
fix: broken gateway pagination and status check tests

### DIFF
--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -821,65 +821,51 @@ pub mod tests {
             vec![matrix.clone()]
         );
 
-        let mut all_projects: Vec<ProjectName> = (1..60)
-            .map(|p| ProjectName(format!("matrix-{p}")))
-            .collect();
-        for p in &all_projects {
-            svc.create_project(p.clone(), neo.clone(), false, 0)
+        // Test project pagination, first create 20 test projects (including the one from above).
+        for p in (1..20).map(|p| format!("matrix-{p}")).into_iter() {
+            svc.create_project(ProjectName(p.clone()), neo.clone(), false, 0)
                 .await
                 .unwrap();
         }
-        all_projects.insert(0, matrix.clone());
 
-        assert_eq!(
-            svc.iter_user_projects_detailed(&neo, 0, u32::MAX)
-                .await
-                .unwrap()
-                .map(|item| item.0)
-                .collect::<Vec<_>>(),
-            all_projects
-        );
-        assert_eq!(
-            svc.iter_user_projects_detailed(&neo, 0, 20)
-                .await
-                .unwrap()
-                .map(|item| item.0)
-                .collect::<Vec<_>>(),
-            all_projects[..20]
-        );
-        assert_eq!(
-            svc.iter_user_projects_detailed(&neo, 20, 20)
-                .await
-                .unwrap()
-                .map(|item| item.0)
-                .collect::<Vec<_>>(),
-            all_projects[20..40]
-        );
-        assert_eq!(
-            svc.iter_user_projects_detailed(&neo, 200, 20)
-                .await
-                .unwrap()
-                .map(|item| item.0)
-                .collect::<Vec<_>>(),
-            vec![]
-        );
+        // We need to fetch all of them from the DB since they are ordered by created_at and project_name,
+        // and created_at will be the same for some of them.
+        let all_projects = svc
+            .iter_user_projects_detailed(&neo, 0, u32::MAX)
+            .await
+            .unwrap()
+            .map(|item| item.0)
+            .collect::<Vec<_>>();
 
-        // assert_eq!(
-        //     svc.iter_user_projects_detailed_filtered(neo.clone(), "ready".to_string())
-        //         .await
-        //         .unwrap()
-        //         .next()
-        //         .expect("to get one project with its user and a valid Ready status"),
-        //     (matrix.clone(), project)
-        // );
+        assert_eq!(all_projects.len(), 20);
 
-        // assert_eq!(
-        //     svc.iter_user_projects_detailed_filtered(neo.clone(), "destroyed".to_string())
-        //         .await
-        //         .unwrap()
-        //         .next(),
-        //     None
-        // );
+        // Get first 5 projects.
+        let paginated = svc
+            .iter_user_projects_detailed(&neo, 0, 5)
+            .await
+            .unwrap()
+            .map(|item| item.0)
+            .collect::<Vec<_>>();
+
+        assert_eq!(all_projects[..5], paginated);
+
+        // Get 10 projects starting at an offset of 10.
+        let paginated = svc
+            .iter_user_projects_detailed(&neo, 10, 10)
+            .await
+            .unwrap()
+            .map(|item| item.0)
+            .collect::<Vec<_>>();
+        assert_eq!(all_projects[10..20], paginated);
+
+        // Get 20 projects starting at an offset of 200.
+        let paginated = svc
+            .iter_user_projects_detailed(&neo, 200, 20)
+            .await
+            .unwrap()
+            .collect::<Vec<_>>();
+
+        assert!(paginated.is_empty());
 
         let mut work = svc
             .new_task()

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -822,7 +822,7 @@ pub mod tests {
         );
 
         // Test project pagination, first create 20 test projects (including the one from above).
-        for p in (1..20).map(|p| format!("matrix-{p}")).into_iter() {
+        for p in (1..20).map(|p| format!("matrix-{p}")) {
             svc.create_project(ProjectName(p.clone()), neo.clone(), false, 0)
                 .await
                 .unwrap();


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

When testing h2 project support, I discovered some broken gateway tests. These have (understandably) slipped through since we don't run them in CI, which is the bigger problem here. :smile:  The status test was not updated to reflect the changes we made to the gateway status check for the shuttle status page, and the pagination tests in service were not deterministic.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Run `USE_PANAMAX=disable make shuttle-deployer`, then run the test command from the gateway readme: 
```
SHUTTLE_TESTS_RUNTIME_IMAGE=public.ecr.aws/shuttle-dev/deployer:latest SHUTTLE_TESTS_NETWORK=shuttle-dev_user-net cargo test --package shuttle-gateway --all-features -- --nocapture
```
