### PR TITLE
fix: missing readmes in deployers local source

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,6 +19,7 @@ RUN find . \( \
     -name "*.toml" -or \
     -name "Cargo.lock" -or \
     -name "*.sql" -or \
+    -name "README.md" -or \
     # Used for local TLS testing, as described in admin/README.md
     -name "*.pem" -or \
     -name "ulid0.so" \


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

The missing README.md files in the deployers local source leads to compiler errors for patched crates that include the readmes at compile-time. 

Example:

```
2023-09-07T12:13:41.093263988+02:00  INFO error: couldn't read /usr/src/shuttle/resources/shared-db/src/../README.md: No such file or directory (os error 2)
2023-09-07T12:13:41.105618912+02:00  INFO  --> /usr/src/shuttle/resources/shared-db/src/lib.rs:1:10
2023-09-07T12:13:41.116456572+02:00  INFO   |
2023-09-07T12:13:41.128448249+02:00  INFO 1 | #![doc = include_str!("../README.md")]
2023-09-07T12:13:41.139924894+02:00  INFO   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2023-09-07T12:13:41.152376137+02:00  INFO   |
```

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested with a local environment setup.
