### PR TITLE
Add --allow-dirty to command hint at end of init

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1132,7 +1132,7 @@ impl Shuttle {
             client,
         )
         .await?;
-        println!("Run `cargo shuttle deploy` to deploy your Shuttle service.");
+        println!("Run `cargo shuttle deploy --allow-dirty` to deploy your Shuttle service.");
 
         Ok(())
     }


### PR DESCRIPTION
This commit modifies the command hint `cargo shuttle deploy` that appears at the end of `cargo shuttle init` so that it includes the `--allow-dirty` flag.

Without this flag, `cargo shuttle` will fail every time a newbie tries to init a new project because shuttle adds files to the project but doesn't commit them to git. Shuttle then notices that there are uncommitted files, and doesn't allow the newbie to deploy the project without specifically allowing the dirty files. This is a bit of a bad experience, because the newbie is just following instructions but also being told that those instructions were wrong.

This PR is a bit of a nit-pick, so feel free to close!
