### PR TITLE
feat: expand gateways args to receive the key for the machine user

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,6 @@ Finally, before gateway will be able to work with some projects, we need to crea
 The following command inserts a gateway user into the `auth` state with deployer privileges:
 
 ```bash
-# the --key needs to be 16 alphanumeric characters
 docker compose --file docker-compose.rendered.yml --project-name shuttle-dev exec auth /usr/local/bin/service --state=/var/lib/shuttle-auth init-deployer --name gateway --key gateway4deployes
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ DD_ENV=unstable
 USE_TLS?=disable
 CARGO_PROFILE=debug
 RUST_LOG?=shuttle=trace,debug
+DEPLOYS_API_KEY?=gateway4deployes
 endif
 
 POSTGRES_EXTRA_PATH?=./extras/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - "--network-name=${STACK}_user-net"
       - "--docker-host=/var/run/docker.sock"
       - "--auth-uri=http://auth:8000"
+      - "--deploys-api-key=${DEPLOYS_API_KEY}"
       - "--provisioner-host=provisioner"
       - "--proxy-fqdn=${APPS_FQDN}"
       - "--use-tls=${USE_TLS}"

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -68,4 +68,7 @@ pub struct ContextArgs {
     /// The path to the docker daemon socket
     #[arg(long, default_value = "/var/run/docker.sock")]
     pub docker_host: String,
+    /// Api key for the user that has rights to start deploys
+    #[arg(long, default_value = "gateway4deployes")]
+    pub deploys_api_key: String,
 }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -586,6 +586,11 @@ pub mod tests {
             let auth_uri: Uri = format!("http://{auth}").parse().unwrap();
 
             let auth_service = AuthService::new(auth);
+            auth_service
+                .lock()
+                .unwrap()
+                .users
+                .insert("gateway".to_string(), vec![Scope::Resources]);
 
             let prefix = format!(
                 "shuttle_test_{}_",
@@ -615,6 +620,7 @@ pub mod tests {
                     auth_uri: auth_uri.clone(),
                     network_name,
                     proxy_fqdn: FQDN::from_str("test.shuttleapp.rs").unwrap(),
+                    deploys_api_key: "gateway".to_string(),
                 },
             };
 

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -1177,6 +1177,10 @@ impl ProjectReady {
     pub async fn is_healthy(&mut self) -> bool {
         self.service.is_healthy().await
     }
+
+    pub async fn start_last_deploy(&mut self, api_key: String) {
+        self.service.start_last_deploy(api_key).await
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1233,6 +1237,10 @@ impl Service {
         let is_healthy = matches!(resp, Ok(Ok(res)) if res.status().is_success());
         self.last_check = Some(HealthCheckRecord::new(is_healthy));
         is_healthy
+    }
+
+    pub async fn start_last_deploy(&mut self, _api_key: String) {
+        // TODO: convert the key to a JWT, get last deployment and start it (ENG-816)
     }
 }
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -193,6 +193,7 @@ pub struct GatewayService {
     // We store these because we'll need them for the health checks
     provisioner_host: Endpoint,
     auth_host: Uri,
+    api_key: String,
 }
 
 impl GatewayService {
@@ -216,6 +217,7 @@ impl GatewayService {
             provisioner_host: Endpoint::new(format!("http://{}:8000", args.provisioner_host))
                 .expect("to have a valid provisioner endpoint"),
             auth_host: args.auth_uri,
+            api_key: args.deploys_api_key,
         }
     }
 
@@ -721,6 +723,7 @@ impl GatewayService {
                 .project(project_name.clone())
                 .and_then(task::start())
                 .and_then(task::run_until_done())
+                .and_then(task::start_idle_deploys())
                 .and_then(task::check_health())
                 .send(&task_sender)
                 .await?;
@@ -755,6 +758,9 @@ impl GatewayService {
     }
     pub fn auth_uri(&self) -> &Uri {
         &self.auth_host
+    }
+    pub fn api_key(&self) -> String {
+        self.api_key.clone()
     }
 }
 


### PR DESCRIPTION
## Description of change
Expands gateways args with the key that will allow it to start up old deploys.

The work of converting the key to a JWT and starting the last idle deploys forms part of another ticket.

## How has this been tested? (if applicable)
By trying to start gateway locally (with the Makefile) to confirm every works correctly


