### PR TITLE
feat(logger): logger queue size trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,16 +244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
-dependencies = [
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-lock"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,7 +1166,6 @@ dependencies = [
  "indicatif",
  "indoc",
  "openssl",
- "opentelemetry-proto",
  "portpicker",
  "reqwest",
  "reqwest-middleware",
@@ -5447,7 +5436,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
- "opentelemetry-proto",
  "pin-project",
  "proptest",
  "rand",
@@ -5484,6 +5472,7 @@ dependencies = [
  "shuttle-common",
  "shuttle-proto",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower",
 ]
@@ -5604,13 +5593,11 @@ dependencies = [
 name = "shuttle-logger"
 version = "0.25.0"
 dependencies = [
- "async-broadcast",
  "async-trait",
  "chrono",
  "clap",
  "ctor",
  "once_cell",
- "opentelemetry-proto",
  "portpicker",
  "pretty_assertions",
  "prost-types",

--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -12,7 +12,7 @@ use sqlx::{
 };
 use thiserror::Error;
 use tokio::sync::broadcast::{self, Sender};
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use tonic::transport::Uri;
 
@@ -67,7 +67,7 @@ impl Postgres {
 
             loop {
                 interval.tick().await;
-                debug!("logger broadcast channel queue size: {}", interval_tx.len());
+                info!("broadcast channel queue size: {}", interval_tx.len());
             }
         });
 
@@ -80,6 +80,7 @@ impl Postgres {
                         );
 
                         debug!("inserting {} logs into the database", logs.len());
+                        debug!("database receiver queue size {}", rx.len());
 
                         builder.push_values(logs, |mut b, log| {
                             b.push_bind(log.deployment_id)

--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -80,7 +80,10 @@ impl Postgres {
                         );
 
                         debug!("inserting {} logs into the database", logs.len());
-                        debug!("database receiver queue size {}", rx.len());
+
+                        if !rx.is_empty() {
+                            debug!("database receiver queue size {}", rx.len());
+                        }
 
                         builder.push_values(logs, |mut b, log| {
                             b.push_bind(log.deployment_id)

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -11,7 +11,7 @@ use tokio::sync::broadcast::Sender;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::error;
+use tracing::{debug, error};
 
 pub mod args;
 mod dal;
@@ -124,6 +124,7 @@ where
             loop {
                 match logs_rx.recv().await {
                     Ok(logs) => {
+                        debug!("stream receiver queue size {}", logs_rx.len());
                         for log in logs {
                             if log.deployment_id == deployment_id
                                 && log.tx_timestamp.timestamp() >= last.seconds

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -124,7 +124,10 @@ where
             loop {
                 match logs_rx.recv().await {
                     Ok(logs) => {
-                        debug!("stream receiver queue size {}", logs_rx.len());
+                        if !logs_rx.is_empty() {
+                            debug!("stream receiver queue size {}", logs_rx.len())
+                        }
+
                         for log in logs {
                             if log.deployment_id == deployment_id
                                 && log.tx_timestamp.timestamp() >= last.seconds


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This adds a debug trace of the logger broadcast channel queue size at an interval of 10 seconds.

The lockfile changes were missed in the logger branch cleanup PR.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Tested in local environment, will test in staging too.

