### PR TITLE
ci: upgrade mac bin build machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   docker-buildx: sensu/docker-buildx@1.1.1
   aws-ecr: circleci/aws-ecr@8.2.1
   win: circleci/windows@5.0
+  macos: circleci/macos@2.3.6
 
 executors:
   docker-rust:
@@ -444,10 +445,12 @@ jobs:
           suffix: ".exe"
   build-binaries-mac:
     macos:
-      xcode: 12.5.1
-    resource_class: medium
+      xcode: 14.2.0
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
+      # Necessary to build for Intel targets on m1.
+      - macos/install-rosetta
       - run:
           name: Install Rust
           command: curl --proto '=https' https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.70.0 --target x86_64-apple-darwin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,10 +732,10 @@ workflows:
           filters:
             branches:
               only: production
-      - build-binaries-mac:
-          filters:
-            branches:
-              only: production
+      - build-binaries-mac
+          # filters:
+          #   branches:
+          #     only: production
       - publish-github-release:
           requires:
             - build-binaries-x86_64-gnu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,8 @@ commands:
           paths:
             - << parameters.target >>/*
             - << parameters.target >>.env
+      - store_artifacts:
+          path: artifacts
 
 jobs:
   workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,6 @@ commands:
           paths:
             - << parameters.target >>/*
             - << parameters.target >>.env
-      - store_artifacts:
-          path: artifacts
 
 jobs:
   workspace:
@@ -734,10 +732,10 @@ workflows:
           filters:
             branches:
               only: production
-      - build-binaries-mac
-          # filters:
-          #   branches:
-          #     only: production
+      - build-binaries-mac:
+          filters:
+            branches:
+              only: production
       - publish-github-release:
           requires:
             - build-binaries-x86_64-gnu


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Upgrading to the m1 mac for the mac binary builds should improve speed, see: https://circleci.com/blog/m1-mac-resource-class/

The mac machine we were using was also about to be deprecated in october.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested in CI. Reduced total time of job from ~11 min to ~4 min, and I verified the binary still works on arm and intel macs.
