### PR TITLE
fix: unused sqlx dep

### DIFF
--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -36,7 +36,6 @@ reqwest-retry = "0.2.0"
 rmp-serde = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres"] }
 strum = { workspace = true }
 tar = { workspace = true }
 tokio = { workspace = true, features = ["macros", "signal"] }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This dependency is not used anywhere in cargo-shuttle.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

cargo-udeps and CI.
