### PR TITLE
feat(gateway): special error if own project is already running

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -98,9 +98,10 @@ impl From<ErrorKind> for ApiError {
                 StatusCode::BAD_REQUEST,
                 "a project with the same name already exists",
             ),
-            ErrorKind::ProjectAlreadyRunning => {
-                (StatusCode::BAD_REQUEST, "project is already running")
-            }
+            ErrorKind::ProjectAlreadyRunning => (
+                StatusCode::BAD_REQUEST,
+                "it looks like your project is already running. You can find out more with `cargo shuttle project status`",
+            ),
             ErrorKind::InvalidCustomDomain => (StatusCode::BAD_REQUEST, "invalid custom domain"),
             ErrorKind::CustomDomainNotFound => (StatusCode::NOT_FOUND, "custom domain not found"),
             ErrorKind::CustomDomainAlreadyExists => {

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -42,6 +42,7 @@ pub enum ErrorKind {
     ProjectNotFound,
     InvalidProjectName,
     ProjectAlreadyExists,
+    ProjectAlreadyRunning,
     ProjectNotReady,
     ProjectUnavailable,
     CustomDomainNotFound,
@@ -97,6 +98,9 @@ impl From<ErrorKind> for ApiError {
                 StatusCode::BAD_REQUEST,
                 "a project with the same name already exists",
             ),
+            ErrorKind::ProjectAlreadyRunning => {
+                (StatusCode::BAD_REQUEST, "project is already running")
+            }
             ErrorKind::InvalidCustomDomain => (StatusCode::BAD_REQUEST, "invalid custom domain"),
             ErrorKind::CustomDomainNotFound => (StatusCode::NOT_FOUND, "custom domain not found"),
             ErrorKind::CustomDomainAlreadyExists => {


### PR DESCRIPTION
## Description of change

The command `cargo shuttle project start` fails if a project with the same name is already present. The error message that's printed now tells the caller that their project is already running if they are the project owner.

Closes #1155

## How has this been tested? (if applicable)

One assertion has been added to the relevant test for each new case. They make sure that the new error variant `ErrorKind::ProjectAlreadyRunning` is returned if either the owner or an admin tries to recreate a running project.

