### PR TITLE
fix(deployer): added runtime error handling

### DIFF
--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -74,6 +74,7 @@ pub async fn task(
                     active_deployment_getter.clone(),
                     runtime_manager.clone(),
                 );
+                let runtime_manager_clone = runtime_manager.clone();
                 let cleanup = move |response: Option<SubscribeStopResponse>| {
                     debug!(response = ?response,  "stop client response: ");
 
@@ -83,20 +84,23 @@ pub async fn task(
                             StopReason::End => completed_cleanup(&id),
                             StopReason::Crash => crashed_cleanup(
                                 &id,
+                                runtime_manager_clone,
                                 Error::Run(anyhow::Error::msg(response.message).into()),
-                            ),
+                            )
                         }
                     } else {
                         crashed_cleanup(
                             &id,
+                            runtime_manager_clone,
                             Error::Runtime(anyhow::anyhow!(
                                 "stop subscribe channel stopped unexpectedly"
                             )),
-                        )
+                        );
                     }
-                };
-                let runtime_manager = runtime_manager.clone();
 
+                };
+
+                let runtime_manager = runtime_manager.clone();
                 set.spawn(async move {
                     let parent_cx = global::get_text_map_propagator(|propagator| {
                         propagator.extract(&built.tracing_context)
@@ -180,12 +184,19 @@ fn stopped_cleanup(_id: &Uuid) {
     info!("{}", DEPLOYER_END_MSG_STOPPED);
 }
 
-#[instrument(name = "Cleaning up crashed deployment", skip(_id), fields(deployment_id = %_id, state = %State::Crashed))]
-fn crashed_cleanup(_id: &Uuid, error: impl std::error::Error + 'static) {
+#[instrument(name = "Cleaning up crashed deployment", skip(id, runtime_manager), fields(deployment_id = %id, state = %State::Crashed))]
+fn crashed_cleanup(id: &Uuid, runtime_manager: Arc<Mutex<RuntimeManager>>, error: impl std::error::Error + 'static) {
     error!(
         error = &error as &dyn std::error::Error,
         "{}", DEPLOYER_END_MSG_CRASHED
     );
+
+    // Fire a task which we'll not wait for. This initializes the runtime process killing.
+    let id = *id;
+    tokio::spawn(async move {
+        runtime_manager.lock().await.kill_process(id);
+        info!(%id, "initiated runtime process killing");
+    });
 }
 
 #[instrument(name = "Cleaning up startup crashed deployment", skip(_id), fields(deployment_id = %_id, state = %State::Crashed))]
@@ -263,11 +274,11 @@ impl Built {
         let runtime_client = runtime_manager
             .lock()
             .await
-            .get_runtime_client(
+            .create_runtime_client(
                 self.id,
                 project_path.as_path(),
                 self.service_name.clone(),
-                alpha_runtime_path,
+                alpha_runtime_path.clone(),
             )
             .await
             .map_err(Error::Runtime)?;
@@ -282,8 +293,7 @@ impl Built {
             resource_manager,
             runtime_client.clone(),
             self.claim,
-        )
-        .await?;
+        ).await?;
 
         let handler = tokio::spawn(run(
             self.id,
@@ -401,21 +411,34 @@ async fn run(
     deployment_updater: impl DeploymentUpdater,
     cleanup: impl FnOnce(Option<SubscribeStopResponse>) + Send + 'static,
 ) {
-    deployment_updater
-        .set_address(&id, &address)
-        .await
-        .expect("to set deployment address");
+    if let Err(err) = deployment_updater.set_address(&id, &address).await {
+        // Clean up based on a stop response built outside the runtime
+        cleanup(Some(SubscribeStopResponse {
+            reason: 2,
+            message: format!("errored while setting the new deployer address: {}", err),
+        }));
+        return;
+    }
 
     let start_request = tonic::Request::new(StartRequest {
         ip: address.to_string(),
     });
 
     // Subscribe to stop before starting to catch immediate errors
-    let mut stream = runtime_client
+    let mut stream = match runtime_client
         .subscribe_stop(tonic::Request::new(SubscribeStopRequest {}))
         .await
-        .unwrap()
-        .into_inner();
+    {
+        Ok(stream) => stream.into_inner(),
+        Err(err) => {
+            // Clean up based on a stop response built outside the runtime
+            cleanup(Some(SubscribeStopResponse {
+                reason: 2,
+                message: format!("errored while opening the StopSubscribe channel: {}", err),
+            }));
+            return;
+        }
+    };
 
     let response = runtime_client.start(start_request).await;
 
@@ -426,9 +449,14 @@ async fn run(
             }
 
             // Wait for stop reason
-            let reason = stream.message().await.expect("message from tonic stream");
-
-            cleanup(reason);
+            match stream.message().await {
+                Ok(reason) => cleanup(reason),
+                // Stream closed abruptly, most probably runtime crashed.
+                Err(err) => cleanup(Some(SubscribeStopResponse {
+                    reason: 2,
+                    message: format!("runtime StopSubscribe channel errored: {}", err),
+                })),
+            }
         }
         Err(ref status) if status.code() == Code::InvalidArgument => {
             cleanup(Some(SubscribeStopResponse {

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -185,7 +185,11 @@ fn stopped_cleanup(_id: &Uuid) {
 }
 
 #[instrument(name = "Cleaning up crashed deployment", skip(id, runtime_manager), fields(deployment_id = %id, state = %State::Crashed))]
-fn crashed_cleanup(id: &Uuid, runtime_manager: Arc<Mutex<RuntimeManager>>, error: impl std::error::Error + 'static) {
+fn crashed_cleanup(
+    id: &Uuid,
+    runtime_manager: Arc<Mutex<RuntimeManager>>,
+    error: impl std::error::Error + 'static,
+) {
     error!(
         error = &error as &dyn std::error::Error,
         "{}", DEPLOYER_END_MSG_CRASHED
@@ -293,7 +297,8 @@ impl Built {
             resource_manager,
             runtime_client.clone(),
             self.claim,
-        ).await?;
+        )
+        .await?;
 
         let handler = tokio::spawn(run(
             self.id,

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -199,7 +199,6 @@ fn crashed_cleanup(
     let id = *id;
     tokio::spawn(async move {
         runtime_manager.lock().await.kill_process(id);
-        info!(%id, "initiated runtime process killing");
     });
 }
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -281,7 +281,7 @@ impl Built {
                 self.id,
                 project_path.as_path(),
                 self.service_name.clone(),
-                alpha_runtime_path.clone(),
+                alpha_runtime_path,
             )
             .await
             .map_err(Error::Runtime)?;

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -71,7 +71,7 @@ impl RuntimeManager {
         }))
     }
 
-    pub async fn get_runtime_client(
+    pub async fn create_runtime_client(
         &mut self,
         id: Uuid,
         project_path: &Path,
@@ -168,6 +168,12 @@ impl RuntimeManager {
         });
 
         Ok(runtime_client)
+    }
+
+    pub fn kill_process(&mut self, id: Uuid) {
+        if let Some((mut process, _)) = self.runtimes.lock().unwrap().remove(&id) {
+            let _ = process.start_kill();
+        }
     }
 
     /// Send a kill / stop signal for a deployment to its running runtime

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -387,7 +387,7 @@ pub mod logger {
             }
         }
 
-        /// Background task to forward the items ones the batch capacity has been reached
+        /// Background task to forward the items once the batch capacity has been reached
         async fn batch(
             mut inner: I,
             mut rx: mpsc::UnboundedReceiver<I::Item>,


### PR DESCRIPTION
## Description of change

* Handled errors around runtime unexpected behavior by logging the errors and killing the runtime process.

When user services are CPU bound the runtime logs stream handled by the deployer can break with a broken pipe error (I haven't confirmed the root cause yet because it is not that straightforward - big stack based on tonic, hyper, and h2, but I expect it to happen because the runtime becomes CPU bound and it can not respond in time to the client keep-alive messages, which will be followed by closing the corresponding end of the tonic channel), exiting the `run` task with panic.

## How has this been tested? (if applicable)

N/A


