### PR TITLE
refactor: remove println from shuttle-logger

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -110,7 +110,10 @@ where
             for log in logs {
                 last = log.tx_timestamp.clone().unwrap_or_default();
                 if let Err(error) = tx.send(Ok(log)).await {
-                    println!("error sending log: {}", error);
+                    error!(
+                        error = &error as &dyn std::error::Error,
+                        "error sending log"
+                    );
                 };
             }
 


### PR DESCRIPTION
## Description of change
Changes all `println!` inside shuttle-logger with some tracing call

## How has this been tested? (if applicable)
NaN :see_no_evil: 


