### PR TITLE
refactor(runtime,codegen): avoid double timestamps problem

### DIFF
--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -16,8 +16,10 @@ pub(crate) fn r#impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let tracing_setup = if cfg!(feature = "setup-tracing") {
         Some(quote! {
                 use shuttle_runtime::colored::*;
+                use shuttle_runtime::tracing_subscriber::{registry, fmt, prelude::*};
                 shuttle_runtime::colored::control::set_override(true);
-                shuttle_runtime::tracing_subscriber::fmt::init();
+                registry().with(fmt::layer().without_time()).init();
+
                 println!(
                     "{}\n{}\nTo disable tracing, remove the default features from {}:\n{}\n{}",
                     "Shuttle's default tracing subscriber is initialized!".yellow().bold(),

--- a/runtime/src/resource_tracker.rs
+++ b/runtime/src/resource_tracker.rs
@@ -56,7 +56,7 @@ impl ResourceTracker {
 
 macro_rules! log {
     ($msg:expr) => {
-        println!("{} [Resource][{}] {}", chrono::Utc::now(), B::TYPE, $msg);
+        println!("[Resource][{}] {}", B::TYPE, $msg);
     };
 }
 


### PR DESCRIPTION
## Description of change

Rebased on top of #1209.

* Runtime resource tracker emit logs prepended by a timestamp we add explicitly. This was removed.
* Our default tracing fmt layer formats events by prepending a timestamp, but we also emit the timestamp for each line from the runtime stdout collecting logic. I changed the default tracing layer to format events without a timestamp.

Note:
* users custom tracing is not touched and if they emit timestamps they will pop up in the deployment logs. I think this should be expected behavior and leave the users the choice to format their logs as wanted. 

## How has this been tested? (if applicable)

Tested locally:
* with the default tracing
* without the default tracing


