### PR TITLE
feat: add a project_id to gateway

### DIFF
--- a/gateway/build.rs
+++ b/gateway/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let crate_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    // Set the LD_LIBRARY_PATH to the crate root so the sqlite migrations
+    // can find the ulid0.so file which is used for sqlite ulid generation.
+    println!("cargo:rustc-env=LD_LIBRARY_PATH={crate_root}");
+}

--- a/gateway/migrations/0005_refactor_to_ulid_primary_key.sql
+++ b/gateway/migrations/0005_refactor_to_ulid_primary_key.sql
@@ -1,0 +1,56 @@
+UPDATE projects SET created_at = datetime('2023-06-01') WHERE created_at IS NULL;
+
+-- We need to create a copy of the table to alter the primary key to the new project_id column.
+CREATE TABLE IF NOT EXISTS projects_copy (
+  project_id ULID PRIMARY KEY,
+  project_name TEXT UNIQUE,
+  account_name TEXT NOT NULL,
+  initial_key TEXT NOT NULL,
+  project_state JSON NOT NULL
+);
+
+-- We use the https://github.com/asg017/sqlite-ulid extension to generate the ulid for new table.
+INSERT INTO projects_copy (project_id, project_name, account_name, initial_key, project_state)
+SELECT 
+  ulid_with_datetime(strftime('%Y-%m-%d %H:%M:%f', projects.created_at)),
+  projects.project_name,
+  projects.account_name,
+  projects.initial_key,
+  projects.project_state
+FROM projects;
+
+-- We need to create a copy of the table to be able to alter the foreign key, it was previously
+-- on project_name but will now be on the new project_id (ULID) column.
+CREATE TABLE IF NOT EXISTS custom_domains_copy (
+  fqdn TEXT PRIMARY KEY,
+  project_id ULID NOT NULL, -- First create the table without the FK constraint on project_id.
+  certificate TEXT NOT NULL,
+  private_key TEXT NOT NULL
+);
+
+INSERT INTO custom_domains_copy (fqdn, project_id, certificate, private_key)
+SELECT 
+  custom_domains.fqdn,
+  projects_copy.project_id, -- Copy the generated ulid from the related projects_copy row.
+  custom_domains.fqdn,
+  custom_domains.private_key
+FROM custom_domains
+JOIN projects_copy ON projects_copy.project_name = custom_domains.project_name;
+
+-- Drop this first, it has an FK to projects.
+DROP TABLE custom_domains;
+
+-- Replace the old projects table with the updated one.
+DROP TABLE projects;
+ALTER TABLE projects_copy RENAME TO projects;
+
+-- Recreate the custom_domains table with an FK constraint on the project_id.
+CREATE TABLE custom_domains (
+  fqdn TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects (project_id),
+  certificate TEXT NOT NULL,
+  private_key TEXT NOT NULL
+);
+
+INSERT INTO custom_domains SELECT * FROM custom_domains_copy;
+DROP TABLE custom_domains_copy;

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -47,7 +47,11 @@ async fn main() -> io::Result<()> {
     let sqlite_options = SqliteConnectOptions::from_str(db_uri)
         .unwrap()
         .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal);
