### PR TITLE
deployer: update logs APIs  to fetch the logs from shuttle-logger

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -227,7 +227,7 @@ USE_PANAMAX=disable make images
 make docker-compose.rendered.yml
 
 # then run
-docker compose -f docker-compose.rendered.yml up provisioner resource-recorder
+docker compose -f docker-compose.rendered.yml up provisioner resource-recorder logger otel-collector
 ```
 
 This starts the provisioner and the auth service, while preventing `gateway` from starting up.
@@ -255,7 +255,7 @@ cargo shuttle login --api-key dh9z58jttoes3qvt
 We're now ready to start a local run of the deployer:
 
 ```bash
-cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --resource-recorder http://localhost:8007 --proxy-fqdn local.rs --admin-secret dh9z58jttoes3qvt --local --project-id "01H7WHDK23XYGSESCBG6XWJ1V0" --project <name>
+OTLP_ADDRESS=http://127.0.0.1:4317 cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --resource-recorder http://localhost:8007 --logger-uri http://localhost:8080 --proxy-fqdn local.rs --admin-secret dh9z58jttoes3qvt --local --project-id "01H7WHDK23XYGSESCBG6XWJ1V0" --project <name>
 ```
 
 The `<project_name>` needs to match the name of the project that will be deployed to this deployer. This is the `Cargo.toml` or `Shuttle.toml` name for the project.

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -253,7 +253,7 @@ impl DeploymentManager {
         self.storage_manager.clone()
     }
 
-    pub fn log_fetcher(
+    pub fn logs_fetcher(
         &self,
     ) -> &LoggerClient<
         shuttle_common::claims::ClaimService<

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -196,7 +196,6 @@ pub struct DeploymentManager {
     _join_set: Arc<Mutex<JoinSet<()>>>,
 }
 
-// let provisioner_client = ProvisionerClient::new(channel);
 /// ```no-test
 /// queue channel   all deployments here are State::Queued until the get a slot from gateway
 ///       |

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -8,6 +8,7 @@ use std::{path::PathBuf, sync::Arc};
 pub use queue::Queued;
 pub use run::{ActiveDeploymentsGetter, Built};
 use shuttle_common::storage_manager::ArtifactsStorageManager;
