### PR TITLE
feat(cargo-shuttle): prompt for init path when not given, warn if init dir not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ Shuttle is built for productivity, reliability and performance:
 
 - Zero-Configuration support for Rust using annotations
 - Automatic resource provisioning (databases, caches, subdomains, etc.) via [Infrastructure-From-Code](https://www.shuttle.rs/blog/2022/05/09/ifc)
-- First-class support for popular Rust frameworks ([Actix Web](https://docs.shuttle.rs/examples/actix), [Rocket](https://docs.shuttle.rs/examples/rocket), [Axum](https://docs.shuttle.rs/examples/axum),
-  [Tide](https://docs.shuttle.rs/examples/tide), [Poem](https://docs.shuttle.rs/examples/poem) and [Tower](https://docs.shuttle.rs/examples/tower))
+- First-class support for popular Rust frameworks ([Actix Web](https://docs.shuttle.rs/examples/actix), [Rocket](https://docs.shuttle.rs/examples/rocket), [Axum](https://docs.shuttle.rs/examples/axum), and [more](https://docs.shuttle.rs/examples/other))
 - Support for deploying Discord bots using [Serenity](https://docs.shuttle.rs/examples/serenity)
-- Scalable hosting (with optional self-hosting)
+- Scalable hosting (with optional self-hosting in the future)
 
 📖 Check out our documentation to get started quickly: [docs.shuttle.rs](https://docs.shuttle.rs)
 

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -224,7 +224,7 @@ pub struct DeployArgs {
 #[derive(Parser, Debug)]
 pub struct RunArgs {
     /// Port to start service on
-    #[arg(long, env, default_value = "8000")]
+    #[arg(long, short = 'p', env, default_value = "8000")]
     pub port: u16,
     /// Use 0.0.0.0 instead of localhost (for usage with local external devices)
     #[arg(long)]
@@ -343,14 +343,14 @@ fn parse_path(path: OsString) -> Result<PathBuf, String> {
 /// Helper function to parse, create if not exists, and return the absolute path
 pub(crate) fn parse_init_path(path: OsString) -> Result<PathBuf, io::Error> {
     // Create the directory if does not exist
-    create_dir_all(&path)?;
-
-    parse_path(path.clone()).map_err(|e| {
+    create_dir_all(&path).map_err(|e| {
         io::Error::new(
             ErrorKind::InvalidInput,
-            format!("could not turn {path:?} into a real path: {e}"),
+            format!("Could not create directory: {e}"),
         )
-    })
+    })?;
+
+    parse_path(path.clone()).map_err(|e| io::Error::new(ErrorKind::InvalidInput, e))
 }
 
 #[cfg(test)]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -84,7 +84,7 @@ impl ProjectArgs {
 
 /// A cargo command for the Shuttle platform (https://www.shuttle.rs/)
 ///
-/// See the CLI docs (https://docs.shuttle.rs/introduction/shuttle-commands)
+/// See the CLI docs (https://docs.shuttle.rs/getting-started/shuttle-commands)
 /// for more information.
 #[derive(Parser)]
 pub enum Command {

--- a/cargo-shuttle/src/main.rs
+++ b/cargo-shuttle/src/main.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
-use cargo_shuttle::{CommandOutcome, Shuttle, ShuttleArgs};
-use clap::Parser;
+use cargo_shuttle::{CommandOutcome, Shuttle};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
-    let result = Shuttle::new()?.run(ShuttleArgs::parse()).await;
+    let result = Shuttle::new()?.parse_args_and_run().await;
 
     if matches!(result, Ok(CommandOutcome::DeploymentFailure)) {
         // Deployment failure results in a shell error exit code being returned (this allows

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -30,7 +30,7 @@ async fn non_interactive_basic_init() {
         "none",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new().unwrap().run(args).await.unwrap();
+    Shuttle::new().unwrap().run(args, true).await.unwrap();
 
     let cargo_toml = read_to_string(temp_dir_path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains("name = \"my-project\""));
@@ -64,7 +64,7 @@ async fn non_interactive_rocket_init() {
         "rocket",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new().unwrap().run(args).await.unwrap();
+    Shuttle::new().unwrap().run(args, true).await.unwrap();
 
     assert_valid_rocket_project(temp_dir_path.as_path(), "my-project");
 
@@ -98,7 +98,7 @@ async fn non_interactive_init_with_from_url() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new().unwrap().run(args).await.unwrap();
+    Shuttle::new().unwrap().run(args, true).await.unwrap();
 
     let cargo_toml = read_to_string(temp_dir_path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains("name = \"my-project\""));
@@ -134,7 +134,7 @@ async fn non_interactive_init_with_from_gh() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new().unwrap().run(args).await.unwrap();
+    Shuttle::new().unwrap().run(args, true).await.unwrap();
 
     let cargo_toml = read_to_string(temp_dir_path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains("name = \"my-project\""));
@@ -170,7 +170,7 @@ async fn non_interactive_init_with_from_repo_name() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new().unwrap().run(args).await.unwrap();
+    Shuttle::new().unwrap().run(args, true).await.unwrap();
 
     let cargo_toml = read_to_string(temp_dir_path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains("name = \"my-project\""));
@@ -206,7 +206,7 @@ async fn non_interactive_init_with_from_local_path() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new().unwrap().run(args).await.unwrap();
+    Shuttle::new().unwrap().run(args, true).await.unwrap();
 
     let cargo_toml = read_to_string(temp_dir_path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains("name = \"my-project\""));

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -379,6 +379,48 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
     Ok(())
 }
 
+#[test]
+fn interactive_rocket_init_prompt_path_dirty_dir() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = Builder::new().prefix("rocket-init").tempdir().unwrap();
+    // Sleep to give time for the directory to finish creating
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let temp_dir_path = temp_dir.path().to_owned();
+
+    std::fs::write(temp_dir_path.join("minion"), "🍌").unwrap();
+
+    let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
+    let mut command = Command::new(bin_path);
+    command.args([
+        "--api-url",
+        "http://shuttle.invalid:80",
+        "init",
+        "--api-key",
+        "dh9z58jttoes3qvt",
+        "--name",
+        "my-project",
+        "-t",
+        "rocket",
+    ]);
+    let mut session = rexpect::session::spawn_command(command, Some(EXPECT_TIMEOUT_MS))?;
+
+    session.exp_string("Where should we create this project?")?;
+    session.exp_string("Directory")?;
+    session.send_line(temp_dir_path.to_str().unwrap())?;
+    session.exp_string("Target directory is not empty. Are you sure?")?;
+    session.send("y")?;
+    session.flush()?;
+    session.exp_string("yes")?;
+    session.exp_string("Creating project")?;
+    session.exp_string("Do you want to create the project environment on Shuttle?")?;
+    session.send("n")?;
+    session.flush()?;
+    session.exp_string("no")?;
+
+    assert_valid_rocket_project(temp_dir_path.as_path(), "my-project");
+
+    Ok(())
+}
+
 fn assert_valid_rocket_project(path: &Path, name: &str) {
     let cargo_toml = read_to_string(path.join("Cargo.toml")).unwrap();
     assert!(cargo_toml.contains(&format!("name = \"{name}\"")));

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -13,14 +13,17 @@ async fn cargo_shuttle_command(
 
     Shuttle::new()
         .unwrap()
-        .run(ShuttleArgs {
-            api_url: Some("http://shuttle.invalid:80".to_string()),
-            project_args: ProjectArgs {
-                working_directory,
-                name: None,
+        .run(
+            ShuttleArgs {
+                api_url: Some("http://shuttle.invalid:80".to_string()),
+                project_args: ProjectArgs {
+                    working_directory,
+                    name: None,
+                },
+                cmd,
             },
-            cmd,
-        })
+            false,
+        )
         .await
 }
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -6,6 +6,56 @@ mod shuttle_main;
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 
+/// Helper macro that generates the entrypoint required by any service - likely the only macro you need in this crate.
+///
+/// ## Without shuttle managed resources
+/// The simplest usage is when your service does not require any shuttle managed resources, so you only need to return a shuttle supported service:
+///
+/// ```rust,no_run
+/// use shuttle_rocket::ShuttleRocket;
+///
+/// #[shuttle_rocket::main]
+/// async fn rocket() -> ShuttleRocket {
+///     let rocket = rocket::build();
+///
+///     Ok(rocket.into())
+/// }
+/// ```
+///
+/// ## Shuttle supported services
+/// The following types can be returned from a `#[shuttle_service::main]` function and enjoy first class service support in shuttle.
+///
+/// | Return type                           | Crate                                                         | Service                                     | Version    | Example                                                                               |
+/// | ------------------------------------- |-------------------------------------------------------------- | ------------------------------------------- | ---------- | -----------------------------------------------------------------------------------   |
+/// | `ShuttleActixWeb`                     |[shuttle-actix-web](https://crates.io/crates/shuttle-actix-web)| [actix-web](https://docs.rs/actix-web/4.3)  | 4.3        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/actix-web/hello-world)      |
+/// | `ShuttleAxum`                         |[shuttle-axum](https://crates.io/crates/shuttle-axum)          | [axum](https://docs.rs/axum/0.6)            | 0.5        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/axum/hello-world)           |
+/// | `ShuttlePoem`                         |[shuttle-poem](https://crates.io/crates/shuttle-poem)          | [poem](https://docs.rs/poem/1.3)            | 1.3        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/poem/hello-world)           |
+/// | `ShuttlePoise`                        |[shuttle-poise](https://crates.io/crates/shuttle-poise)        | [poise](https://docs.rs/poise/0.5)          | 0.5        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/poise/hello-world)          |
+/// | `ShuttleRocket`                       |[shuttle-rocket](https://crates.io/crates/shuttle-rocket)      | [rocket](https://docs.rs/rocket/0.5.0-rc.2) | 0.5.0-rc.2 | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/rocket/hello-world)         |
+/// | `ShuttleSalvo`                        |[shuttle-salvo](https://crates.io/crates/shuttle-salvo)        | [salvo](https://docs.rs/salvo/0.37)         | 0.37       | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/salvo/hello-world)          |
+/// | `ShuttleSerenity`                     |[shuttle-serenity](https://crates.io/crates/shuttle-serenity   | [serenity](https://docs.rs/serenity/0.11)   | 0.11       | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/serenity/hello-world)       |
+/// | `ShuttleThruster`                     |[shuttle-thruster](https://crates.io/crates/shuttle-thruster)  | [thruster](https://docs.rs/thruster/1.3)    | 1.3        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/thruster/hello-world)       |
+/// | `ShuttleTower`                        |[shuttle-tower](https://crates.io/crates/shuttle-tower)        | [tower](https://docs.rs/tower/0.4)          | 0.4        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/tower/hello-world)          |
+/// | `ShuttleTide`                         |[shuttle-tide](https://crates.io/crates/shuttle-tide)          | [tide](https://docs.rs/tide/0.16)           | 0.16       | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/tide/hello-world)           |
+///
+/// ## Getting shuttle managed resources
+/// Shuttle is able to manage resource dependencies for you. These resources are passed in as inputs to your `#[shuttle_runtime::main]` function and are configured using attributes:
+/// ```rust,no_run
+/// use sqlx::PgPool;
+/// use shuttle_rocket::ShuttleRocket;
+///
+/// struct MyState(PgPool);
+///
+/// #[shuttle_runtime::main]
+/// async fn rocket(#[shuttle_shared_db::Postgres] pool: PgPool) -> ShuttleRocket {
+///     let state = MyState(pool);
+///     let rocket = rocket::build().manage(state);
+///
+///     Ok(rocket.into())
+/// }
+/// ```
+///
+/// More [shuttle managed resources can be found here](https://github.com/shuttle-hq/shuttle/tree/main/resources)
 #[cfg(feature = "frameworks")]
 #[proc_macro_error]
 #[proc_macro_attribute]

--- a/common-tests/src/cargo_shuttle.rs
+++ b/common-tests/src/cargo_shuttle.rs
@@ -32,14 +32,17 @@ pub async fn cargo_shuttle_run(working_directory: &str, external: bool) -> Strin
         release: false,
     };
 
-    let runner = Shuttle::new().unwrap().run(ShuttleArgs {
-        api_url: Some("http://shuttle.invalid:80".to_string()),
-        project_args: ProjectArgs {
-            working_directory: working_directory.clone(),
-            name: None,
+    let runner = Shuttle::new().unwrap().run(
+        ShuttleArgs {
+            api_url: Some("http://shuttle.invalid:80".to_string()),
+            project_args: ProjectArgs {
+                working_directory: working_directory.clone(),
+                name: None,
+            },
+            cmd: Command::Run(run_args),
         },
-        cmd: Command::Run(run_args),
-    });
+        false,
+    );
 
     tokio::spawn({
         let working_directory = working_directory.clone();

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -6,10 +6,9 @@ Shuttle is built for productivity, reliability and performance:
 
 - Zero-Configuration support for Rust using annotations
 - Automatic resource provisioning (databases, caches, subdomains, etc.) via [Infrastructure-From-Code](https://www.shuttle.rs/blog/2022/05/09/ifc)
-- First-class support for popular Rust frameworks ([Actix Web](https://docs.shuttle.rs/examples/actix), [Rocket](https://docs.shuttle.rs/examples/rocket), [Axum](https://docs.shuttle.rs/examples/axum),
-  [Tide](https://docs.shuttle.rs/examples/tide), [Poem](https://docs.shuttle.rs/examples/poem) and [Tower](https://docs.shuttle.rs/examples/tower))
+- First-class support for popular Rust frameworks ([Actix Web](https://docs.shuttle.rs/examples/actix), [Rocket](https://docs.shuttle.rs/examples/rocket), [Axum](https://docs.shuttle.rs/examples/axum), and [more](https://docs.shuttle.rs/examples/other))
 - Support for deploying Discord bots using [Serenity](https://docs.shuttle.rs/examples/serenity)
-- Scalable hosting (with optional self-hosting)
+- Scalable hosting (with optional self-hosting in the future)
 
 📖 Check out our documentation to get started quickly: [docs.shuttle.rs](https://docs.shuttle.rs)
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -215,56 +215,6 @@
 //! You can also [open an issue or a discussion on GitHub](https://github.com/shuttle-hq/shuttle).
 //!
 
-/// Helper macro that generates the entrypoint required by any service - likely the only macro you need in this crate.
-///
-/// # Without shuttle managed resources
-/// The simplest usage is when your service does not require any shuttle managed resources, so you only need to return a shuttle supported service:
-///
-/// ```rust,no_run
-/// use shuttle_rocket::ShuttleRocket;
-///
-/// #[shuttle_rocket::main]
-/// async fn rocket() -> ShuttleRocket {
-///     let rocket = rocket::build();
-///
-///     Ok(rocket.into())
-/// }
-/// ```
-///
-/// ## shuttle supported services
-/// The following types can be returned from a `#[shuttle_service::main]` function and enjoy first class service support in shuttle.
-///
-/// | Return type                           | Crate                                                         | Service                                     | Version    | Example                                                                               |
-/// | ------------------------------------- |-------------------------------------------------------------- | ------------------------------------------- | ---------- | -----------------------------------------------------------------------------------   |
-/// | `ShuttleActixWeb`                     |[shuttle-actix-web](https://crates.io/crates/shuttle-actix-web)| [actix-web](https://docs.rs/actix-web/4.3)  | 4.3        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/actix-web/hello-world)      |
-/// | `ShuttleAxum`                         |[shuttle-axum](https://crates.io/crates/shuttle-axum)          | [axum](https://docs.rs/axum/0.6)            | 0.5        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/axum/hello-world)           |
-/// | `ShuttlePoem`                         |[shuttle-poem](https://crates.io/crates/shuttle-poem)          | [poem](https://docs.rs/poem/1.3)            | 1.3        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/poem/hello-world)           |
-/// | `ShuttlePoise`                        |[shuttle-poise](https://crates.io/crates/shuttle-poise)        | [poise](https://docs.rs/poise/0.5)          | 0.5        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/poise/hello-world)          |
-/// | `ShuttleRocket`                       |[shuttle-rocket](https://crates.io/crates/shuttle-rocket)      | [rocket](https://docs.rs/rocket/0.5.0-rc.2) | 0.5.0-rc.2 | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/rocket/hello-world)         |
-/// | `ShuttleSalvo`                        |[shuttle-salvo](https://crates.io/crates/shuttle-salvo)        | [salvo](https://docs.rs/salvo/0.37)         | 0.37       | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/salvo/hello-world)          |
-/// | `ShuttleSerenity`                     |[shuttle-serenity](https://crates.io/crates/shuttle-serenity   | [serenity](https://docs.rs/serenity/0.11)   | 0.11       | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/serenity/hello-world)       |
-/// | `ShuttleThruster`                     |[shuttle-thruster](https://crates.io/crates/shuttle-thruster)  | [thruster](https://docs.rs/thruster/1.3)    | 1.3        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/thruster/hello-world)       |
-/// | `ShuttleTower`                        |[shuttle-tower](https://crates.io/crates/shuttle-tower)        | [tower](https://docs.rs/tower/0.4)          | 0.4        | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/tower/hello-world)          |
-/// | `ShuttleTide`                         |[shuttle-tide](https://crates.io/crates/shuttle-tide)          | [tide](https://docs.rs/tide/0.16)           | 0.16       | [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/tide/hello-world)           |
-///
-/// # Getting shuttle managed resources
-/// Shuttle is able to manage resource dependencies for you. These resources are passed in as inputs to your `#[shuttle_runtime::main]` function and are configured using attributes:
-/// ```rust,no_run
-/// use sqlx::PgPool;
-/// use shuttle_rocket::ShuttleRocket;
-///
-/// struct MyState(PgPool);
-///
-/// #[shuttle_runtime::main]
-/// async fn rocket(#[shuttle_shared_db::Postgres] pool: PgPool) -> ShuttleRocket {
-///     let state = MyState(pool);
-///     let rocket = rocket::build().manage(state);
-///
-///     Ok(rocket.into())
-/// }
-/// ```
-///
-/// More [shuttle managed resources can be found here](https://github.com/shuttle-hq/shuttle/tree/main/resources)
 pub use shuttle_codegen::main;
 
 mod alpha;


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- Giving template and proj name but no path used to assume path='.', but will now correctly see that you didn't provide path, and prompt you.
- Warning can let you quit the init:
  ![image](https://github.com/shuttle-hq/shuttle/assets/54029719/b8407793-a5c0-4008-849f-b9baabd339f8)


## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Added a test that tests one version of these two changes in combination.
