### PR TITLE
feat(common): change request_span macro to info level

### DIFF
--- a/common/src/backends/metrics.rs
+++ b/common/src/backends/metrics.rs
@@ -182,7 +182,7 @@ macro_rules! request_span {
             ""
         };
 
-        tracing::debug_span!(
+        tracing::info_span!(
             "request",
             http.uri = %$request.uri(),
             http.method = %$request.method(),


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We're no longer seeing the tracelayer logs in the deployer, since it's now defaulting to INFO. This changes the tracelayer span to INFO so we can see it. 

PS. this macro is also used in gateway and auth.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Verified we can see the tracelayer output in a local environment.
