### PR TITLE
feat(runtime): add alpha runtime version check

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -604,6 +604,18 @@ impl Shuttle {
                 runtime_path
             } else {
                 trace!(path = ?executable_path, "using alpha runtime");
+                if let Err(err) = check_version(&executable_path) {
+                    println!("Warning: {}.", err);
+                    println!(
+                        "[HINT]: cargo-shuttle is on version {VERSION}. \
+                        Check this project's Cargo.toml if shuttle-runtime matches this."
+                    );
+                    println!(
+                        "[HINT]: If cargo-shuttle was installed \
+                        using cargo, you can get the latest version \
+                        by running `cargo install cargo-shuttle`."
+                    );
+                }
                 executable_path.clone()
             }
         };

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1397,11 +1397,11 @@ fn check_version(runtime_path: &Path) -> Result<()> {
 /// nonzero digit is the same."
 fn semvers_are_compatible(a: &semver::Version, b: &semver::Version) -> bool {
     if a.major != 0 || b.major != 0 {
-        return a.major == b.major;
+        a.major == b.major
     } else if a.minor != 0 || b.minor != 0 {
-        return a.minor == b.minor;
+        a.minor == b.minor
     } else {
-        return a.patch == b.patch;
+        a.patch == b.patch
     }
 }
 
@@ -1630,7 +1630,6 @@ version = "0.1.0"
             ("1.0.0", "1.0.0", true),
             ("1.8.0", "1.0.0", true),
             ("0.1.0", "0.2.1", false),
-            ("0.9.0", "0.2.0", false),
             ("0.9.0", "0.2.0", false),
         ];
         for (version_a, version_b, are_compatible) in semver_tests {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -605,16 +605,27 @@ impl Shuttle {
             } else {
                 trace!(path = ?executable_path, "using alpha runtime");
                 if let Err(err) = check_version(&executable_path) {
-                    println!("Warning: {}.", err);
-                    println!(
-                        "[HINT]: cargo-shuttle is on version {VERSION}. \
-                        Check this project's Cargo.toml if shuttle-runtime matches this."
-                    );
-                    println!(
-                        "[HINT]: If cargo-shuttle was installed \
-                        using cargo, you can get the latest version \
-                        by running `cargo install cargo-shuttle`."
-                    );
+                    warn!("{}", err);
+                    if let Some(mismatch) = err.downcast_ref::<VersionMismatchError>() {
+                        println!("Warning: {}.", mismatch);
+                        if mismatch.shuttle_runtime > mismatch.cargo_shuttle {
+                            // The runtime is newer than cargo-shuttle so we
+                            // should help the user to update cargo-shuttle.
+                            println!(
+                                "[HINT]: You should update cargo-shuttle. \
+                                If cargo-shuttle was installed using cargo, \
+                                you can get the latest version by running \
+                                `cargo install cargo-shuttle`."
+                            );
+                        } else {
+                            println!(
+                                "[HINT]: You should update shuttle-runtime. \
+                                Change its version to {} in this project's \
+                                Cargo.toml to use a compatible version.",
+                                mismatch.cargo_shuttle
+                            );
+                        }
+                    }
                 }
                 executable_path.clone()
             }
@@ -1345,8 +1356,7 @@ impl Shuttle {
 
 fn check_version(runtime_path: &Path) -> Result<()> {
     let valid_version = semver::Version::from_str(VERSION)
-        .context("failed to convert runtime version to semver")?
-        .to_string();
+        .context("failed to convert runtime version to semver")?;
 
     if !runtime_path.try_exists()? {
         bail!("shuttle-runtime is not installed");
@@ -1369,15 +1379,49 @@ fn check_version(runtime_path: &Path) -> Result<()> {
             .1
             .trim(),
     )
-    .context("failed to convert runtime version to semver")?
-    .to_string();
+    .context("failed to convert runtime version to semver")?;
 
-    if runtime_version == valid_version {
+    if semvers_are_compatible(&valid_version, &runtime_version) {
         Ok(())
     } else {
-        bail!("shuttle-runtime and cargo-shuttle are not the same version")
+        Err(VersionMismatchError {
+            shuttle_runtime: runtime_version,
+            cargo_shuttle: valid_version,
+        })
+        .context("shuttle-runtime and cargo-shuttle have incompatible versions")
     }
 }
+
+/// Check if two versions are compatible based on the rule used by
+/// cargo: "Versions `a` and `b` are compatible if their left-most
+/// nonzero digit is the same."
+fn semvers_are_compatible(a: &semver::Version, b: &semver::Version) -> bool {
+    if a.major != 0 || b.major != 0 {
+        return a.major == b.major;
+    } else if a.minor != 0 || b.minor != 0 {
+        return a.minor == b.minor;
+    } else {
+        return a.patch == b.patch;
+    }
+}
+
+#[derive(Debug)]
+struct VersionMismatchError {
+    shuttle_runtime: semver::Version,
+    cargo_shuttle: semver::Version,
+}
+
+impl std::fmt::Display for VersionMismatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "shuttle-runtime {} and cargo-shuttle {} are incompatible",
+            self.shuttle_runtime, self.cargo_shuttle
+        )
+    }
+}
+
+impl std::error::Error for VersionMismatchError {}
 
 fn create_spinner() -> ProgressBar {
     let pb = indicatif::ProgressBar::new_spinner();
@@ -1578,5 +1622,24 @@ version = "0.1.0"
         entries.sort();
 
         assert_eq!(entries, vec!["Cargo.lock", "Cargo.toml", "src/main.rs"]);
+    }
+
+    #[test]
+    fn semver_compatibility_check_works() {
+        let semver_tests = &[
+            ("1.0.0", "1.0.0", true),
+            ("1.8.0", "1.0.0", true),
+            ("0.1.0", "0.2.1", false),
+            ("0.9.0", "0.2.0", false),
+            ("0.9.0", "0.2.0", false),
+        ];
+        for (version_a, version_b, are_compatible) in semver_tests {
+            let version_a = semver::Version::from_str(version_a).unwrap();
+            let version_b = semver::Version::from_str(version_b).unwrap();
+            assert_eq!(
+                super::semvers_are_compatible(&version_a, &version_b),
+                *are_compatible
+            );
+        }
     }
 }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -619,9 +619,8 @@ impl Shuttle {
                             );
                         } else {
                             println!(
-                                "[HINT]: You should update shuttle-runtime. \
-                                Change its version to {} in this project's \
-                                Cargo.toml to use a compatible version.",
+                                "[HINT]: A newer version of shuttle-runtime is available. \
+                                Change its version to {} in this project's Cargo.toml to update it.",
                                 mismatch.cargo_shuttle
                             );
                         }

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -51,7 +51,7 @@ mod args;
 
 pub async fn start(loader: impl Loader<ProvisionerFactory> + Send + 'static) {
     // `--version` overrides any other arguments.
-    if std::env::args().find(|arg| arg == "--version").is_some() {
+    if std::env::args().any(|arg| &arg == "--version") {
         let name = env!("CARGO_PKG_NAME");
         let version = env!("CARGO_PKG_VERSION");
         println!("{name} {version}");

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -43,7 +43,7 @@ use tonic::{
 use tower::ServiceBuilder;
 use tracing::{error, info, trace, warn};
 
-use crate::{provisioner_factory::ProvisionerFactory, Logger, ResourceTracker};
+use crate::{print_version, provisioner_factory::ProvisionerFactory, Logger, ResourceTracker};
 
 use self::args::Args;
 
@@ -52,9 +52,7 @@ mod args;
 pub async fn start(loader: impl Loader<ProvisionerFactory> + Send + 'static) {
     // `--version` overrides any other arguments.
     if std::env::args().any(|arg| &arg == "--version") {
-        let name = env!("CARGO_PKG_NAME");
-        let version = env!("CARGO_PKG_VERSION");
-        println!("{name} {version}");
+        print_version();
         return;
     }
 

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -50,6 +50,14 @@ use self::args::Args;
 mod args;
 
 pub async fn start(loader: impl Loader<ProvisionerFactory> + Send + 'static) {
+    // `--version` overrides any other arguments.
+    if std::env::args().find(|arg| arg == "--version").is_some() {
+        let name = env!("CARGO_PKG_NAME");
+        let version = env!("CARGO_PKG_VERSION");
+        println!("{name} {version}");
+        return;
+    }
+
     let args = match Args::parse() {
         Ok(args) => args,
         Err(e) => {

--- a/runtime/src/bin/shuttle-next.rs
+++ b/runtime/src/bin/shuttle-next.rs
@@ -5,7 +5,7 @@ use std::{
 
 use shuttle_common::backends::tracing::{setup_tracing, ExtractPropagationLayer};
 use shuttle_proto::runtime::runtime_server::RuntimeServer;
-use shuttle_runtime::{AxumWasm, NextArgs};
+use shuttle_runtime::{print_version, AxumWasm, NextArgs};
 use tonic::transport::Server;
 use tracing::trace;
 
@@ -35,12 +35,4 @@ async fn main() {
     let router = server_builder.add_service(svc);
 
     router.serve(addr).await.unwrap();
-}
-
-fn print_version() {
-    // same way `clap` gets these
-    let name = env!("CARGO_PKG_NAME");
-    let version = env!("CARGO_PKG_VERSION");
-
-    println!("{name} {version}");
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -291,3 +291,11 @@ pub use anyhow::Context;
 pub use strfmt::strfmt;
 pub use tracing;
 pub use tracing_subscriber;
+
+// Print the version of the runtime.
+fn print_version() {
+    let name = env!("CARGO_PKG_NAME");
+    let version = env!("CARGO_PKG_VERSION");
+
+    println!("{name} {version}");
+}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,7 +293,7 @@ pub use tracing;
 pub use tracing_subscriber;
 
 // Print the version of the runtime.
-fn print_version() {
+pub fn print_version() {
     let name = env!("CARGO_PKG_NAME");
     let version = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
Add a version flag check to the alpha runtime and check if its version is the same as the version of cargo-shuttle. Warn the user if that is not the case and give hints. The next runtime already has such a check.

Closes #1053