### PR TITLE
feat: Handling regular signals sent to cargo-shuttle on Windows

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -922,7 +922,6 @@ impl Shuttle {
         Ok(())
     }
 
-
     #[cfg(target_family = "windows")]
     async fn handle_signals() -> bool {
         let mut ctrl_break_notif = tokio::signal::windows::ctrl_break()


### PR DESCRIPTION
## Description of change
Gracefully handling windows signal to interrupt local run for #872.
/claim #872

## How has this been tested? (if applicable)
Tested by running on windows, with Ctrl+C



