### PR TITLE
fix(cargo-shuttle): secrets project requires a Secrets.toml

### DIFF
--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -20,6 +20,12 @@ async fn rocket_hello_world() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rocket_secrets() {
+    std::fs::copy(
+        "../examples/rocket/secrets/Secrets.toml.example",
+        "../examples/rocket/secrets/Secrets.toml",
+    )
+    .unwrap();
+
     let url = cargo_shuttle_run("../examples/rocket/secrets", false).await;
 
     let request_text = reqwest::Client::new()


### PR DESCRIPTION
## Description of change

`cargo-shuttle` tests are failing on main.

## How has this been tested? (if applicable)

Locally, running the `rocket_secrets` test.


