### PR TITLE
fix(otel): restore honeycomb and dd exporters

### DIFF
--- a/extras/otel/otel-collector-config.yaml
+++ b/extras/otel/otel-collector-config.yaml
@@ -50,32 +50,25 @@ processors:
         action: insert
 
 exporters:
-  logging:
-    loglevel: error
-#   datadog:
-#     api:
-#       site: datadoghq.eu
-#       key: ${env:DD_API_KEY}
-  # otlp:
-    # endpoint: "api.honeycomb.io:443"
-    # headers:
-    #   "x-honeycomb-team": ${env:HONEYCOMB_API_KEY}
+  datadog:
+    api:
+      site: datadoghq.eu
+      key: ${env:DD_API_KEY}
   otlp:
-    endpoint: "logger:8000"
-    tls: 
-      insecure: true
-    compression: none
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": ${env:HONEYCOMB_API_KEY}
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [attributes, batch]
-      exporters: [logging, otlp]
+      exporters: [datadog, otlp]
     logs:
       receivers: [otlp]
       processors: [attributes, batch]
-      exporters: [logging]
+      exporters: [datadog, otlp]
     metrics:
       receivers: [hostmetrics, prometheus/otel, otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [datadog]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Restores the exporters we disabled to ease local testing when we used the otel collector to export traces to our logger. This is a rollback to the previous code.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Only tested that the local environment runs as normal with this change. The otel collector fails with missing api-keys, as it always has for local environments.
