### PR TITLE
ci: separate ci and unstable jobs, better caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ jobs:
   test-workspace-member:
     parameters:
       crate:
-        description: "Crate in workspace to test"
+        description: Crate in workspace to test
         type: string
     executor: docker-rust
     steps:
@@ -260,11 +260,14 @@ jobs:
   test-workspace-member-with-integration:
     parameters:
       crate:
-        description: "Crate in workspace to test"
+        description: Crate in workspace to test
         type: string
       resource_class:
-        description: "The resource type to use for the machine"
+        description: The resource type to use for the machine
         type: string
+      sccache-size:
+        type: string
+        default: ""
     executor: docker-rust
     resource_class: << parameters.resource_class >>
     steps:
@@ -272,7 +275,8 @@ jobs:
       - install-protoc
       - checkout
       - run: git submodule update --init
-      - restore-cargo-and-sccache
+      - restore-cargo-and-sccache:
+          sccache-size: << parameters.sccache-size >>
       - apply-patches
       - run:
           name: Run unit tests
@@ -294,6 +298,9 @@ jobs:
       crate:
         description: "Crate in workspace to test"
         type: string
+      sccache-size:
+        type: string
+        default: ""
     # Using a machine image since tests will start a docker container
     executor: machine-ubuntu
     steps:
@@ -302,7 +309,7 @@ jobs:
       - checkout
       - run: git submodule update --init
       - restore-cargo-and-sccache:
-          sccache-size: 2G
+          sccache-size: << parameters.sccache-size >>
       - apply-patches
       - run:
           name: Run integration tests that need docker
@@ -345,7 +352,7 @@ jobs:
       - save_cache:
           name: Save buildx cache
           paths:
-            - "/tmp/cache/buildx"
+            - /tmp/cache/buildx
           key: docker-buildx-{{ .Branch }}-{{ .Revision }}
           when: always
   build-and-push:
@@ -750,6 +757,8 @@ workflows:
             parameters:
               resource_class:
                 - xlarge
+              sccache-size:
+                - 2G
               crate:
                 - cargo-shuttle
                 - shuttle-deployer
@@ -757,6 +766,8 @@ workflows:
           name: << matrix.crate >> with docker
           matrix:
             parameters:
+              sccache-size:
+                - 1G
               crate:
                 # need to spawn docker containers, therefore in a machine
                 - cargo-shuttle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,6 +754,8 @@ workflows:
           filters:
             branches:
               only: production
+  unstable:
+    jobs:
       - approve-push-unstable:
           type: approval
           filters:
@@ -766,9 +768,6 @@ workflows:
           production: false
           requires:
             - approve-push-unstable
-          filters:
-            branches:
-              only: main
       - deploy-images:
           name: Deploy images to unstable
           postgres-password: DEV_POSTGRES_PASSWORD
@@ -831,9 +830,6 @@ workflows:
             - build-binaries-aarch64
             - build-binaries-windows
             - build-binaries-mac
-          filters:
-            branches:
-              only: production
       - approve-push-production:
           type: approval
           filters:
@@ -846,9 +842,6 @@ workflows:
           production: true
           requires:
             - approve-push-production
-          filters:
-            branches:
-              only: production
       - deploy-images:
           name: deploy-images-to-production
           postgres-password: PROD_POSTGRES_PASSWORD
@@ -862,9 +855,6 @@ workflows:
           production: true
           requires:
             - build-and-push-production
-          filters:
-            branches:
-              only: production
       - approve-publish-crates:
           type: approval
           filters:
@@ -879,9 +869,6 @@ workflows:
           name: publish-<< matrix.path >>
           requires:
             - approve-publish-crates
-          filters:
-            branches:
-              only: production
       - publish-crates:
           matrix:
             parameters:
@@ -891,9 +878,6 @@ workflows:
           name: publish-<< matrix.path >>
           requires:
             - publish-common
-          filters:
-            branches:
-              only: production
       - publish-crates:
           matrix:
             parameters:
@@ -909,9 +893,6 @@ workflows:
           name: publish-<< matrix.path >>
           requires:
             - publish-service
-          filters:
-            branches:
-              only: production
       - publish-crates:
           matrix:
             parameters:
@@ -931,6 +912,3 @@ workflows:
           name: publish-<< matrix.path >>
           requires:
             - publish-runtime
-          filters:
-            branches:
-              only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -758,7 +758,7 @@ workflows:
               resource_class:
                 - xlarge
               sccache-size:
-                - 2G
+                - 1G
               crate:
                 - cargo-shuttle
                 - shuttle-deployer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,9 @@ commands:
             echo 'export SCCACHE_CACHE_SIZE=<< parameters.sccache-size >>' >> $BASH_ENV
       - run:
           name: Start sccache
-          command: ~/.cargo/bin/sccache --start-server
+          command: |
+            ~/.cargo/bin/sccache --start-server
+            ~/.cargo/bin/sccache --show-stats
       - restore_cache:
           name: Restore sccache cache
           keys: # This can use fallback due to size limit.
