### PR TITLE
fix: static folder is not updated

### DIFF
--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -99,7 +99,7 @@ impl<'a> ResourceBuilder<PathBuf> for StaticFolder<'a> {
 
     async fn build(build_data: &Self::Output) -> Result<PathBuf, shuttle_service::Error> {
         let input_dir = &build_data.input;
-        let output_dir = build_data.output.join(&build_data.assets.clone());
+        let output_dir = build_data.output.join(&build_data.assets);
 
         if &output_dir == input_dir {
             return Ok(output_dir);

--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -161,7 +161,10 @@ mod tests {
     impl MockFactory {
         fn new() -> Self {
             Self {
-                temp_dir: Builder::new().prefix("static_folder").tempdir().unwrap(),
+                temp_dir: Builder::new()
+                    .prefix("static_folder")
+                    .tempdir_in("./")
+                    .unwrap(),
             }
         }
 
@@ -234,10 +237,12 @@ mod tests {
         // Call plugin
         let static_folder = StaticFolder::new();
 
-        let actual_folder = static_folder.output(&mut factory).await.unwrap();
+        let paths = static_folder.output(&mut factory).await.unwrap();
+        // Should copy the files.
+        StaticFolder::build(&paths).await.unwrap();
 
         assert_eq!(
-            actual_folder,
+            paths.output.join(paths.assets),
             factory.storage_path().join("static"),
             "expect path to the static folder"
         );


### PR DESCRIPTION
## Description of change

We want to copy the contents of the build storage for the static file to the runtime storage. That can happen during the `ResourceBuilder::build` call.

## How has this been tested? (if applicable)

Locally, deploying an axum static-files project, and checking that at a second deployment the assets were updated.


