### PR TITLE
Added the missing support for creating custom resources

### DIFF
--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -22,6 +22,7 @@ pub fn get_resources_table(resources: &Vec<Response>, service_name: &str) -> Str
                 Type::StaticFolder => "Static Folder",
                 Type::Persist => "Persist",
                 Type::Turso => "Turso",
+                Type::Custom => "Custom",
             };
 
             let elements = acc.entry(title).or_insert(Vec::new());
@@ -46,6 +47,10 @@ pub fn get_resources_table(resources: &Vec<Response>, service_name: &str) -> Str
 
         if let Some(persist) = resource_groups.get("Persist") {
             output.push(get_persist_table(persist, service_name));
+        };
+
+        if let Some(custom) = resource_groups.get("Custom") {
+            output.push(get_custom_resources_table(custom, service_name));
         };
 
         output.join("\n")
@@ -148,6 +153,9 @@ fn get_persist_table(persist_instances: &[&Response], service_name: &str) -> Str
             .add_attribute(Attribute::Bold)]);
 
     for _ in persist_instances {
+        // TODO: add some information that would make the persist resource identifiable.
+        // This requires changing the backend resource list response to include a resource identifier
+        // that can be used to query for more info related to a resource.
         table.add_row(vec!["Instance"]);
     }
 
@@ -156,6 +164,35 @@ fn get_persist_table(persist_instances: &[&Response], service_name: &str) -> Str
 {table}
 "#,
         "persist instances".bold(),
+        service_name
+    )
+}
+
+fn get_custom_resources_table(
+    custom_resource_instances: &[&Response],
+    service_name: &str,
+) -> String {
+    let mut table = Table::new();
+
+    table
+        .load_preset(UTF8_FULL)
+        .apply_modifier(UTF8_ROUND_CORNERS)
+        .set_header(vec![Cell::new("Instances")
+            .set_alignment(CellAlignment::Center)
+            .add_attribute(Attribute::Bold)]);
+
+    for (idx, _) in custom_resource_instances.iter().enumerate() {
+        // TODO: add some information that would make the custom resources identifiable.
+        // This requires changing the backend resource list response to include a resource identifier
+        // that can be used to query for more info related to a resource.
+        table.add_row(vec![format!("custom-resource-{}", idx.to_string())]);
+    }
+
+    format!(
+        r#"These {} are linked to {}
+{table}
+"#,
+        "custom resource instances".bold(),
         service_name
     )
 }

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -153,9 +153,6 @@ fn get_persist_table(persist_instances: &[&Response], service_name: &str) -> Str
             .add_attribute(Attribute::Bold)]);
 
     for _ in persist_instances {
-        // TODO: add some information that would make the persist resource identifiable.
-        // This requires changing the backend resource list response to include a resource identifier
-        // that can be used to query for more info related to a resource.
         table.add_row(vec!["Instance"]);
     }
 

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -36,6 +36,7 @@ pub enum Type {
     StaticFolder,
     Persist,
     Turso,
+    Custom,
 }
 
 impl Response {
@@ -60,6 +61,7 @@ impl Display for Type {
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
             Type::Turso => write!(f, "turso"),
+            Type::Custom => write!(f, "custom"),
         }
     }
 }

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -376,7 +376,7 @@ impl ResourceManager for Persistence {
             "INSERT OR REPLACE INTO resources (service_id, type, config, data) VALUES (?, ?, ?, ?)",
         )
         .bind(resource.service_id)
-        .bind(resource.r#type)
+        .bind(resource.r#type.clone())
         .bind(&resource.config)
         .bind(&resource.data)
         .execute(&self.pool)

--- a/deployer/src/persistence/resource/mod.rs
+++ b/deployer/src/persistence/resource/mod.rs
@@ -36,13 +36,14 @@ impl From<Resource> for shuttle_common::resource::Response {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Type {
     Database(DatabaseType),
     Secrets,
     StaticFolder,
     Persist,
     Turso,
+    Custom,
 }
 
 impl From<Type> for shuttle_common::resource::Type {
@@ -53,6 +54,7 @@ impl From<Type> for shuttle_common::resource::Type {
             Type::StaticFolder => Self::StaticFolder,
             Type::Persist => Self::Persist,
             Type::Turso => Self::Turso,
+            Type::Custom => Self::Custom,
         }
     }
 }
@@ -65,6 +67,7 @@ impl From<shuttle_common::resource::Type> for Type {
             shuttle_common::resource::Type::StaticFolder => Self::StaticFolder,
             shuttle_common::resource::Type::Persist => Self::Persist,
             shuttle_common::resource::Type::Turso => Self::Turso,
+            shuttle_common::resource::Type::Custom => Self::Custom,
         }
     }
 }