@@ -289,12 +291,12 @@ jobs:
       - install-protoc
       - checkout
       - run: git submodule update --init
-      - restore-cargo-cache
+      - restore-cargo-cache:
+          sccache-size: 2G
       - apply-patches
       - run:
           name: Run integration tests that need docker
           command: |
-            SCCACHE_CACHE_SIZE=2G
             set +o pipefail
             path=$(echo "<< parameters.crate >>" | sed "s/shuttle-\(.*\)/\1/")
             if [ -f "$path/integration_docker.sh" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ executors:
 # sscache steps are from this guide
 # https://medium.com/@edouard.oger/rust-caching-on-circleci-using-sccache-c996344f0115
 commands:
-  restore-cargo-cache:
+  restore-cargo-and-sccache:
     parameters:
       sccache-size:
         description: Max size for the cache
@@ -29,10 +29,6 @@ commands:
         # Large integration tests override this default.
         default: 500M
     steps:
-      - restore_cache:
-          name: Restore cargo registry cache
-          key: cargo-{{ checksum "Cargo.lock" }}
-          # Don't use fallback key to prevent registry cache from growing indefinitely.
       - run:
           name: Install sccache
           command: |
@@ -46,15 +42,18 @@ commands:
             echo 'export SCCACHE_CACHE_SIZE=<< parameters.sccache-size >>' >> $BASH_ENV
       - run:
           name: Start sccache
-          command: |
-            ~/.cargo/bin/sccache --start-server
-            ~/.cargo/bin/sccache --show-stats
+          command: ~/.cargo/bin/sccache --start-server
       - restore_cache:
           name: Restore sccache cache
-          keys: # This can use fallback due to size limit.
+          keys: # Find latest cache for this job on same branch, else fall back to older cache.
             - sccache-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-
             - sccache-cache-{{ .Environment.CIRCLE_JOB }}-
-  save-cargo-cache:
+      - restore_cache:
+          name: Restore cargo registry cache
+          keys: # This is saved once per lockfile update. If new lockfile, get an older cache.
+            - cargo-{{ checksum "Cargo.lock" }}
+            - cargo-
+  save-sccache:
     steps:
       - run:
           name: Sccache stats
@@ -65,13 +64,23 @@ commands:
           # If a new commit is built, it will fall back on the most recent cache from the same branch.
           key: sccache-cache-{{ .Environment.CIRCLE_JOB }}-{{ .Branch }}-{{ .Revision }}
           paths:
-            - "~/.cache/sccache"
+            - ~/.cache/sccache
+  # This is only performed by the workspace clippy job, since it does the largest cargo fetch.
+  # Other jobs might restore a slightly older copy of this cache.
+  save-cargo-cache:
+    steps:
+      # Discard crates.io patches so that it produces a re-usable cache key checksum.
+      - run:
+          name: Restore Cargo.lock
+          command: git restore Cargo.lock
       - save_cache:
           name: Save cargo cache
+          # This is saved once per lockfile update.
           key: cargo-{{ checksum "Cargo.lock" }}
           paths:
-            - ~/.cargo/registry
-            - ~/.cargo/git
+            - ~/.cargo/registry/cache
+            - ~/.cargo/registry/index
+            - ~/.cargo/git/db
   restore-buildx-cache:
     steps:
       - docker-buildx/install:
@@ -190,7 +199,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - restore-cargo-cache
+      - restore-cargo-and-sccache
       # Check this to make sure we do not include patched dependencies in the Cargo.lock
       - run: |
           [ -z "$(grep "\[\[patch.unused\]\]" Cargo.lock)" ] || \
@@ -202,11 +211,12 @@ jobs:
                        --all-features \
                        --no-deps -- \
                        --D warnings
-      - save-cargo-cache
       # An out of date lockfile will be modified after the clippy command has run
       - run: |
           git diff --exit-code Cargo.lock || \
             ( echo "Please commit an up to date Cargo.lock"; exit 1 )
+      - save-sccache
+      - save-cargo-cache
   test-standalone:
     parameters:
       path:
@@ -219,7 +229,7 @@ jobs:
     executor: docker-rust
     steps:
       - checkout
-      - restore-cargo-cache
+      - restore-cargo-and-sccache
       - apply-patches
       - run: cargo fmt --all --check --manifest-path << parameters.path >>/Cargo.toml
       - run: |
@@ -234,7 +244,7 @@ jobs:
                      --manifest-path << parameters.path >>/Cargo.toml \
                      -- \
                      --nocapture
-      - save-cargo-cache
+      - save-sccache
   test-workspace-member:
     parameters:
       crate:
@@ -244,9 +254,9 @@ jobs:
     steps:
       - install-rust
       - checkout
-      - restore-cargo-cache
+      - restore-cargo-and-sccache
       - run: cargo test -p << parameters.crate >> --all-features --lib -- --nocapture
-      - save-cargo-cache
+      - save-sccache
   test-workspace-member-with-integration:
     parameters:
       crate:
@@ -262,7 +272,7 @@ jobs:
       - install-protoc
       - checkout
       - run: git submodule update --init
-      - restore-cargo-cache
+      - restore-cargo-and-sccache
       - apply-patches
       - run:
           name: Run unit tests
@@ -278,7 +288,7 @@ jobs:
               echo "nothing to test here, adjust CI file or add an integration script"
               exit 1
             fi
-      - save-cargo-cache
+      - save-sccache
   test-workspace-member-with-integration-docker:
     parameters:
       crate:
@@ -291,7 +301,7 @@ jobs:
       - install-protoc
       - checkout
       - run: git submodule update --init
-      - restore-cargo-cache:
+      - restore-cargo-and-sccache:
           sccache-size: 2G
       - apply-patches
       - run:
@@ -305,7 +315,7 @@ jobs:
               echo "nothing to test here, adjust CI file or add an integration script"
               exit 1
             fi
-      - save-cargo-cache
+      - save-sccache
   e2e-test:
     executor: machine-ubuntu
     steps:
@@ -722,6 +732,7 @@ workflows:
               crate:
                 - shuttle-auth
                 - shuttle-proto
+                - shuttle-resource-recorder
       - test-workspace-member-with-integration:
           name: << matrix.crate >>
           matrix:
@@ -730,7 +741,6 @@ workflows:
               resource_class:
                 - large
               crate:
-                - shuttle-resource-recorder
                 - shuttle-runtime
                 - shuttle-service
       - test-workspace-member-with-integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,13 @@ executors:
 # https://medium.com/@edouard.oger/rust-caching-on-circleci-using-sccache-c996344f0115
 commands:
   restore-cargo-cache:
+    parameters:
+      sccache-size:
+        description: Max size for the cache
+        type: string
+        # 500 MB is the recommended soft cap for a cache on circleci.
+        # Large integration tests override this default.
+        default: 500M
     steps:
       - restore_cache:
           name: Restore cargo registry cache
@@ -28,8 +35,6 @@ commands:
           # Don't use fallback key to prevent registry cache from growing indefinitely.
       - run:
           name: Install sccache
-          # 500 MB is the recommended soft cap for a cache on circleci.
-          # Large integration tests override this default.
           command: |
             SCCACHE_VERSION='v0.5.4'
             ls ~/.cargo/bin/sccache \
@@ -38,7 +43,10 @@ commands:
                 > ~/.cargo/bin/sccache \
               && chmod +x ~/.cargo/bin/sccache
             echo 'export RUSTC_WRAPPER=~/.cargo/bin/sccache' >> $BASH_ENV
-            echo 'export SCCACHE_CACHE_SIZE=500M' >> $BASH_ENV
+            echo 'export SCCACHE_CACHE_SIZE=<< parameters.sccache-size >>' >> $BASH_ENV
+      - run:
+          name: Start sccache
+          command: ~/.cargo/bin/sccache --start-server
       - restore_cache:
           name: Restore sccache cache
           keys: # This can use fallback due to size limit.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -428,7 +428,8 @@ async fn run_pre_deploy_tests(
         // We set the tests to build with the release profile since deployments compile
         // with the release profile by default. This means crates don't need to be
         // recompiled in debug mode for the tests, reducing memory usage during deployment.
-        .arg("--release")
+        // When running unit tests, it can compile in debug mode.
+        .arg(if cfg!(not(test)) { "--release" } else { "" })
         .arg("--jobs=4")
         .arg("--color=always")
         .current_dir(project_path)

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -392,10 +392,8 @@ async fn build_deployment(
     project_path: &Path,
     tx: crossbeam_channel::Sender<Message>,
 ) -> Result<BuiltService> {
-    // Investigate if this can be optimized for local run / CI.
-    // Remember the same flag for cargo test as well.
-    // let release = std::env::var("CI").is_ok_and(|s| s == "true") || std::env::var("PROD").is_ok_and(|s| s == "true");
-    let runtimes = build_workspace(project_path, true, tx, true)
+    // Build in release mode, except for when testing, such as in CI
+    let runtimes = build_workspace(project_path, cfg!(not(test)), tx, true)
         .await
         .map_err(|e| Error::Build(e.into()))?;
 

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -234,10 +234,9 @@ async fn compile(
     }
 
     let profile = if release_mode {
-        cargo.arg("--profile").arg("release");
+        cargo.arg("--release");
         "release"
     } else {
-        cargo.arg("--profile").arg("dev");
         "debug"
     };
 


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
![image](https://github.com/shuttle-hq/shuttle/assets/54029719/e74f90dd-2fee-47ad-87ba-95f13a8b0dfd)

- unstable is no longer part of the ci job
  - makes approving/cancelling/rerunning unstable job much cleaner
- less filters for jobs that already depend on filters
- faster

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Works with and without the filter commented
