### PR TITLE
chore(makefile): remove unnecessary sleep commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,23 +260,18 @@ publish-resources: publish-resources/aws-rds \
 
 publish-cargo-shuttle: publish-resources/secrets
 	cd cargo-shuttle; cargo publish
-	sleep 10 # Wait for crates.io to update
 
 publish-service: publish-codegen publish-common
 	cd service; cargo publish
-	sleep 10 # Wait for crates.io to update
 
 publish-codegen:
 	cd codegen; cargo publish
-	sleep 10 # Wait for crates.io to update
 
 publish-common:
 	cd common; cargo publish
-	sleep 10 # Wait for crates.io to update
 
 publish-resources/%: publish-service
 	cd resources/$(*); cargo publish
-	sleep 10 # Wait for crates.io to update
 
 --validate-version:
 	echo "$(version)" | rg -q "\d+\.\d+\.\d+" || { echo "version argument must be in the form x.y.z"; exit 1; }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Closes #1160 
There are a couple of unnecessary sleep commands specifically for cargo publish in Makefile:

[shuttle/Makefile](https://github.com/shuttle-hq/shuttle/blob/531014eaf4b38e1b3844324bb7154c6128228bb8/Makefile#L261-L276)

Lines 261 to 276 in [531014e](https://github.com/shuttle-hq/shuttle/commit/531014eaf4b38e1b3844324bb7154c6128228bb8)
 publish-cargo-shuttle: publish-resources/secrets 
 	cd cargo-shuttle; cargo publish 
 	sleep 10 # Wait for crates.io to update 
  
 publish-service: publish-codegen publish-common 
 	cd service; cargo publish 
 	sleep 10 # Wait for crates.io to update 
  
 publish-codegen: 
 	cd codegen; cargo publish 
 	sleep 10 # Wait for crates.io to update 
  
 publish-common: 
 	cd common; cargo publish 
 	sleep 10 # Wait for crates.io to update 
  

This is unnecessary since cargo publish now waits for the crate to be available on the registry index.

Reference: https://github.com/rust-lang/cargo/blob/7b61184ad196e6b361a9a46e967899c618597557/src/cargo/ops/registry/publish.rs#L219

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->


