### PR TITLE
fix: add volume to mongo container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,8 @@ services:
     restart: always
     networks:
       user-net:
+    volumes:
+      - mongodb-vol:/var/lib/mongodb/data
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
   panamax-crates-vol:
   panamax-io-index-vol:
   resource-recorder-vol:
+  mongodb-vol:
 networks:
   user-net:
     attachable: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
     networks:
       user-net:
     volumes:
-      - mongodb-vol:/var/lib/mongodb/data
+      - mongodb-vol:/data/db
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We had two reports of MongoDB databases resetting recently. The reason is that the shared MongoDB container was remade, and it was never assigned a volume, so the data was not persisted. 

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Deployed the container with the new volume without losing the current data in our staging environment.
