### PR TITLE
feat: add service-info resource to obtain Shuttle service info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ commands:
             shuttle-shared-db = { path = "$PWD/resources/shared-db" }
             shuttle-secrets = { path = "$PWD/resources/secrets" }
             shuttle-static-folder = { path = "$PWD/resources/static-folder" }
+            shuttle-service-info = { path = "$PWD/resources/service-info" }
             shuttle-turso = { path = "$PWD/resources/turso" }
 
             shuttle-axum = { path = "$PWD/services/shuttle-axum" }
@@ -617,6 +618,7 @@ workflows:
                 - resources/persist
                 - resources/secrets
                 - resources/static-folder
+                - resources/service-info
                 - resources/turso
                 - services/shuttle-actix-web
                 - services/shuttle-axum
@@ -831,6 +833,7 @@ workflows:
                   "resources/secrets",
                   "resources/shared-db",
                   "resources/static-folder",
+                  "resources/service-info",
                   "resources/turso",
                 ]
           name: publish-<< matrix.path >>

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -136,6 +136,7 @@ shuttle-persist = { path = "[base]/shuttle/resources/persist" }
 shuttle-shared-db = { path = "[base]/shuttle/resources/shared-db" }
 shuttle-secrets = { path = "[base]/shuttle/resources/secrets" }
 shuttle-static-folder = { path = "[base]/shuttle/resources/static-folder" }
+shuttle-service-info = { path = "[base]/shuttle/resources/service-info" }
 shuttle-turso = { path = "[base]/shuttle/resources/turso" }
 
 shuttle-axum = { path = "[base]/shuttle/services/shuttle-axum" }

--- a/Makefile
+++ b/Makefile
@@ -255,8 +255,9 @@ publish: publish-resources publish-cargo-shuttle
 
 publish-resources: publish-resources/aws-rds \
 	publish-resources/persist \
-	publish-resources/shared-db
-	publish-resources/static-folder
+	publish-resources/shared-db \
+	publish-resources/static-folder \
+	publish-resources/service-info
 
 publish-cargo-shuttle: publish-resources/secrets
 	cd cargo-shuttle; cargo publish

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -22,6 +22,7 @@ pub fn get_resources_table(resources: &Vec<Response>, service_name: &str) -> Str
                 Type::StaticFolder => "Static Folder",
                 Type::Persist => "Persist",
                 Type::Turso => "Turso",
+                Type::ServiceInfo => "Service Info",
                 Type::Custom => "Custom",
             };
 

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -36,6 +36,7 @@ pub enum Type {
     StaticFolder,
     Persist,
     Turso,
+    ServiceInfo,
     Custom,
 }
 
@@ -82,6 +83,7 @@ impl Display for Type {
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
             Type::Turso => write!(f, "turso"),
+            Type::ServiceInfo => write!(f, "service_info"),
             Type::Custom => write!(f, "custom"),
         }
     }

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -41,6 +41,7 @@ if [[ $PROD != "true" ]]; then
     shuttle-shared-db = { path = "/usr/src/shuttle/resources/shared-db" }
     shuttle-secrets = { path = "/usr/src/shuttle/resources/secrets" }
     shuttle-static-folder = { path = "/usr/src/shuttle/resources/static-folder" }
+    shuttle-service-info = { path = "/usr/src/shuttle/resources/service-info" }
     shuttle-turso = { path = "/usr/src/shuttle/resources/turso" }
 
     shuttle-actix-web = { path = "/usr/src/shuttle/services/shuttle-actix-web" }

--- a/deployer/src/persistence/resource/mod.rs
+++ b/deployer/src/persistence/resource/mod.rs
@@ -66,6 +66,7 @@ pub enum Type {
     StaticFolder,
     Persist,
     Turso,
+    ServiceInfo,
     Custom,
 }
 
@@ -77,6 +78,7 @@ impl From<Type> for shuttle_common::resource::Type {
             Type::StaticFolder => Self::StaticFolder,
             Type::Persist => Self::Persist,
             Type::Turso => Self::Turso,
+            Type::ServiceInfo => Self::ServiceInfo,
             Type::Custom => Self::Custom,
         }
     }
