### PR TITLE
fix: default network subnet overlap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,12 @@ networks:
       driver: default
       config:
         - subnet: 10.99.0.0/16
+  default:
+    attachable: false
+    ipam:
+      driver: default
+      config:
+        - subnet: 11.99.0.0/16
 services:
   auth:
     image: "${CONTAINER_REGISTRY}/auth:${AUTH_TAG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 11.99.0.0/16
+        - subnet: 10.100.0.0/16
 services:
   auth:
     image: "${CONTAINER_REGISTRY}/auth:${AUTH_TAG}"


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

The default network subnet overlapped with our VPC subnet, leading the logger service to not be able to reach the rds instance via DNS.

## How has this been tested? (if applicable)
<!-- Please describe the tests that you ran to verify your changes. -->

Applied to staging environment.
