### PR TITLE
refactor: remove tracing from runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5715,7 +5715,6 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tower",
- "tracing",
  "uuid",
  "wasi-common",
  "wasmtime",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,7 +25,6 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1.11"
 tonic = { workspace = true }
 tower = { workspace = true }
-tracing = { workspace = true, features = ["default"] }
 cap-std = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -287,7 +287,6 @@ pub use async_trait::async_trait;
 // Dependencies required by the codegen
 pub use anyhow::Context;
 pub use strfmt::strfmt;
-pub use tracing;
 
 // Print the version of the runtime.
 pub fn print_version() {

--- a/runtime/src/provisioner_factory.rs
+++ b/runtime/src/provisioner_factory.rs
@@ -10,7 +10,6 @@ use shuttle_common::{
 use shuttle_proto::provisioner::{provisioner_client::ProvisionerClient, DatabaseRequest};
 use shuttle_service::{Environment, Factory, ServiceName};
 use tonic::{transport::Channel, Request};
-use tracing::info;
 
 /// A factory (service locator) which goes through the provisioner crate
 pub struct ProvisionerFactory {
@@ -48,8 +47,6 @@ impl Factory for ProvisionerFactory {
         &mut self,
         db_type: database::Type,
     ) -> Result<DatabaseReadyInfo, shuttle_service::Error> {
-        info!("Provisioning a {db_type}. This can take a while...");
-
         let mut request = Request::new(DatabaseRequest {
             project_name: self.service_name.to_string(),
             db_type: Some(db_type.clone().into()),
@@ -67,8 +64,6 @@ impl Factory for ProvisionerFactory {
             .into_inner();
 
         let info: DatabaseReadyInfo = response.into();
-
-        info!("Done provisioning database");
 
         Ok(info)
     }


### PR DESCRIPTION
## Description of change
Removes the tracing dependency from runtime since we can use stdout instead.

## How has this been tested? (if applicable)
Using `cargo shuttle run` on a postgres project


