### PR TITLE
fix: install shuttle-next runtime in deployers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -57,7 +57,8 @@ RUN /prepare.sh "${prepare_args}"
 
 COPY --from=cache /build /usr/src/shuttle/
 
-# Any prepare steps that depend on the COPY from src cache
+# Any prepare steps that depend on the COPY from src cache.
+# This step currently installs shuttle-next and adds the panamax mirror config.
 RUN /prepare.sh --after-src "${prepare_args}"
 
 COPY --from=builder /build/target/${CARGO_PROFILE}/shuttle-${folder} /usr/local/bin/service

--- a/Containerfile
+++ b/Containerfile
@@ -58,7 +58,7 @@ RUN /prepare.sh "${prepare_args}"
 COPY --from=cache /build /usr/src/shuttle/
 
 # Any prepare steps that depend on the COPY from src cache.
-# This step currently installs shuttle-next and adds the panamax mirror config.
+# In the deployer shuttle-next is installed and the panamax mirror config is added in this step.
 RUN /prepare.sh --after-src "${prepare_args}"
 
 COPY --from=builder /build/target/${CARGO_PROFILE}/shuttle-${folder} /usr/local/bin/service

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -5,17 +5,6 @@
 # service might need some extra preparation steps for its final image         #
 ###############################################################################
 
-
-# Stuff that depends on local source files
-if [ "$1" = "--after-src" ]; then
-
-    # Install the shuttle runtime
-    cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next
-
-    exit 0
-fi
-
-
 # Patch crates to be on same versions
 mkdir -p $CARGO_HOME
 touch $CARGO_HOME/config.toml
@@ -48,6 +37,9 @@ fi
 
 # Add the wasm32-wasi target
 rustup target add wasm32-wasi
+
+# Install the shuttle-next runtime for shuttle-next services.
+cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next
 
 while getopts "p," o; do
     case $o in

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -4,13 +4,14 @@
 # This file is used by our common Containerfile incase the container for this #
 # service might need some extra preparation steps for its final image         #
 ###############################################################################
+
+# Stuff that depends on local source files
 if [ "$1" = "--after-src" ]; then
     # Install the shuttle-next runtime for shuttle-next services.
     cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next --registry crates-io
 
     exit 0
 fi
-
 
 # Patch crates to be on same versions
 mkdir -p $CARGO_HOME

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -4,6 +4,13 @@
 # This file is used by our common Containerfile incase the container for this #
 # service might need some extra preparation steps for its final image         #
 ###############################################################################
+if [ "$1" = "--after-src" ]; then
+    # Install the shuttle-next runtime for shuttle-next services.
+    cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next --registry crates-io
+
+    exit 0
+fi
+
 
 # Patch crates to be on same versions
 mkdir -p $CARGO_HOME
@@ -37,9 +44,6 @@ fi
 
 # Add the wasm32-wasi target
 rustup target add wasm32-wasi
-
-# Install the shuttle-next runtime for shuttle-next services.
-cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next
 
 while getopts "p," o; do
     case $o in

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -8,8 +8,22 @@
 # Stuff that depends on local source files
 if [ "$1" = "--after-src" ]; then
     # Install the shuttle-next runtime for shuttle-next services.
-    cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next --registry crates-io
+    cargo install shuttle-runtime --path "/usr/src/shuttle/runtime" --bin shuttle-next --features next || exit 1
 
+    while getopts "p," o; do
+    case $o in
+        "p") # if panamax is used, the '-p' parameter is passed
+            # Make future crates requests to our own mirror
+            echo '
+[source.shuttle-crates-io-mirror]
+registry = "sparse+http://panamax:8080/index/"
+[source.crates-io]
+replace-with = "shuttle-crates-io-mirror"' >> $CARGO_HOME/config.toml
+                ;;
+            *)
+                ;;
+        esac
+    done
     exit 0
 fi
 
@@ -45,21 +59,6 @@ fi
 
 # Add the wasm32-wasi target
 rustup target add wasm32-wasi
-
-while getopts "p," o; do
-    case $o in
-        "p") # if panamax is used, the '-p' parameter is passed
-            # Make future crates requests to our own mirror
-            echo '
-[source.shuttle-crates-io-mirror]
-registry = "sparse+http://panamax:8080/index/"
-[source.crates-io]
-replace-with = "shuttle-crates-io-mirror"' >> $CARGO_HOME/config.toml
-            ;;
-        *)
-            ;;
-    esac
-done
 
 # Install common build tools for external crates
 # The image should already have these: https://github.com/docker-library/buildpack-deps/blob/65d69325ad741cea6dee20781c1faaab2e003d87/debian/buster/Dockerfile


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

~~This ensures the shuttle-next runtime binary is installed in the deployer, which shuttle-next services expect. This means building the deployer image will always need to install shuttle-next, which is not ideal.~~ 

The shuttle-next binary was failing to install for production builds since the prepare.sh had already ran once and set the registry to panamax, so when the prepare.sh for shuttle-next install was ran it was trying to fetch the crates from panamax (which is not available when we build the images, it is for deployers to use at runtime). 

In the future, we should consider releasing the shuttle-next binary like we do for the cargo-shuttle CLI, so it can simply be downloaded from GitHub.

Closes #1096 
## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Deployed new image to unstable and it's working now.
