### PR TITLE
feat(logger): refactor to loop, add traces

### DIFF
--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -84,7 +84,7 @@ impl Postgres {
                         };
                     }
                     Err(err) => {
-                        error!(error = %err, "failed to receive message");
+                        error!(error = %err, "failed to receive message in database receiver");
                     }
                 }
             }

--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -12,7 +12,7 @@ use sqlx::{
 };
 use thiserror::Error;
 use tokio::sync::broadcast::{self, Sender};
-use tracing::{error, trace};
+use tracing::{debug, error};
 
 use tonic::transport::Uri;
 
@@ -69,7 +69,7 @@ impl Postgres {
                             "INSERT INTO logs (deployment_id, shuttle_service_name, data, tx_timestamp)",
                         );
 
-                        trace!("inserting {} logs into the database", logs.len());
+                        debug!("inserting {} logs into the database", logs.len());
 
                         builder.push_values(logs, |mut b, log| {
                             b.push_bind(log.deployment_id)


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We used a while let loop in the logger, if the channel overflowed it would return a lagged error. This way we can rather trace the error and see clearly when it occurs (and keep listening on the channel).

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested by deploying to staging.
