### PR TITLE
fix(cargo-shuttle): break deploy logs when StartResponse is received

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -14,7 +14,7 @@ use std::process::exit;
 use std::str::FromStr;
 
 use shuttle_common::deployment::{
-    DEPLOYER_END_MESSAGES_BAD, DEPLOYER_END_MESSAGES_GOOD, DEPLOYER_START_RESPONSE,
+    DEPLOYER_END_MESSAGES_BAD, DEPLOYER_END_MESSAGES_GOOD,
 };
 use shuttle_common::models::deployment::CREATE_SERVICE_BODY_LIMIT;
 use shuttle_common::{
@@ -1165,11 +1165,6 @@ impl Shuttle {
                         .any(|m| log_item.line.contains(m))
                     {
                         debug!("received end message, breaking deployment stream");
-                        break;
-                    }
-
-                    if log_item.line.contains(DEPLOYER_START_RESPONSE) {
-                        debug!("received start response inside the logs, breaking the loop");
                         break;
                     }
                 }

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -33,12 +33,12 @@ pub const DEPLOYER_END_MSG_BUILD_ERR: &str = "Is the Shuttle runtime missing?\"}
 pub const DEPLOYER_END_MSG_CRASHED: &str = "Service encountered an error and crashed";
 pub const DEPLOYER_END_MSG_STOPPED: &str = "Service was stopped by the user";
 pub const DEPLOYER_END_MSG_COMPLETED: &str = "Service finished running all on its own";
-pub const DEPLOYER_START_RESPONSE: &str = "{response=\"StartResponse { success: ";
+pub const DEPLOYER_RUNTIME_START_RESPONSE: &str = "{response=\"StartResponse { success: ";
 
 pub const DEPLOYER_END_MESSAGES_BAD: &[&str] =
     &[DEPLOYER_END_MSG_STARTUP_ERR, DEPLOYER_END_MSG_BUILD_ERR, DEPLOYER_END_MSG_CRASHED];
 pub const DEPLOYER_END_MESSAGES_GOOD: &[&str] =
-    &[DEPLOYER_END_MSG_STOPPED, DEPLOYER_END_MSG_COMPLETED];
+    &[DEPLOYER_END_MSG_STOPPED, DEPLOYER_END_MSG_COMPLETED, DEPLOYER_RUNTIME_START_RESPONSE];
 
 #[cfg(test)]
 mod tests {

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -32,6 +32,7 @@ pub const DEPLOYER_END_MSG_STARTUP_ERR: &str = "Service startup encountered an e
 pub const DEPLOYER_END_MSG_CRASHED: &str = "Service encountered an error and crashed";
 pub const DEPLOYER_END_MSG_STOPPED: &str = "Service was stopped by the user";
 pub const DEPLOYER_END_MSG_COMPLETED: &str = "Service finished running all on its own";
+pub const DEPLOYER_START_RESPONSE: &str = "{response=\"StartResponse { success: ";
 
 pub const DEPLOYER_END_MESSAGES_BAD: &[&str] =
     &[DEPLOYER_END_MSG_STARTUP_ERR, DEPLOYER_END_MSG_CRASHED];

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -29,13 +29,14 @@ pub enum Environment {
 }
 
 pub const DEPLOYER_END_MSG_STARTUP_ERR: &str = "Service startup encountered an error";
+pub const DEPLOYER_END_MSG_BUILD_ERR: &str = "Is the Shuttle runtime missing?\"} service build encountered an error";
 pub const DEPLOYER_END_MSG_CRASHED: &str = "Service encountered an error and crashed";
 pub const DEPLOYER_END_MSG_STOPPED: &str = "Service was stopped by the user";
 pub const DEPLOYER_END_MSG_COMPLETED: &str = "Service finished running all on its own";
 pub const DEPLOYER_START_RESPONSE: &str = "{response=\"StartResponse { success: ";
 
 pub const DEPLOYER_END_MESSAGES_BAD: &[&str] =
-    &[DEPLOYER_END_MSG_STARTUP_ERR, DEPLOYER_END_MSG_CRASHED];
+    &[DEPLOYER_END_MSG_STARTUP_ERR, DEPLOYER_END_MSG_BUILD_ERR, DEPLOYER_END_MSG_CRASHED];
 pub const DEPLOYER_END_MESSAGES_GOOD: &[&str] =
     &[DEPLOYER_END_MSG_STOPPED, DEPLOYER_END_MSG_COMPLETED];
 

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -122,9 +122,9 @@ where
                     if log.tx_timestamp.timestamp() >= last.seconds
                         && log.tx_timestamp.timestamp_nanos() > last.nanos.into()
                     {
-                        tx.send(Ok(log.into())).await.unwrap_or_else(|_| {
-                            error!("Errored while sending logs to persistence")
-                        });
+                        tx.send(Ok(log.into()))
+                            .await
+                            .unwrap_or_else(|err| error!("Errored while sending logs: {err}"));
                     }
                 }
             }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -122,9 +122,10 @@ where
                     if log.tx_timestamp.timestamp() >= last.seconds
                         && log.tx_timestamp.timestamp_nanos() > last.nanos.into()
                     {
-                        tx.send(Ok(log.into()))
-                            .await
-                            .unwrap_or_else(|err| error!("Errored while sending logs: {err}"));
+                        if let Err(err) = tx.send(Ok(log.into())).await {
+                            error!("Errored while sending logs: {err}");
+                            return;
+                        }
                     }
                 }
             }

--- a/logger/tests/helpers.rs
+++ b/logger/tests/helpers.rs
@@ -21,8 +21,8 @@ struct Config<'a> {
     is_ready_cmd: Vec<&'a str>,
 }
 
-impl DockerInstance {
-    pub fn new() -> Self {
+impl Default for DockerInstance {
+    fn default() -> Self {
         let Config {
             engine,
             env,
@@ -63,7 +63,9 @@ impl DockerInstance {
             uri: format!("{engine}://{engine}:password@localhost:{host_port}"),
         }
     }
+}
 
+impl DockerInstance {
     fn wait_ready(mut timeout: Duration, is_ready_cmd: &[&str]) {
         let mut now = SystemTime::now();
         while !timeout.is_zero() {

--- a/logger/tests/integration_tests.rs
+++ b/logger/tests/integration_tests.rs
@@ -29,7 +29,7 @@ use uuid::Uuid;
 
 const SHUTTLE_SERVICE: &str = "test";
 
-static PG: Lazy<DockerInstance> = Lazy::new(|| DockerInstance::new());
+static PG: Lazy<DockerInstance> = Lazy::new(DockerInstance::default);
 
 #[dtor]
 fn cleanup() {


### PR DESCRIPTION
## Description of change

Receiving `StartResponse` for a `cargo shuttle deploy` means the deployment logs ended and we can stop the deployment logs stream.


## How has this been tested? (if applicable)

By locally deploying a project on a local deployer.


