### PR TITLE
fix(deployer): handle gracefully builder connection failure

### DIFF
--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -86,13 +86,15 @@ where
 
     pub fn builder_client(
         mut self,
-        builder_client: BuilderClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+        builder_client: Option<
+            BuilderClient<
+                shuttle_common::claims::ClaimService<
+                    shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+                >,
             >,
         >,
     ) -> Self {
-        self.builder_client = Some(builder_client);
+        self.builder_client = builder_client;
 
         self
     }
@@ -166,7 +168,6 @@ where
         let secret_getter = self.secret_getter.expect("a secret getter to be set");
         let resource_manager = self.resource_manager.expect("a resource manager to be set");
         let logs_fetcher = self.logs_fetcher.expect("a logs fetcher to be set");
-        let builder_client = self.builder_client.expect("a builder client to be set");
 
         let (queue_send, queue_recv) = mpsc::channel(QUEUE_BUFFER_SIZE);
         let (run_send, run_recv) = mpsc::channel(RUN_BUFFER_SIZE);
@@ -184,7 +185,7 @@ where
             build_log_recorder,
             secret_recorder,
             queue_client,
-            builder_client,
+            self.builder_client,
             builds_path.clone(),
         ));
         // Run queue. Waits for built deployments and runs them.

--- a/deployer/src/deployment/state_change_layer.rs
+++ b/deployer/src/deployment/state_change_layer.rs
@@ -800,7 +800,7 @@ mod tests {
             .secret_getter(StubSecretGetter)
             .resource_manager(StubResourceManager)
             .log_fetcher(logger_client.clone())
-            .builder_client(builder_client.clone())
+            .builder_client(Some(builder_client))
             .runtime(get_runtime_manager(Batcher::wrap(logger_client)).await)
             .deployment_updater(StubDeploymentUpdater)
             .queue_client(StubBuildQueueClient)

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -37,11 +37,11 @@ pub async fn start(
             shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
         >,
     >,
-    builder_client: BuilderClient<
+    builder_client: Option<BuilderClient<
         shuttle_common::claims::ClaimService<
             shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
         >,
-    >,
+    >>,
     args: Args,
 ) {
     // when _set is dropped once axum exits, the deployment tasks will be aborted.

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -37,11 +37,13 @@ pub async fn start(
             shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
         >,
     >,
-    builder_client: Option<BuilderClient<
-        shuttle_common::claims::ClaimService<
-            shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+    builder_client: Option<
+        BuilderClient<
+            shuttle_common::claims::ClaimService<
+                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
+            >,
         >,
-    >>,
+    >,
     args: Args,
 ) {
     // when _set is dropped once axum exits, the deployment tasks will be aborted.

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -46,14 +46,14 @@ async fn main() {
     let logger_batcher = Batcher::wrap(logger_client.clone());
 
     let builder_client = match args.builder_uri.connect().await {
-        Ok(endpoint) => Some(BuilderClient::new(
+        Ok(channel) => Some(BuilderClient::new(
             ServiceBuilder::new()
                 .layer(ClaimLayer)
                 .layer(InjectPropagationLayer)
-                .service(endpoint),
+                .service(channel),
         )),
         Err(err) => {
-            error!("Couldn't connect to the shadow-builder: {err}");
+            error!("Couldn't connect to the shuttle-builder: {err}");
             None
         }
     };


### PR DESCRIPTION
## Description of change

Deployer handles now gracefully connection failure to builder.


## How has this been tested? (if applicable)

Tested locally.


