### PR TITLE
feat(orchestrator): initialize shuttle-orchestrator as a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5653,6 +5653,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shuttle-common",
+ "shuttle-orchestrator",
  "shuttle-proto",
  "snailquote",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5701,6 +5701,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuttle-orchestrator"
+version = "0.27.0"
+
+[[package]]
 name = "shuttle-proto"
 version = "0.27.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ repository = "https://github.com/shuttle-hq/shuttle"
 shuttle-codegen = { path = "codegen", version = "0.27.0" }
 shuttle-common = { path = "common", version = "0.27.0" }
 shuttle-common-tests = { path = "common-tests", version = "0.27.0" }
+shuttle-orchestrator = { path = "orchestrator", version = "0.27.0" }
 shuttle-proto = { path = "proto", version = "0.27.0" }
 shuttle-service = { path = "service", version = "0.27.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "deployer",
   "gateway",
   "logger",
+  "orchestrator",
   "proto",
   "provisioner",
   "resource-recorder",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -61,6 +61,9 @@ features = ["backend", "models", "openapi"]
 [dependencies.shuttle-proto]
 workspace = true
 
+[dependencies.shuttle-orchestrator]
+workspace = true
+
 [dev-dependencies]
 anyhow = { workspace = true }
 colored = { workspace = true }

--- a/orchestrator/Cargo.toml
+++ b/orchestrator/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "shuttle-orchestrator"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/orchestrator/src/lib.rs
+++ b/orchestrator/src/lib.rs
@@ -1,0 +1,1 @@
+//! shuttle-orchestrator: manages the services’ sandboxing, and state.


### PR DESCRIPTION
## Description of change

This PR simply creates a new library in the workspace called `shuttle-orchestrator`.

Let me know if anything else is needed.

## How has this been tested? (if applicable)

`cargo build`
