### PR TITLE
feat(gateway): inform project owner about running state

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -30,7 +30,7 @@ impl Display for ApiError {
 
 impl std::error::Error for ApiError {}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display)]
+#[derive(Debug, Clone, PartialEq, Eq, strum::Display)]
 pub enum ErrorKind {
     KeyMissing,
     BadHost,
@@ -41,8 +41,12 @@ pub enum ErrorKind {
     UserAlreadyExists,
     ProjectNotFound,
     InvalidProjectName,
-    ProjectAlreadyExists,
-    ProjectAlreadyRunning,
+    ProjectAlreadyExists {
+        // A message describing a running state of the project.
+        // Used if the project already exists but is owned
+        // by the caller, which means they can modify the project.
+        owner_state_msg: Option<String>,
+    },
     ProjectNotReady,
     ProjectUnavailable,
     CustomDomainNotFound,
@@ -94,14 +98,20 @@ impl From<ErrorKind> for ApiError {
                 StatusCode::BAD_REQUEST,
                 "the requested operation is invalid",
             ),
-            ErrorKind::ProjectAlreadyExists => (
+            ErrorKind::ProjectAlreadyExists {
+                owner_state_msg: None,
+            } => (
                 StatusCode::BAD_REQUEST,
                 "a project with the same name already exists",
             ),
-            ErrorKind::ProjectAlreadyRunning => (
-                StatusCode::BAD_REQUEST,
-                "it looks like your project is already running. You can find out more with `cargo shuttle project status`",
-            ),
+            ErrorKind::ProjectAlreadyExists {
+                owner_state_msg: Some(message),
+            } => {
+                return Self {
+                    message,
+                    status_code: StatusCode::BAD_REQUEST.as_u16(),
+                }
+            }
             ErrorKind::InvalidCustomDomain => (StatusCode::BAD_REQUEST, "invalid custom domain"),
             ErrorKind::CustomDomainNotFound => (StatusCode::NOT_FOUND, "custom domain not found"),
             ErrorKind::CustomDomainAlreadyExists => {

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -41,12 +41,11 @@ pub enum ErrorKind {
     UserAlreadyExists,
     ProjectNotFound,
     InvalidProjectName,
-    ProjectAlreadyExists {
-        // A message describing a running state of the project.
-        // Used if the project already exists but is owned
-        // by the caller, which means they can modify the project.
-        owner_state_msg: Option<String>,
-    },
+    ProjectAlreadyExists,
+    /// Contains a message describing a running state of the project.
+    /// Used if the project already exists but is owned
+    /// by the caller, which means they can modify the project.
+    OwnProjectAlreadyExists(String),
     ProjectNotReady,
     ProjectUnavailable,
     CustomDomainNotFound,
@@ -98,15 +97,11 @@ impl From<ErrorKind> for ApiError {
                 StatusCode::BAD_REQUEST,
                 "the requested operation is invalid",
             ),
-            ErrorKind::ProjectAlreadyExists {
-                owner_state_msg: None,
-            } => (
+            ErrorKind::ProjectAlreadyExists => (
                 StatusCode::BAD_REQUEST,
                 "a project with the same name already exists",
             ),
-            ErrorKind::ProjectAlreadyExists {
-                owner_state_msg: Some(message),
-            } => {
+            ErrorKind::OwnProjectAlreadyExists(message) => {
                 return Self {
                     message,
                     status_code: StatusCode::BAD_REQUEST.as_u16(),

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -72,7 +72,7 @@ impl Error {
     }
 
     pub fn kind(&self) -> ErrorKind {
-        self.kind
+        self.kind.clone()
     }
 }
 


### PR DESCRIPTION


## Description of change

`cargo shuttle project start` fails if the project already exists. If the existing project is owned by the caller of the command, new error messages are now  displayed. They automatically provide the project owner with the current status of their project, and they indicate that her or his project is running. Depending on the current state, different hints are also provided.

Extends #1192

## How has this been tested? (if applicable)

The assertions added in #1192 have been updated to match the changes.