+        .synchronous(SqliteSynchronous::Normal)
+        // Set the ulid0 extension for generating ULID's in migrations.
+        // This uses the ulid0.so file in the crate root, with the
+        // LD_LIBRARY_PATH env set in build.rs.
+        .extension("ulid0");
 
     let db = SqlitePool::connect_with(sqlite_options).await.unwrap();
     MIGRATIONS.run(&db).await.unwrap();

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -289,7 +289,7 @@ impl GatewayService {
 
         query
             .push_bind(account_name)
-            .push(" ORDER BY created_at DESC NULLS LAST, project_name LIMIT ")
+            .push(" ORDER BY project_id DESC, project_name LIMIT ")
             .push_bind(limit);
 
         if offset > 0 {
@@ -398,7 +398,7 @@ impl GatewayService {
     ) -> Result<Project, Error> {
         if let Some(row) = query(
             r#"
-        SELECT project_name, account_name, initial_key, project_state
+        SELECT project_name, project_id, account_name, initial_key, project_state
         FROM projects
         WHERE (project_name = ?1)
         AND (account_name = ?2 OR ?3)
@@ -412,6 +412,7 @@ impl GatewayService {
         {
             // If the project already exists and belongs to this account
             let project = row.get::<SqlxJson<Project>, _>("project_state").0;
+            let project_id = row.get::<String, _>("project_id");
             if project.is_destroyed() {
                 // But is in `::Destroyed` state, recreate it
                 let mut creating = ProjectCreating::new_with_random_initial_key(
@@ -419,7 +420,7 @@ impl GatewayService {
                     idle_minutes,
                 );
                 // Restore previous custom domain, if any
-                match self.find_custom_domain_for_project(&project_name).await {
+                match self.find_custom_domain_for_project(&project_id).await {
                     Ok(custom_domain) => {
                         creating = creating.with_fqdn(custom_domain.fqdn.to_string());
                     }
@@ -462,7 +463,7 @@ impl GatewayService {
             ProjectCreating::new_with_random_initial_key(project_name.clone(), idle_minutes),
         ));
 
-        query("INSERT INTO projects (project_name, account_name, initial_key, project_state, created_at) VALUES (?1, ?2, ?3, ?4, CURRENT_TIMESTAMP)")
+        query("INSERT INTO projects (project_id, project_name, account_name, initial_key, project_state) VALUES (ulid(), ?1, ?2, ?3, ?4)")
             .bind(&project_name)
             .bind(&account_name)
             .bind(project.initial_key().unwrap())
@@ -473,7 +474,7 @@ impl GatewayService {
                 // If the error is a broken PK constraint, this is a
                 // project name clash
                 if let Some(db_err_code) = err.as_database_error().and_then(DatabaseError::code) {
-                    if db_err_code == "1555" {  // SQLITE_CONSTRAINT_PRIMARYKEY
+                    if db_err_code == "2067" {  // SQLITE_CONSTRAINT_UNIQUE
                         return Error::from_kind(ErrorKind::ProjectAlreadyExists)
                     }
                 }
@@ -493,9 +494,15 @@ impl GatewayService {
         certs: &str,
         private_key: &str,
     ) -> Result<(), Error> {
-        query("INSERT OR REPLACE INTO custom_domains (fqdn, project_name, certificate, private_key) VALUES (?1, ?2, ?3, ?4)")
-            .bind(fqdn.to_string())
+        let project_id = query("SELECT project_id FROM projects WHERE project_name = ?1")
             .bind(project_name)
+            .fetch_one(&self.db)
+            .await?
+            .get::<String, _>("project_id");
+
+        query("INSERT OR REPLACE INTO custom_domains (fqdn, project_id, certificate, private_key) VALUES (?1, ?2, ?3, ?4)")
+            .bind(fqdn.to_string())
+            .bind(project_id)
             .bind(certs)
             .bind(private_key)
             .execute(&self.db)
@@ -505,7 +512,7 @@ impl GatewayService {
     }
 
     pub async fn iter_custom_domains(&self) -> Result<impl Iterator<Item = CustomDomain>, Error> {
-        query("SELECT fqdn, project_name, certificate, private_key FROM custom_domains")
+        query("SELECT fqdn, project_name, certificate, private_key FROM custom_domains AS cd JOIN projects AS p ON cd.project_id = p.project_id")
             .fetch_all(&self.db)
             .await
             .map(|res| {
@@ -519,14 +526,14 @@ impl GatewayService {
             .map_err(|_| Error::from_kind(ErrorKind::Internal))
     }
 
-    pub async fn find_custom_domain_for_project(
+    async fn find_custom_domain_for_project(
         &self,
-        project_name: &ProjectName,
+        project_id: &str,
     ) -> Result<CustomDomain, Error> {
         let custom_domain = query(
-            "SELECT fqdn, project_name, certificate, private_key FROM custom_domains WHERE project_name = ?1",
+            "SELECT fqdn, project_name, certificate, private_key FROM custom_domains AS cd JOIN projects AS p ON cd.project_id = p.project_id WHERE p.project_id = ?1",
         )
-        .bind(project_name.to_string())
+        .bind(project_id)
         .fetch_optional(&self.db)
         .await?
         .map(|row| CustomDomain {
@@ -544,7 +551,7 @@ impl GatewayService {
         fqdn: &Fqdn,
     ) -> Result<CustomDomain, Error> {
         let custom_domain = query(
-            "SELECT fqdn, project_name, certificate, private_key FROM custom_domains WHERE fqdn = ?1",
+            "SELECT fqdn, project_name, certificate, private_key FROM custom_domains AS cd JOIN projects AS p ON cd.project_id = p.project_id WHERE fqdn = ?1",
         )
         .bind(fqdn.to_string())
         .fetch_optional(&self.db)
@@ -828,7 +835,7 @@ pub mod tests {
                 .unwrap();
         }
 
-        // We need to fetch all of them from the DB since they are ordered by created_at and project_name,
+        // We need to fetch all of them from the DB since they are ordered by created_at (in the id) and project_name,
         // and created_at will be the same for some of them.
         let all_projects = svc
             .iter_user_projects_detailed(&neo, 0, u32::MAX)


### PR DESCRIPTION
## Description of change
This adds a ULID for project IDs to gateway. This will be needed for the new resource recorder.

It also replaces the need for a `created_at` field since the ULID has a timestamp in it.

Most of gateway still uses the project name (and not this new id) everywhere. I think this is fine for now as the deployer update will take care to switch over to the IDs.

## How has this been tested? (if applicable)
By running all the tests locally


