### PR TITLE
fix(Containerfile): copied shuttle-logger service in the final image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -55,6 +55,10 @@ RUN cargo build \
 # Base image for running each "shuttle-..." binary
 ARG RUSTUP_TOOLCHAIN
 FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-buster as shuttle-crate-base
+ARG folder
+# Some crates need additional libs
+COPY ${folder}/*.so /usr/lib/
+ENV LD_LIBRARY_PATH=/usr/lib/
 ENTRYPOINT ["/usr/local/bin/service"]
 
 
@@ -74,10 +78,6 @@ ARG RUSTUP_TOOLCHAIN
 ENV RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN}
 # Used as env variable in prepare script
 ARG PROD
-ARG folder
-# Some crates need additional libs
-COPY ${folder}/*.so /usr/lib/
-ENV LD_LIBRARY_PATH=/usr/lib/
 COPY deployer/prepare.sh /prepare.sh
 RUN /prepare.sh "${prepare_args}"
 COPY --from=builder /build/target/${CARGO_PROFILE}/shuttle-deployer /usr/local/bin/service
@@ -97,6 +97,8 @@ FROM shuttle-gateway AS shuttle-gateway-dev
 COPY --from=planner /build/*.pem /usr/src/shuttle/
 
 FROM shuttle-crate-base AS shuttle-logger
+ARG CARGO_PROFILE
+COPY --from=builder /build/target/${CARGO_PROFILE}/shuttle-logger /usr/local/bin/service
 FROM shuttle-logger AS shuttle-logger-dev
 
 FROM shuttle-crate-base AS shuttle-provisioner


### PR DESCRIPTION
## Description of change

We dont copy the shuttle-logger service binary in the docker image.

## How has this been tested? (if applicable)

Locally.