@@ -90,6 +92,7 @@ impl From<shuttle_common::resource::Type> for Type {
             shuttle_common::resource::Type::StaticFolder => Self::StaticFolder,
             shuttle_common::resource::Type::Persist => Self::Persist,
             shuttle_common::resource::Type::Turso => Self::Turso,
+            shuttle_common::resource::Type::ServiceInfo => Self::ServiceInfo,
             shuttle_common::resource::Type::Custom => Self::Custom,
         }
     }
@@ -103,6 +106,7 @@ impl Display for Type {
             Type::StaticFolder => write!(f, "static_folder"),
             Type::Persist => write!(f, "persist"),
             Type::Turso => write!(f, "turso"),
+            Type::ServiceInfo => write!(f, "service_info"),
             Type::Custom => write!(f, "custom"),
         }
     }
@@ -123,6 +127,7 @@ impl FromStr for Type {
                 "static_folder" => Ok(Self::StaticFolder),
                 "persist" => Ok(Self::Persist),
                 "turso" => Ok(Self::Turso),
+                "service_info" => Ok(Self::ServiceInfo),
                 "custom" => Ok(Self::Custom),
                 _ => Err(format!("'{s}' is an unknown resource type")),
             }
@@ -173,6 +178,7 @@ mod tests {
             Type::StaticFolder,
             Type::Persist,
             Type::Turso,
+            Type::ServiceInfo,
             Type::Custom,
         ];
 

--- a/e2e/tests/integration/helpers/mod.rs
+++ b/e2e/tests/integration/helpers/mod.rs
@@ -46,6 +46,7 @@ shuttle-persist = {{ path = "{}" }}
 shuttle-shared-db = {{ path = "{}" }}
 shuttle-secrets = {{ path = "{}" }}
 shuttle-static-folder = {{ path = "{}" }}
+shuttle-service-info = {{ path = "{}" }}
 
 shuttle-axum = {{ path = "{}" }}
 shuttle-actix-web = {{ path = "{}" }}
@@ -68,6 +69,10 @@ shuttle-warp = {{ path = "{}" }}"#,
                     WORKSPACE_ROOT
                         .join("resources")
                         .join("static-folder")
+                        .display(),
+                    WORKSPACE_ROOT
+                        .join("resources")
+                        .join("service-info")
                         .display(),
                     WORKSPACE_ROOT
                         .join("services")

