### PR TITLE
refactor(runtime): replace trace with println

### DIFF
--- a/runtime/src/bin/shuttle-next.rs
+++ b/runtime/src/bin/shuttle-next.rs
@@ -7,7 +7,6 @@ use shuttle_common::backends::tracing::ExtractPropagationLayer;
 use shuttle_proto::runtime::runtime_server::RuntimeServer;
 use shuttle_runtime::{print_version, AxumWasm, NextArgs};
 use tonic::transport::Server;
-use tracing::trace;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
@@ -20,7 +19,7 @@ async fn main() {
 
     let args = NextArgs::parse().unwrap();
 
-    trace!(args = ?args, "parsed args");
+    println!("parsed args");
 
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), args.port);
 

--- a/runtime/src/next/mod.rs
+++ b/runtime/src/next/mod.rs
@@ -68,7 +68,7 @@ impl Runtime for AxumWasm {
         request: tonic::Request<LoadRequest>,
     ) -> Result<tonic::Response<LoadResponse>, Status> {
         let wasm_path = request.into_inner().path;
-        println!("loading shuttle-next project");
+        println!("loading shuttle-next project: {wasm_path}");
 
         let router = RouterBuilder::new()
             .map_err(|err| Status::from_error(err.into()))?


### PR DESCRIPTION
Fixes the following build failure:

```
error[E0432]: unresolved import `tracing`
  --> runtime/src/next/mod.rs:26:5
   |
26 | use tracing::{error, trace, warn};
   |     ^^^^^^^ help: a similar path exists: `shuttle_common::tracing`

```