### PR TITLE
test(logger): run integration tests serially

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,6 +5287,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,6 +5636,7 @@ dependencies = [
  "pretty_assertions",
  "prost-types",
  "serde_json",
+ "serial_test",
  "shuttle-common",
  "shuttle-common-tests",
  "shuttle-proto",

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -42,3 +42,4 @@ serde_json = { workspace = true }
 shuttle-common-tests = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry = { workspace = true }
+serial_test = "2.0.0"


### PR DESCRIPTION
Utilize `serial_test` crate to run the logger tests serially. Running them in parallel or with `--test-threads 1` causes spurious errors.