### PR TITLE
chore: bump sqlx in resources

### DIFF
--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1.56"
 paste = "1.0.7"
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.21.0" }
-sqlx = { version = "0.6.2", features = ["runtime-tokio-native-tls"] }
+sqlx = { version = "0.7.1", features = ["runtime-tokio-native-tls"] }
 
 [features]
 postgres = ["sqlx/postgres"]

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -11,8 +11,7 @@ async-trait = "0.1.56"
 mongodb = { version = "2.3.0", optional = true }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.21.0" }
-sqlx = { version = "0.6.2", optional = true }
-
+sqlx = { version = "0.7.1", optional = true }
 [features]
 postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
 postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -12,6 +12,7 @@ mongodb = { version = "2.3.0", optional = true }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.21.0" }
 sqlx = { version = "0.7.1", optional = true }
+
 [features]
 postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
 postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We need to upgrade sqlx to 0.7 in our resources, since users expect to be able to use it and it was released a while ago, but our current resources return a 0.6 pool.

Closes #1085

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Local run of all examples that use the resources on this branch: https://github.com/shuttle-hq/shuttle-examples/pull/75
