### PR TITLE
feat(logger): increase logger channel capacity

### DIFF
--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -58,7 +58,7 @@ impl Postgres {
             .await
             .expect("to run migrations successfully");
 
-        let (tx, mut rx): (Sender<Vec<Log>>, _) = broadcast::channel(1000);
+        let (tx, mut rx): (Sender<Vec<Log>>, _) = broadcast::channel(8000);
         let pool_spawn = pool.clone();
 
         tokio::spawn(async move {


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

At 80k logs per second we start to see some lag (channel dropping the `n` oldest messages, at 80k LPS it's dropping roughly 20 LPS). This is quite high capacity, but we will try to increase the channel capacity and see if we can handle even more.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Deploying to staging. This lead to us no longer dropping messages for a while, before it hit the rds capacity and started having very slow writes. This lead to the channel filling up again and eventually dropping messages. We shouldn't merge this, unless we increase the rds capacity.
