### PR TITLE
deployer: fixed runtime logs receiving

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -522,7 +522,7 @@ impl Shuttle {
         run_args: &RunArgs,
         service: &BuiltService,
         provisioner_server: &JoinHandle<Result<(), tonic::transport::Error>>,
-        i: u16,
+        idx: u16,
         provisioner_port: u16,
     ) -> Result<
         Option<(
@@ -614,7 +614,7 @@ impl Shuttle {
             StorageManagerType::WorkingDir(working_directory.to_path_buf()),
             &format!("http://localhost:{provisioner_port}"),
             None,
-            run_args.port - i - 1,
+            run_args.port - idx - 1,
             runtime_path,
         )
         .await
@@ -682,7 +682,7 @@ impl Shuttle {
                 Ipv4Addr::LOCALHOST
             }
             .into(),
-            run_args.port + i,
+            run_args.port + idx,
         );
 
         println!(

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -36,7 +36,6 @@ mod tests {
 
     #[test]
     fn test_state_deser() {
-        println!("bla");
         assert_eq!(State::Queued, State::from_str("Queued").unwrap());
         assert_eq!(State::Unknown, State::from_str("unKnown").unwrap());
         assert_eq!(State::Built, State::from_str("built").unwrap());

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -27,3 +27,18 @@ pub enum Environment {
     Local,
     Production,
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::deployment::State;
+
+    #[test]
+    fn test_state_deser() {
+        println!("bla");
+        assert_eq!(State::Queued, State::from_str("Queued").unwrap());
+        assert_eq!(State::Unknown, State::from_str("unKnown").unwrap());
+        assert_eq!(State::Built, State::from_str("built").unwrap());
+    }
+}

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
-use strum::Display;
+use strum::{Display, EnumString};
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Display, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Display, Serialize, EnumString)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
+#[strum(ascii_case_insensitive)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[cfg_attr(feature = "openapi", schema(as = shuttle_common::deployment::State))]
 pub enum State {

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -118,7 +118,7 @@ impl TryFrom<runtime::LogItem> for Log {
     fn try_from(log: runtime::LogItem) -> Result<Self, Self::Error> {
         Ok(Self {
             id: Default::default(),
-            state: State::from_str(&log.state).map_err(|err| ParseError::State(err.to_string()))?,
+            state: State::from_str(&log.state).unwrap_or_default(),
             level: runtime::LogLevel::from_i32(log.level)
                 .unwrap_or_default()
                 .into(),

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -406,8 +406,7 @@ async fn run(
             info!(response = ?response.into_inner(),  "start client response: ");
 
             // Wait for stop reason
-            let reason: Option<SubscribeStopResponse> =
-                stream.message().await.expect("message from tonic stream");
+            let reason = stream.message().await.expect("message from tonic stream");
 
             cleanup(reason);
         }

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -406,7 +406,8 @@ async fn run(
             info!(response = ?response.into_inner(),  "start client response: ");
 
             // Wait for stop reason
-            let reason = stream.message().await.expect("message from tonic stream");
+            let reason: Option<SubscribeStopResponse> =
+                stream.message().await.expect("message from tonic stream");
 
             cleanup(reason);
         }

--- a/deployer/src/persistence/state.rs
+++ b/deployer/src/persistence/state.rs
@@ -70,3 +70,17 @@ impl From<shuttle_common::deployment::State> for State {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::persistence::State;
+
+    #[test]
+    fn test_state_deser() {
+        assert_eq!(State::Building, State::from_str("builDing").unwrap());
+        assert_eq!(State::Queued, State::from_str("queued").unwrap());
+        assert_eq!(State::Stopped, State::from_str("Stopped").unwrap());
+    }
+}

--- a/deployer/src/persistence/state.rs
+++ b/deployer/src/persistence/state.rs
@@ -3,6 +3,7 @@ use utoipa::ToSchema;
 
 /// States a deployment can be in
 #[derive(sqlx::Type, Debug, Display, Clone, Copy, EnumString, PartialEq, Eq, ToSchema)]
+#[strum(ascii_case_insensitive)]
 pub enum State {
     /// Deployment is queued to be build
     Queued,

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -130,7 +130,6 @@ impl RuntimeManager {
             while let Ok(Some(log)) = stream.message().await {
                 if let Ok(mut log) = deploy_layer::Log::try_from(log) {
                     log.id = id;
-
                     sender.send(log).expect("to send log to persistence");
                 }
             }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - ${DOCKER_SOCK}:/var/run/docker.sock
     environment:
       - RUST_LOG=${RUST_LOG}
-      - LD_LIBRARY_PATH=/usr/src/shuttle
+      - LD_LIBRARY_PATH=/usr/src/shuttle/gateway
     command:
       - "--state=/var/lib/shuttle"
       - "start"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -98,6 +98,7 @@ pub mod runtime {
     use std::{
         convert::TryFrom,
         path::PathBuf,
+        str::FromStr,
         time::{Duration, SystemTime},
     };
 
@@ -140,7 +141,7 @@ pub mod runtime {
             Ok(Self {
                 id: Default::default(),
                 timestamp: DateTime::from(SystemTime::try_from(log.timestamp.unwrap_or_default())?),
-                state: shuttle_common::deployment::State::Running,
+                state: State::from_str(&log.state).unwrap_or(State::Unknown),
                 level: LogLevel::from_i32(log.level).unwrap_or_default().into(),
                 file: log.file,
                 line: log.line,

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -315,8 +315,6 @@ where
             .context("invalid socket address")
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
-        let _logs_tx = self.logs_tx.clone();
-
         trace!(%service_address, "starting");
 
         let (kill_tx, kill_rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
## Description of change
Fixed runtime logs sending to the deployer.

## How has this been tested? (if applicable)
Locally, by deploying a project and querying for the service logs. I was able to see the rocket logs of a rocket service.