### PR TITLE
Add suggestion to 'project not ready' error msg

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -70,7 +70,10 @@ impl From<ErrorKind> for ApiError {
                 StatusCode::NOT_FOUND,
                 "project not found. Run `cargo shuttle project start` to create a new project.",
             ),
-            ErrorKind::ProjectNotReady => (StatusCode::SERVICE_UNAVAILABLE, "project not ready"),
+            ErrorKind::ProjectNotReady => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "project not ready. Try run `cargo shuttle project restart`.",
+            ),
             ErrorKind::ProjectUnavailable => {
                 (StatusCode::BAD_GATEWAY, "project returned invalid response")
             }


### PR DESCRIPTION
## Description of change

Just a quick error message PR based on [this discord message](https://discord.com/channels/803236282088161321/953005742842069013/1143130801999990836) from @jonaro00 which expands on the `project not ready` error.

This adds the help text ```Try run `cargo shuttle project restart`.``` if the project is not ready:

```
Error: 503 Service Unavailable
message: project not ready. Try run `cargo shuttle project restart`.
```


