### PR TITLE
ci: always build images in release profile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,9 +666,9 @@ workflows:
               only: production
       - approve-push-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID
@@ -676,9 +676,9 @@ workflows:
           production: false
           requires:
             - approve-push-unstable
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - deploy-images:
           name: Deploy images to unstable
           postgres-password: DEV_POSTGRES_PASSWORD

--- a/Containerfile
+++ b/Containerfile
@@ -10,13 +10,13 @@ WORKDIR /build
 
 # Stores source cache
 FROM shuttle-build as cache
-ARG CARGO_PROFILE
+ARG PROD
 WORKDIR /src
 COPY . .
 RUN find ${SRC_CRATES} \( -name "*.proto" -or -name "*.rs" -or -name "*.toml" -or -name "Cargo.lock" -or -name "README.md" -or -name "*.sql" -or -name "ulid0.so" \) -type f -exec install -D \{\} /build/\{\} \;
 # This is used to carry over in the docker images any *.pem files from shuttle root directory,
 # to be used for TLS testing, as described here in the admin README.md.
-RUN if [ "$CARGO_PROFILE" != "release" ]; then \
+RUN if [ "$PROD" != "true" ]; then \
     find ${SRC_CRATES} -name "*.pem" -type f -exec install -D \{\} /build/\{\} \;; \
     fi
 
@@ -29,16 +29,12 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # Builds crate according to cargo chef recipe
 FROM shuttle-build AS builder
-ARG CARGO_PROFILE
 ARG folder
 COPY --from=planner /build/recipe.json recipe.json
-RUN cargo chef cook \
-    # if CARGO_PROFILE is release, pass --release, else use default debug profile
-    $(if [ "$CARGO_PROFILE" = "release" ]; then echo --release; fi) \
-    --recipe-path recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
 COPY --from=cache /build .
-RUN cargo build --bin shuttle-${folder} \
-    $(if [ "$CARGO_PROFILE" = "release" ]; then echo --release; fi)
+RUN cargo build --bin shuttle-${folder} --release
 
 
 # The final image for this "shuttle-..." crate
@@ -48,7 +44,6 @@ ARG folder
 ARG prepare_args
 # used as env variable in prepare script
 ARG PROD
-ARG CARGO_PROFILE
 ARG RUSTUP_TOOLCHAIN
 ENV RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN}
 
@@ -61,5 +56,5 @@ COPY --from=cache /build /usr/src/shuttle/
 # In the deployer shuttle-next is installed and the panamax mirror config is added in this step.
 RUN /prepare.sh --after-src "${prepare_args}"
 
-COPY --from=builder /build/target/${CARGO_PROFILE}/shuttle-${folder} /usr/local/bin/service
+COPY --from=builder /build/target/release/shuttle-${folder} /usr/local/bin/service
 ENTRYPOINT ["/usr/local/bin/service"]

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ CONTAINER_REGISTRY=public.ecr.aws/shuttle
 DD_ENV=production
 # make sure we only ever go to production with `--tls=enable`
 USE_TLS=enable
-CARGO_PROFILE=release
 RUST_LOG=debug
 else
 DOCKER_COMPOSE_FILES=docker-compose.yml docker-compose.dev.yml
@@ -66,7 +65,6 @@ DB_FQDN=db.unstable.shuttle.rs
 CONTAINER_REGISTRY=public.ecr.aws/shuttle-dev
 DD_ENV=unstable
 USE_TLS?=disable
-CARGO_PROFILE=debug
 RUST_LOG?=shuttle=trace,debug
 DEPLOYS_API_KEY?=gateway4deployes
 endif
@@ -166,7 +164,6 @@ shuttle-%: ${SRC} Cargo.lock
 		--build-arg prepare_args=$(PREPARE_ARGS) \
 		--build-arg PROD=$(PROD) \
 		--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
-		--build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
 		--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \
 		--tag $(CONTAINER_REGISTRY)/$(*):$(TAG) \
 		--tag $(CONTAINER_REGISTRY)/$(*):latest \

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ RESOURCE_RECORDER_TAG?=$(TAG)
 
 DOCKER_BUILD?=docker buildx build
 
+ifeq ($(CI),true)
+DOCKER_BUILD+= --progress plain
+endif
+
 DOCKER_COMPOSE=$(shell which docker-compose)
 ifeq ($(DOCKER_COMPOSE),)
 DOCKER_COMPOSE=docker compose


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We shouldn't build for staging and production with different images, this could lead to us missing bugs that don't appear in the debug profile. Additionally, this PR changes the docker build output to plain for CI.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Ran with and without PROD=true, and also ran build and deploy to unstable in CI.
