### PR TITLE
chore(container): use pre-installed cargo-chef image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,8 +3,7 @@
 
 # Base image for builds and cache
 ARG RUSTUP_TOOLCHAIN
-FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-buster as shuttle-build
-RUN cargo install cargo-chef --locked
+FROM lukemathwalker/cargo-chef:latest-rust-${RUSTUP_TOOLCHAIN}-buster as shuttle-build
 WORKDIR /build
 
 


### PR DESCRIPTION
## Description of change

This PR updates the base image of Containerfile to `lukemathwalker/cargo-chef` to avoid installing `cargo-chef` via `cargo install`.

## How has this been tested? (if applicable)

\-
