### PR TITLE
Revert "feat(shuttle-axum) Make AxumService generic to be able to use axum::State with it (#924)"

### DIFF
--- a/services/shuttle-axum/src/lib.rs
+++ b/services/shuttle-axum/src/lib.rs
@@ -18,7 +18,7 @@ use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
 /// A wrapper type for [axum::Router] so we can implement [shuttle_runtime::Service] for it.
-pub struct AxumService<S = ()>(pub axum::Router<S>);
+pub struct AxumService(pub axum::Router);
 
 #[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for AxumService {
@@ -34,11 +34,10 @@ impl shuttle_runtime::Service for AxumService {
     }
 }
 
-impl<S> From<axum::Router<S>> for AxumService<S> {
-    fn from(router: axum::Router<S>) -> Self {
+impl From<axum::Router> for AxumService {
+    fn from(router: axum::Router) -> Self {
         Self(router)
     }
 }
-
 /// The return type that should be returned from the [shuttle_runtime::main] function.
 pub type ShuttleAxum = Result<AxumService, Error>;


### PR DESCRIPTION
This reverts commit e6ade25efbca897a732ee3bb4f7de285b8e16d50.

## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

An axum router with `<S != ()>` cannot be turned into a service. IT is only implemented for `<S = ()>` https://docs.rs/axum/latest/axum/struct.Router.html#impl-Router%3C(),+B%3E
The generic `<S>` means which state the router is missing. https://docs.rs/axum/latest/axum/routing/struct.Router.html#what-s-in-routers-means


## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

The example that was created for "verifying" #924, https://github.com/shuttle-hq/shuttle-examples/pull/52, did not verify the functionality of the generic (it's a good example tho). If you try setting S to anything, your code will now compile.
Basically, #924 was never fully tested.
