### PR TITLE
bug: project_id label missing

### DIFF
--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -724,6 +724,7 @@ impl ProjectCreating {
                     "Labels": {
                         "shuttle.prefix": prefix,
                         "shuttle.project": project_name,
+                        "shuttle.project_id": self.project_id.to_string(),
                         "shuttle.idle_minutes": format!("{idle_minutes}"),
                     },
                     "Cmd": [


### PR DESCRIPTION
## Description of change
We try to access the project id on the container in the code below, but we never set it.

https://github.com/shuttle-hq/shuttle/blob/609411c2d98e52f20d24830aa527598a4347dc9f/gateway/src/project.rs#L107-L114

## How has this been tested? (if applicable)
Nan


