### PR TITLE
feat(deployer): send runtime logs to the logger service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5512,6 +5512,7 @@ dependencies = [
  "opentelemetry-http",
  "pipe",
  "portpicker",
+ "prost-types",
  "rand",
  "rmp-serde",
  "serde",

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -8,7 +8,7 @@ mod provisioner_server;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::fs::{read_to_string, File};
-use std::io::{stdout, Write};
+use std::io::stdout;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::process::exit;
@@ -665,8 +665,7 @@ impl Shuttle {
         let mut reader = BufReader::new(child_stdout).lines();
         tokio::spawn(async move {
             while let Some(line) = reader.next_line().await.unwrap() {
-                let mut stdout = stdout().lock();
-                writeln!(stdout, "{}", line).unwrap();
+                println!("{}", line);
             }
         });
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -641,6 +641,7 @@ impl Shuttle {
         };
 
         // Child process and gRPC client for sending requests to it
+        // TODO: Is child stdout should be handled?
         let (mut runtime, mut runtime_client) = runtime::start(
             is_wasm,
             StorageManagerType::WorkingDir(working_directory.to_path_buf()),

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -24,6 +24,7 @@ once_cell = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true }
 pipe = { workspace = true }
+prost-types = { workspace = true }
 portpicker = { workspace = true }
 rmp-serde = { workspace = true }
 serde = { workspace = true }

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -460,10 +460,7 @@ mod tests {
             .await
             .expect("failed to connect to logger");
 
-        let channel = ServiceBuilder::new()
-            .layer(ClaimLayer)
-            .layer(InjectPropagationLayer)
-            .service(channel);
+        let channel = ServiceBuilder::new().service(channel);
 
         let logger_client = LoggerClient::new(channel);
 

--- a/deployer/src/deployment/deploy_layer.rs
+++ b/deployer/src/deployment/deploy_layer.rs
@@ -460,7 +460,10 @@ mod tests {
             .await
             .expect("failed to connect to logger");
 
-        let channel = ServiceBuilder::new().service(channel);
+        let channel = ServiceBuilder::new()
+            .layer(ClaimLayer)
+            .layer(InjectPropagationLayer)
+            .service(channel);
 
         let logger_client = LoggerClient::new(channel);
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -544,10 +544,7 @@ mod tests {
             .await
             .expect("failed to connect to logger");
 
-        let channel = ServiceBuilder::new()
-            .layer(ClaimLayer)
-            .layer(InjectPropagationLayer)
-            .service(channel);
+        let channel = ServiceBuilder::new().service(channel);
 
         let logger_client = LoggerClient::new(channel);
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -253,7 +253,11 @@ impl Built {
         let runtime_client = runtime_manager
             .lock()
             .await
-            .get_runtime_client(self.id, alpha_runtime_path.clone())
+            .get_runtime_client(
+                self.id,
+                self.service_name.clone(),
+                alpha_runtime_path.clone(),
+            )
             .await
             .map_err(Error::Runtime)?;
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -544,7 +544,10 @@ mod tests {
             .await
             .expect("failed to connect to logger");
 
-        let channel = ServiceBuilder::new().service(channel);
+        let channel = ServiceBuilder::new()
+            .layer(ClaimLayer)
+            .layer(InjectPropagationLayer)
+            .service(channel);
 
         let logger_client = LoggerClient::new(channel);
 

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -33,13 +33,6 @@ async fn main() {
         "deployer",
     );
 
-    let runtime_manager = RuntimeManager::new(
-        args.artifacts_path.clone(),
-        args.provisioner_address.uri().to_string(),
-        args.logger_uri.uri().to_string(),
-        Some(args.auth_uri.to_string()),
-    );
-
     let channel = args
         .logger_uri
         .connect()
@@ -52,6 +45,14 @@ async fn main() {
         .service(channel);
 
     let logger_client = LoggerClient::new(channel);
+
+    let runtime_manager = RuntimeManager::new(
+        args.artifacts_path.clone(),
+        args.provisioner_address.uri().to_string(),
+        args.logger_uri.uri().to_string(),
+        logger_client.clone(),
+        Some(args.auth_uri.to_string()),
+    );
 
     select! {
         _ = start_proxy(args.proxy_address, args.proxy_fqdn.clone(), persistence.clone()) => {

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use prost_types::Timestamp;
 use shuttle_common::claims::{ClaimService, InjectPropagation};
 use shuttle_proto::{
-    logger::{logger_client::LoggerClient, StoreLogsRequest, StoredLogItem},
+    logger::{logger_client::LoggerClient, LogItem, LogLine, StoreLogsRequest},
     runtime::{self, runtime_client::RuntimeClient, StopRequest},
 };
 use tokio::{io::AsyncBufReadExt, io::BufReader, process, sync::Mutex};
@@ -161,11 +161,13 @@ impl RuntimeManager {
         tokio::spawn(async move {
             while let Some(line) = reader.next_line().await.unwrap() {
                 // TODO: `store_logs` accepts a Vec but logs are sent one by one. Is this feasible?
-                let logs = vec![StoredLogItem {
+                let logs = vec![LogItem {
                     deployment_id: id.to_string(),
-                    service_name: service_name.to_string(),
-                    tx_timestamp: Some(Timestamp::from(SystemTime::UNIX_EPOCH)),
-                    data: line.as_bytes().to_vec(),
+                    log_line: Some(LogLine {
+                        service_name: service_name.to_string(),
+                        tx_timestamp: Some(Timestamp::from(SystemTime::UNIX_EPOCH)),
+                        data: "log 1 example".as_bytes().to_vec(),
+                    }),
                 }];
                 logger_client.store_logs(StoreLogsRequest { logs }).await;
             }

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -147,13 +147,14 @@ impl RuntimeManager {
         tokio::spawn(async move {
             while let Some(line) = reader.next_line().await.unwrap() {
                 // TODO: `store_logs` accepts a Vec but logs are sent one by one. Is this feasible?
+                let utc = Utc::now();
                 let logs = vec![LogItem {
                     deployment_id: id.to_string(),
                     log_line: Some(LogLine {
                         service_name: service_name.to_string(),
                         tx_timestamp: Some(Timestamp {
-                            seconds: Utc::now().timestamp(),
-                            nanos: 0,
+                            seconds: utc.timestamp(),
+                            nanos: utc.timestamp_subsec_nanos().try_into().unwrap_or_default(),
                         }),
                         data: line.as_bytes().to_vec(),
                     }),

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -1,6 +1,7 @@
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::SystemTime};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use anyhow::Context;
+use chrono::Utc;
 use prost_types::Timestamp;
 use shuttle_common::claims::{ClaimService, InjectPropagation};
 use shuttle_proto::{
@@ -165,8 +166,11 @@ impl RuntimeManager {
                     deployment_id: id.to_string(),
                     log_line: Some(LogLine {
                         service_name: service_name.to_string(),
-                        tx_timestamp: Some(Timestamp::from(SystemTime::UNIX_EPOCH)),
-                        data: "log 1 example".as_bytes().to_vec(),
+                        tx_timestamp: Some(Timestamp {
+                            seconds: Utc::now().timestamp(),
+                            nanos: 0,
+                        }),
+                        data: line.as_bytes().to_vec(),
                     }),
                 }];
                 logger_client.store_logs(StoreLogsRequest { logs }).await;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -95,7 +95,7 @@ pub mod provisioner {
 }
 
 pub mod runtime {
-    use std::{path::PathBuf, time::Duration};
+    use std::{path::PathBuf, process::Stdio, time::Duration};
 
     use anyhow::Context;
     use shuttle_common::claims::{
@@ -164,6 +164,7 @@ pub mod runtime {
         );
         let runtime = process::Command::new(runtime_executable_path)
             .args(&args)
+            .stdout(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .context("spawning runtime process")?;


### PR DESCRIPTION
Simply capture logs and send them to the logger service.

yolo.