### PR TITLE
Enable auto-sharding in shuttle-poise

### DIFF
--- a/services/shuttle-poise/src/lib.rs
+++ b/services/shuttle-poise/src/lib.rs
@@ -58,7 +58,7 @@ where
 {
     async fn bind(mut self, _addr: SocketAddr) -> Result<(), shuttle_runtime::Error> {
         self.0
-            .start()
+            .start_autosharded()
             .await
             .map_err(shuttle_runtime::CustomError::new)?;
 

--- a/services/shuttle-serenity/src/lib.rs
+++ b/services/shuttle-serenity/src/lib.rs
@@ -60,7 +60,7 @@ impl shuttle_runtime::Service for SerenityService {
     /// Takes the client that is returned by the user in their [shuttle_runtime::main] function
     /// and starts it.
     async fn bind(mut self, _addr: SocketAddr) -> Result<(), Error> {
-        self.0.start().await.map_err(CustomError::new)?;
+        self.0.start_autosharded().await.map_err(CustomError::new)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Description of change
Enable auto-sharding in shuttle-poise for Discord bots in 2500+ servers/guilds to work.

This PR shall resolve #1215.

## How has this been tested? (if applicable)
Natsuki, my Discord bot, is happily running on shuttle.rs right now.
https://github.com/jdh8/natsuki
https://console.shuttle.rs/project/natsuki
https://discord.com/application-directory/410315411695992833

I only removed the dangling submodule `examples` in the `deploy` branch.  It is otherwise the same as the main branch.