### PR TITLE
logger: store span names 

### DIFF
--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -116,10 +116,11 @@ impl Sqlite {
 #[async_trait]
 impl Dal for Sqlite {
     async fn get_logs(&self, deployment_id: String) -> Result<Vec<Log>, DalError> {
-        let result = sqlx::query_as("SELECT * FROM logs WHERE deployment_id = ?")
-            .bind(deployment_id)
-            .fetch_all(&self.pool)
-            .await?;
+        let result =
+            sqlx::query_as("SELECT * FROM logs WHERE deployment_id = ? ORDER BY timestamp")
+                .bind(deployment_id)
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(result)
     }

--- a/logger/tests/integration_tests.rs
+++ b/logger/tests/integration_tests.rs
@@ -66,12 +66,8 @@ async fn generate_and_get_runtime_logs() {
     let quoted_deployment_id = format!("\"{DEPLOYMENT_ID}\"");
     let expected = vec![
         MinLogItem {
-            level: LogLevel::Trace,
-            fields: json!({"message": "inside span 1 event"}),
-        },
-        MinLogItem {
             level: LogLevel::Info,
-            fields: json!({"message": "[span] span_name1", "deployment_id": quoted_deployment_id }),
+            fields: json!({"message": "[span] deploy", "deployment_id": quoted_deployment_id }),
         },
         MinLogItem {
             level: LogLevel::Error,
@@ -95,7 +91,11 @@ async fn generate_and_get_runtime_logs() {
         },
         MinLogItem {
             level: LogLevel::Info,
-            fields: json!({"message": "[span] deploy", "deployment_id": quoted_deployment_id }),
+            fields: json!({"message": "[span] span_name1", "deployment_id": quoted_deployment_id }),
+        },
+        MinLogItem {
+            level: LogLevel::Trace,
+            fields: json!({"message": "inside span 1 event"}),
         },
     ];
 
@@ -175,6 +175,10 @@ async fn generate_and_get_service_logs() {
 
     let expected = vec![
         MinLogItem {
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] deploy_instrumented", "deployment_id": DEPLOYMENT_ID.to_string() }),
+        },
+        MinLogItem {
             level: LogLevel::Error,
             fields: json!({"message": "error"}),
         },
@@ -193,10 +197,6 @@ async fn generate_and_get_service_logs() {
         MinLogItem {
             level: LogLevel::Trace,
             fields: json!({"message": "trace"}),
-        },
-        MinLogItem {
-            level: LogLevel::Info,
-            fields: json!({"message": "[span] deploy_instrumented", "deployment_id": DEPLOYMENT_ID.to_string() }),
         },
     ];
 
@@ -277,11 +277,12 @@ async fn generate_and_stream_logs() {
         .unwrap()
         .unwrap();
 
+    let quoted_deployment_id = format!("\"{DEPLOYMENT_ID}\"");
     assert_eq!(
         MinLogItem::from(log),
         MinLogItem {
-            level: LogLevel::Trace,
-            fields: json!({"message": "inside span 1 event"}),
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] span_name1", "deployment_id": quoted_deployment_id}),
         },
     );
 
@@ -290,13 +291,11 @@ async fn generate_and_stream_logs() {
         .unwrap()
         .unwrap()
         .unwrap();
-
-    let quoted_deployment_id = format!("\"{DEPLOYMENT_ID}\"");
     assert_eq!(
         MinLogItem::from(log),
         MinLogItem {
-            level: LogLevel::Info,
-            fields: json!({"message": "[span] span_name1", "deployment_id": quoted_deployment_id}),
+            level: LogLevel::Trace,
+            fields: json!({"message": "inside span 1 event"}),
         },
     );
 
@@ -308,7 +307,6 @@ async fn generate_and_stream_logs() {
         .unwrap()
         .unwrap()
         .unwrap();
-
     assert_eq!(
         MinLogItem::from(log),
         MinLogItem {
@@ -322,7 +320,6 @@ async fn generate_and_stream_logs() {
         .unwrap()
         .unwrap()
         .unwrap();
-
     assert_eq!(
         MinLogItem::from(log),
         MinLogItem {

--- a/logger/tests/integration_tests.rs
+++ b/logger/tests/integration_tests.rs
@@ -158,7 +158,7 @@ async fn generate_and_get_service_logs() {
 
     // Start a subscriber and generate some logs using an instrumented deploy function.
     generate_service_logs(port, DEPLOYMENT_ID.into(), deploy_instrumented);
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
     let dst = format!("http://localhost:{port}");
 

--- a/logger/tests/integration_tests.rs
+++ b/logger/tests/integration_tests.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use serde_json::{json, Value};
 use shuttle_common::{
     claims::Scope,
-    tracing::{FILEPATH_KEY, LINENO_KEY, NAMESPACE_KEY, TARGET_KEY},
+    tracing::{FILEPATH_KEY, LINENO_KEY, MESSAGE_KEY, NAMESPACE_KEY, TARGET_KEY},
 };
 use shuttle_common_tests::JwtScopesLayer;
 use shuttle_logger::{Service, ShuttleLogsOtlp, Sqlite};
@@ -63,10 +63,15 @@ async fn generate_and_get_runtime_logs() {
         .unwrap()
         .into_inner();
 
+    let quoted_deployment_id = format!("\"{DEPLOYMENT_ID}\"");
     let expected = vec![
         MinLogItem {
             level: LogLevel::Trace,
-            fields: json!({"message": "foo"}),
+            fields: json!({"message": "inside span 1 event"}),
+        },
+        MinLogItem {
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] span_name1", "deployment_id": quoted_deployment_id }),
         },
         MinLogItem {
             level: LogLevel::Error,
@@ -87,6 +92,10 @@ async fn generate_and_get_runtime_logs() {
         MinLogItem {
             level: LogLevel::Trace,
             fields: json!({"message": "trace"}),
+        },
+        MinLogItem {
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] deploy", "deployment_id": quoted_deployment_id }),
         },
     ];
 
@@ -185,6 +194,10 @@ async fn generate_and_get_service_logs() {
             level: LogLevel::Trace,
             fields: json!({"message": "trace"}),
         },
+        MinLogItem {
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] deploy_instrumented", "deployment_id": DEPLOYMENT_ID.to_string() }),
+        },
     ];
 
     assert_eq!(
@@ -243,7 +256,7 @@ async fn generate_and_stream_logs() {
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
     // Start a subscriber and generate some logs.
-    generate_runtime_logs(port, DEPLOYMENT_ID.into(), foo);
+    generate_runtime_logs(port, DEPLOYMENT_ID.into(), span_name1);
 
     // Connect to the logger server so we can fetch logs.
     let dst = format!("http://localhost:{port}");
@@ -268,12 +281,27 @@ async fn generate_and_stream_logs() {
         MinLogItem::from(log),
         MinLogItem {
             level: LogLevel::Trace,
-            fields: json!({"message": "foo"}),
+            fields: json!({"message": "inside span 1 event"}),
+        },
+    );
+
+    let log = timeout(std::time::Duration::from_millis(500), response.message())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    let quoted_deployment_id = format!("\"{DEPLOYMENT_ID}\"");
+    assert_eq!(
+        MinLogItem::from(log),
+        MinLogItem {
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] span_name1", "deployment_id": quoted_deployment_id}),
         },
     );
 
     // Start a subscriber and generate some more logs.
-    generate_runtime_logs(port, DEPLOYMENT_ID.into(), bar);
+    generate_runtime_logs(port, DEPLOYMENT_ID.into(), span_name2);
 
     let log = timeout(std::time::Duration::from_millis(500), response.message())
         .await
@@ -285,7 +313,21 @@ async fn generate_and_stream_logs() {
         MinLogItem::from(log),
         MinLogItem {
             level: LogLevel::Trace,
-            fields: json!({"message": "bar"}),
+            fields: json!({"message": "inside span 2 event"}),
+        },
+    );
+
+    let log = timeout(std::time::Duration::from_millis(500), response.message())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        MinLogItem::from(log),
+        MinLogItem {
+            level: LogLevel::Info,
+            fields: json!({"message": "[span] span_name2", "deployment_id": quoted_deployment_id}),
         },
     );
 }
@@ -356,7 +398,7 @@ fn deploy(deployment_id: String) {
     debug!("debug");
     trace!("trace");
     // This tests that we handle nested spans.
-    foo(deployment_id);
+    span_name1(deployment_id);
 }
 
 #[instrument(fields(%deployment_id))]
@@ -369,13 +411,13 @@ fn deploy_instrumented(deployment_id: String) {
 }
 
 #[instrument]
-fn foo(deployment_id: String) {
-    trace!("foo");
+fn span_name1(deployment_id: String) {
+    trace!("inside span 1 event");
 }
 
 #[instrument]
-fn bar(deployment_id: String) {
-    trace!("bar");
+fn span_name2(deployment_id: String) {
+    trace!("inside span 2 event");
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -394,10 +436,22 @@ impl From<LogItem> for MinLogItem {
             let mut fields: Value = serde_json::from_slice(&log.fields).unwrap();
 
             let map = fields.as_object_mut().unwrap();
-            let target = map.remove(TARGET_KEY).unwrap();
-            let filepath = map.remove(FILEPATH_KEY).unwrap();
 
-            assert_eq!(target, "integration_tests");
+            let message = map.get(MESSAGE_KEY).unwrap();
+            // Span logs don't contain a target field
+            if !message.as_str().unwrap().starts_with("[span] ") {
+                let target = map.remove(TARGET_KEY).unwrap();
+                assert_eq!(target, "integration_tests");
+            } else {
+                // We want to remove what's not of interest for checking
+                // the spans are containing the right information.
+                let _ = map.remove("busy_ns").unwrap();
+                let _ = map.remove("idle_ns").unwrap();
+                let _ = map.remove("thread.id").unwrap();
+                let _ = map.remove("thread.name").unwrap();
+            }
+
+            let filepath = map.remove(FILEPATH_KEY).unwrap();
             assert_eq!(filepath, "logger/tests/integration_tests.rs");
 
             map.remove(LINENO_KEY).unwrap();


### PR DESCRIPTION
## Description of change

Previously we dropped on any span name information, but we'll need them to be shown in `cargo-shuttle`.

## How has this been tested? (if applicable)

Through integration tests. Need to follow up with more local/unstable testing soon.


