### PR TITLE
bug: project entering a state loop

### DIFF
--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -502,11 +502,13 @@ where
                     ContainerStateStatusEnum::RUNNING => {
                         Self::Started(ProjectStarted::new(container, VecDeque::new()))
                     }
-                    ContainerStateStatusEnum::CREATED => Self::Starting(ProjectStarting {
+                    // We can reach the starting state because either:
+                    // - The project was created for the first time
+                    // - It crashed and we are restarting it
+                    ContainerStateStatusEnum::CREATED | ContainerStateStatusEnum::EXITED => Self::Starting(ProjectStarting {
                         container,
                         restart_count,
                     }),
-                    ContainerStateStatusEnum::EXITED => Self::Restarting(ProjectRestarting  { container, restart_count: 0 }),
                     _ => {
                         return Err(Error::custom(
                             ErrorKind::Internal,


### PR DESCRIPTION
## Description of change
Projects sometimes seem to get stuck in a startup loop when the startup accidentally runs with a project stop command. That is because this `refresh` function, maybe being called from the ambulance task, maybe from something else, would have incorrectly put a project that is starting up, directly after a restart, back into the restart state.

## How has this been tested? (if applicable)
By starting gateway locally and messing with the container state to first reproduce it and then to confirm the fix is working.


