### PR TITLE
gateway: add LD_LIBRARY_PATH in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - ${DOCKER_SOCK}:/var/run/docker.sock
     environment:
       - RUST_LOG=${RUST_LOG}
+      - LD_LIBRARY_PATH=/usr/src/shuttle
     command:
       - "--state=/var/lib/shuttle"
       - "start"


### PR DESCRIPTION
## Description of change

The ulid0.so can not be found when deploying on unstable from main.


## How has this been tested? (if applicable)

Previously tested in #1099 