+use shuttle_proto::logger::logger_client::LoggerClient;
 use tracing::{instrument, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -28,6 +29,13 @@ const RUN_BUFFER_SIZE: usize = 100;
 
 pub struct DeploymentManagerBuilder<LR, SR, ADG, DU, SG, RM, QC> {
     build_log_recorder: Option<LR>,
+    logs_fetcher: Option<
+        LoggerClient<
+            shuttle_common::claims::ClaimService<
+                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+            >,
+        >,
+    >,
     secret_recorder: Option<SR>,
     active_deployment_getter: Option<ADG>,
     artifacts_path: Option<PathBuf>,
@@ -50,6 +58,19 @@ where
 {
     pub fn build_log_recorder(mut self, build_log_recorder: LR) -> Self {
         self.build_log_recorder = Some(build_log_recorder);
+
+        self
+    }
+
+    pub fn log_fetcher(
+        mut self,
+        logs_fetcher: LoggerClient<
+            shuttle_common::claims::ClaimService<
+                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+            >,
+        >,
+    ) -> Self {
+        self.logs_fetcher = Some(logs_fetcher);
 
         self
     }
@@ -122,6 +143,7 @@ where
             .expect("a deployment updater to be set");
         let secret_getter = self.secret_getter.expect("a secret getter to be set");
         let resource_manager = self.resource_manager.expect("a resource manager to be set");
+        let logs_fetcher = self.logs_fetcher.expect("a logs fetcher to be set");
 
         let (queue_send, queue_recv) = mpsc::channel(QUEUE_BUFFER_SIZE);
         let (run_send, run_recv) = mpsc::channel(RUN_BUFFER_SIZE);
@@ -153,6 +175,7 @@ where
             queue_send,
             run_send,
             runtime_manager,
+            logs_fetcher,
             storage_manager,
             _join_set: Arc::new(Mutex::new(set)),
         }
@@ -165,9 +188,15 @@ pub struct DeploymentManager {
     run_send: RunSender,
     runtime_manager: Arc<Mutex<RuntimeManager>>,
     storage_manager: ArtifactsStorageManager,
+    logs_fetcher: LoggerClient<
+        shuttle_common::claims::ClaimService<
+            shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+        >,
+    >,
     _join_set: Arc<Mutex<JoinSet<()>>>,
 }
 
+// let provisioner_client = ProvisionerClient::new(channel);
 /// ```no-test
 /// queue channel   all deployments here are State::Queued until the get a slot from gateway
 ///       |
@@ -189,6 +218,7 @@ impl DeploymentManager {
     ) -> DeploymentManagerBuilder<LR, SR, ADG, DU, SG, RM, QC> {
         DeploymentManagerBuilder {
             build_log_recorder: None,
+            logs_fetcher: None,
             secret_recorder: None,
             active_deployment_getter: None,
             artifacts_path: None,
@@ -221,6 +251,16 @@ impl DeploymentManager {
 
     pub fn storage_manager(&self) -> ArtifactsStorageManager {
         self.storage_manager.clone()
+    }
+
+    pub fn log_fetcher(
+        &self,
+    ) -> &LoggerClient<
+        shuttle_common::claims::ClaimService<
+            shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+        >,
+    > {
+        &self.logs_fetcher
     }
 }
 

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -543,7 +543,7 @@ pub async fn start_deployment(
 #[instrument(skip_all, fields(%project_name, %deployment_id))]
 #[utoipa::path(
     get,
-    path = "/projects/{project_name}/ws/deployments/{deployment_id}/logs",
+    path = "/projects/{project_name}/deployments/{deployment_id}/logs",
     responses(
         (status = 200, description = "Gets the logs a specific deployment.", body = [shuttle_common::log::Item]),
         (status = 500, description = "Database or streaming error.", body = String),
@@ -582,7 +582,7 @@ pub async fn get_logs(
 
 #[utoipa::path(
     get,
-    path = "/projects/{project_name}/deployments/{deployment_id}/logs",
+    path = "/projects/{project_name}/ws/deployments/{deployment_id}/logs",
     responses(
         (status = 200, description = "Subscribes to a specific deployment logs.")
     ),

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -44,7 +44,7 @@ async fn main() {
         .logger_uri
         .connect()
         .await
-        .expect("failed to connect to resource recorder");
+        .expect("failed to connect to logger");
 
     let channel = ServiceBuilder::new()
         .layer(ClaimLayer)

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -392,11 +392,6 @@ impl Persistence {
         .map_err(Error::from)
     }
 
-    pub(crate) async fn get_deployment_logs(&self, id: &Uuid) -> Result<Vec<Log>> {
-        // TODO: stress this a bit
-        get_deployment_logs(&self.pool, id).await
-    }
-
     /// Get a broadcast channel for listening to logs that are being stored into persistence
     pub fn get_log_subscriber(&self) -> Receiver<deploy_layer::Log> {
         self.stream_log_send.subscribe()
@@ -456,14 +451,6 @@ async fn insert_log(pool: &SqlitePool, log: impl Into<Log>) -> Result<()> {
         .execute(pool)
         .await
         .map(|_| ())
-        .map_err(Error::from)
-}
-
-async fn get_deployment_logs(pool: &SqlitePool, id: &Uuid) -> Result<Vec<Log>> {
-    sqlx::query_as("SELECT * FROM logs WHERE id = ? ORDER BY timestamp")
-        .bind(id)
-        .fetch_all(pool)
-        .await
         .map_err(Error::from)
 }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -231,5 +231,71 @@ pub mod resource_recorder {
 }
 
 pub mod logger {
+    use chrono::{naive::serde, DateTime, NaiveDateTime, Utc};
+    use shuttle_common::tracing::{FILEPATH_KEY, LINENO_KEY, TARGET_KEY};
+    use tracing::error;
+
     include!("generated/logger.rs");
+
+    impl From<LogLevel> for shuttle_common::log::Level {
+        fn from(level: LogLevel) -> Self {
+            match level {
+                LogLevel::Trace => Self::Trace,
+                LogLevel::Debug => Self::Debug,
+                LogLevel::Info => Self::Info,
+                LogLevel::Warn => Self::Warn,
+                LogLevel::Error => Self::Error,
+            }
+        }
+    }
+
+    impl From<LogItem> for shuttle_common::LogItem {
+        fn from(value: LogItem) -> Self {
+            let proto_timestamp = value.timestamp.clone().unwrap_or_default();
+            let level = value.level();
+            let mut fields: serde_json::Map<String, serde_json::Value> =
+                match serde_json::from_slice(&value.fields) {
+                    Ok(serde_json::Value::Object(o)) => o,
+                    Ok(_) => {
+                        error!("unexpected JSON value, expected an object");
+                        serde_json::Map::new()
+                    }
+                    Err(err) => {
+                        error!("malformed fields object: {err}");
+                        serde_json::Map::new()
+                    }
+                };
+
+            // Safe to unwrap since we've previously serialised the fields we're removing below.
+            let file = fields
+                .remove(FILEPATH_KEY)
+                .map(|v| v.as_str().unwrap_or_default().to_string());
+            let line = fields
+                .remove(LINENO_KEY)
+                .map(|v| u32::try_from(v.as_u64().unwrap_or_default()).unwrap_or_default());
+            let target = fields
+                .remove(TARGET_KEY)
+                .map(|v| v.as_str().unwrap_or_default().to_string())
+                .unwrap_or_default();
+
+            Self {
+                id: Default::default(),
+                timestamp: DateTime::from_utc(
+                    NaiveDateTime::from_timestamp_opt(
+                        proto_timestamp.seconds,
+                        proto_timestamp.nanos.try_into().unwrap_or_default(),
+                    )
+                    .unwrap_or_default(),
+                    Utc,
+                ),
+                // TODO: update this to the corresponding state shown in the runtime log, when present
+                state: shuttle_common::deployment::State::Running,
+                level: level.into(),
+                file,
+                line,
+                target,
+                fields: serde_json::to_vec(&fields).unwrap_or_default(),
+            }
+        }
+    }
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -231,7 +231,7 @@ pub mod resource_recorder {
 }
 
 pub mod logger {
-    use chrono::{naive::serde, DateTime, NaiveDateTime, Utc};
+    use chrono::{DateTime, NaiveDateTime, Utc};
     use shuttle_common::tracing::{FILEPATH_KEY, LINENO_KEY, TARGET_KEY};
     use tracing::error;
 


### PR DESCRIPTION
## Description of change

Updated `get_logs` and `get_logs_stream` deployer methods to be based on `shuttle-logger`.
This PR is rebased on top of #1139 .

## How has this been tested? (if applicable)

N/A, pending on #1139 .

