### PR TITLE
feat: honeycomb for local runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ USE_PANAMAX=disable make up
 
 > Note: `make up` can also be run with `SHUTTLE_DETACH=disable`, which means docker-compose will not be run with `--detach`. This is often desirable for local testing.
 
+> Note: `make up` can also be run with `HONEYCOMB_API_KEY=<api_key>` if you have a honeycomb.io account and want to test the instrumentation of the services. This is mostly used only by the internal team.
+
 > Note: Other useful commands can be found within the [Makefile](https://github.com/shuttle-hq/shuttle/blob/main/Makefile).
 
 The API is now accessible on `localhost:8000` (for app proxies) and `localhost:8001` (for the control plane). When running `cargo run --bin cargo-shuttle` (in a debug build), the CLI will point itself to `localhost` for its API calls.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,6 +198,7 @@ services:
     environment:
       - DD_API_KEY=${DD_API_KEY}
       - DD_ENV=${DD_ENV}
+      - HONEYCOMB_API_KEY=${HONEYCOMB_API_KEY}
     deploy:
       placement:
         constraints:

--- a/extras/otel/otel-collector-config.yaml
+++ b/extras/otel/otel-collector-config.yaml
@@ -54,16 +54,20 @@ exporters:
     api:
       site: datadoghq.eu
       key: ${env:DD_API_KEY}
+  otlp:
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": ${env:HONEYCOMB_API_KEY}
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [attributes, batch]
-      exporters: [datadog]
+      exporters: [datadog, otlp]
     logs:
       receivers: [otlp]
       processors: [attributes, batch]
-      exporters: [datadog]
+      exporters: [datadog, otlp]
     metrics:
       receivers: [hostmetrics, prometheus/otel, otlp]
       processors: [batch]


### PR DESCRIPTION
## Description of change
This enables honeycomb but for local runs only. There will be a separate PR to update the CI for production

## How has this been tested? (if applicable)
By checking the traces in my honeycomb account.