@@ -77,6 +80,7 @@ impl Display for Type {
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
             Type::Turso => write!(f, "turso"),
+            Type::Custom => write!(f, "custom"),
         }
     }
 }
@@ -145,6 +149,7 @@ mod tests {
             Type::StaticFolder,
             Type::Persist,
             Type::Turso,
+            Type::Custom,
         ];
 
         for input in inputs {

--- a/deployer/src/persistence/resource/mod.rs
+++ b/deployer/src/persistence/resource/mod.rs
@@ -100,6 +100,7 @@ impl FromStr for Type {
                 "static_folder" => Ok(Self::StaticFolder),
                 "persist" => Ok(Self::Persist),
                 "turso" => Ok(Self::Turso),
+                "custom" => Ok(Self::Custom),
                 _ => Err(format!("'{s}' is an unknown resource type")),
             }
         }

--- a/resource-recorder/src/type/mod.rs
+++ b/resource-recorder/src/type/mod.rs
@@ -11,6 +11,7 @@ pub enum Type {
     StaticFolder,
     Persist,
     Turso,
+    Custom,
 }
 
 impl Display for Type {
@@ -21,6 +22,7 @@ impl Display for Type {
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
             Type::Turso => write!(f, "turso"),
+            Type::Custom => write!(f, "custom"),
         }
     }
 }
@@ -40,6 +42,7 @@ impl FromStr for Type {
                 "static_folder" => Ok(Self::StaticFolder),
                 "persist" => Ok(Self::Persist),
                 "turso" => Ok(Self::Turso),
+                "custom" => Ok(Self::Custom),
                 _ => Err(format!("'{s}' is an unknown resource type")),
             }
         }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -52,72 +52,14 @@ pub trait Factory: Send + Sync {
 /// This is mainly meant for consumption by our code generator and should generally not be called by users.
 ///
 /// ## Creating your own managed resource
-/// You may want to create your own managed resource by implementing this trait for some builder `B` to construct resource `T`. [`Factory`] can be used to provision resources
-/// on shuttle's servers if your resource will need any.
 ///
-/// Your resource will be available on a [shuttle_runtime::main][main] function as follow:
-/// ```
-/// #[shuttle_runtime::main]
-/// async fn my_service(
-///     [custom_resource_crate::namespace::B] custom_resource: T,
-/// ) -> shuttle_axum::ShuttleAxum {}
-/// ```
+/// You may want to create your own managed resource by implementing this trait for some builder `B` to construct resource `T`.
+/// [`Factory`] can be used to provision resources on Shuttle's servers if your service will need any.
 ///
-/// Here `custom_resource_crate::namespace` is the crate and namespace to a builder `B` that implements [`ResourceBuilder`] to create resource `T`.
+/// Please refer to `shuttle-examples/custom-resource` for examples of how to create custom resource. For more advanced provisioning
+/// of custom resources, please [get in touch](https://discord.gg/shuttle) and detail your use case. We'll be interested to see what you
+/// want to provision and how to do it on your behalf on the fly.
 ///
-/// ### Example
-/// ```
-/// pub struct Builder {
-///     name: String,
-/// }
-///
-/// pub struct Resource {
-///     name: String,
-/// }
-///
-/// impl Builder {
-///     /// Name to give resource
-///     pub fn name(self, name: &str) -> Self {
-///         self.name = name.to_string();
-///
-///         self
-///     }
-/// }
-///
-/// #[async_trait]
-/// impl ResourceBuilder<Resource> for Builder {
-///     const TYPE: Type = Type::Custom;
-///
-///     type Config = Self;
-///
-///     type Output = String;
-///
-///     fn new() -> Self {
-///         Self {
-///             name: String::new(),
-///         }
-///     }
-///
-///     fn config(&self) -> &Self::Config {
-///         self
-///     }
-///
-///     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, shuttle_service::Error> {
-///         Ok(self.name)
-///     }
-///
-///     async fn build(build_data: &Self::Output) -> Result<Resource, shuttle_service::Error> {
-///         Ok(Resource { name: build_data })
-///     }
-/// }
-/// ```
-///
-/// Then using this resource in a service:
-/// ```
-/// #[shuttle_runtime::main]
-/// async fn my_service(
-///     [custom_resource_crate::Builder(name = "John")] resource: custom_resource_crate::Resource
-/// ) -> shuttle_axum::ShuttleAxum {}
 /// ```
 #[async_trait]
 pub trait ResourceBuilder<T> {


### PR DESCRIPTION
## Description of change

The `shuttle-common::resource::Type` misses the `Type::Custom` variant that gets to be used when provisioning custom resources according to the `service` crate docs.

## How has this been tested? (if applicable)
Locally against https://github.com/shuttle-hq/shuttle-examples/pull/73 and on unstable.


