### PR TITLE
static-folder: fix clippy

### DIFF
--- a/resources/static-folder/src/lib.rs
+++ b/resources/static-folder/src/lib.rs
@@ -107,7 +107,7 @@ impl<'a> ResourceBuilder<PathBuf> for StaticFolder<'a> {
 
         let copy_options = CopyOptions::new().overwrite(true);
 
-        match copy(&input_dir, &build_data.output, &copy_options) {
+        match copy(input_dir, &build_data.output, &copy_options) {
             Ok(_) => Ok(output_dir),
             Err(error) => {
                 error!(


### PR DESCRIPTION
## Description of change

Fixed clippy for static-folder tests.

## How has this been tested? (if applicable)

Run `cargo clippy --tests` locally against static-folder.