--- a/resources/service-info/Cargo.toml
+++ b/resources/service-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-service-info"
-version = "0.22.0"
+version = "0.24.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to get Shuttle service information"
@@ -9,4 +9,4 @@ keywords = ["shuttle-service", "service-info"]
 [dependencies]
 async-trait = "0.1.56"
 serde = { version = "1.0.0", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.22.0" }
+shuttle-service = { path = "../../service", version = "0.24.0" }

--- a/resources/service-info/Cargo.toml
+++ b/resources/service-info/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "shuttle-service-info"
+version = "0.22.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Plugin to get Shuttle service information"
+keywords = ["shuttle-service", "service-info"]
+
+[dependencies]
+async-trait = "0.1.56"
+serde = { version = "1.0.0", features = ["derive"] }
+shuttle-service = { path = "../../service", version = "0.22.0" }

--- a/resources/service-info/README.md
+++ b/resources/service-info/README.md
@@ -1,0 +1,7 @@
+# Shuttle Service Info
+
+This plugin allows applications to obtain certain information about their runtime environment.
+
+## Usage
+
+Add `shuttle-service-info` to the dependencies for your service. You can get this resource using the `shuttle-service-info::ServiceInfo` attribute to get a `ServiceInfo`. This struct will contain information such as the Shuttle service name.

--- a/resources/service-info/README.md
+++ b/resources/service-info/README.md
@@ -4,4 +4,4 @@ This plugin allows applications to obtain certain information about their runtim
 
 ## Usage
 
-Add `shuttle-service-info` to the dependencies for your service. You can get this resource using the `shuttle-service-info::ServiceInfo` attribute to get a `ServiceInfo`. This struct will contain information such as the Shuttle service name.
+Add `shuttle-service-info` to the dependencies for your service. You can get this resource using the `shuttle-service-info::ShuttleServiceInfo` attribute to get a `ServiceInfo`. This struct will contain information such as the Shuttle service name.

--- a/resources/service-info/README.md
+++ b/resources/service-info/README.md
@@ -4,4 +4,19 @@ This plugin allows applications to obtain certain information about their runtim
 
 ## Usage
 
-Add `shuttle-service-info` to the dependencies for your service. You can get this resource using the `shuttle-service-info::ShuttleServiceInfo` attribute to get a `ServiceInfo`. This struct will contain information such as the Shuttle service name.
+Add `shuttle-service-info` to the dependencies for your service.
+
+You can get this resource using the `shuttle_service_info::ShuttleServiceInfo` attribute to get a `ServiceInfo`. This struct will contain information such as the Shuttle service name.
+
+```rust
+#[shuttle_runtime::main]
+async fn app(
+    #[shuttle_service_info::ShuttleServiceInfo] service_info: shuttle_service_info::ServiceInfo,
+) -> __ { ... }
+```
+
+#### Example projects that use `shuttle-service-info`
+
+| Framework | Link                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------ |
+| Axum      | [axum example](https://github.com/shuttle-hq/shuttle-examples/tree/main/axum/service-info) |

--- a/resources/service-info/src/lib.rs
+++ b/resources/service-info/src/lib.rs
@@ -5,13 +5,13 @@ use shuttle_service::{error::Error, Factory, ResourceBuilder, Type};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ServiceInfo {
     /// The Shuttle service name.
-    name: String,
+    service_name: String,
 }
 
 impl ServiceInfo {
     /// Get the Shuttle service name.
-    pub fn name(&self) -> &str {
-        &self.name
+    pub fn service_name(&self) -> &str {
+        &self.service_name
     }
 }
 
@@ -35,7 +35,7 @@ impl ResourceBuilder<ServiceInfo> for ShuttleServiceInfo {
 
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, Error> {
         Ok(ServiceInfo {
-            name: factory.get_service_name().to_string(),
+            service_name: factory.get_service_name().to_string(),
         })
     }
 

--- a/resources/service-info/src/lib.rs
+++ b/resources/service-info/src/lib.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use shuttle_service::{error::Error, Factory, ResourceBuilder, Type};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ServiceInfo {
+    /// The Shuttle service name.
+    name: String,
+}
+
+impl ServiceInfo {
+    /// Get the Shuttle service name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+pub struct ShuttleServiceInfo;
+
+#[async_trait]
+impl ResourceBuilder<ServiceInfo> for ShuttleServiceInfo {
+    fn new() -> Self {
+        Self
+    }
+
+    const TYPE: Type = Type::ServiceInfo;
+
+    type Config = ();
+
+    type Output = ServiceInfo;
+
+    fn config(&self) -> &Self::Config {
+        &()
+    }
+
+    async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, Error> {
+        Ok(ServiceInfo {
+            name: factory.get_service_name().to_string(),
+        })
+    }
+
+    async fn build(build_data: &Self::Output) -> Result<ServiceInfo, Error> {
+        Ok(build_data.clone())
+    }
+}


### PR DESCRIPTION
## Description of change

This PR adds a new `ServiceInfo` type of resource which provides some information about the current service's runtime environment.

Closes #562.

## How has this been tested? (if applicable)

I've tested this a tiny amount in a project I have running locally but don't really trust it yet - would love if someone can test it better!

---

Note: I'm getting married this weekend then going straight on my honeymoon so won't really have time to follow up on this for a couple of weeks! 💒 🌴 Please feel free to push any fixes up, or make a completely different branch if needed, and merge whenever you're happy.