### PR TITLE
fix(docker-compose.dev): adjust auth dev dependency

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -237,7 +237,7 @@ Make sure an admin user is inserted into auth and that the key is used by cargo-
 We're now ready to start a local run of the deployer:
 
 ```bash
-OTLP_ADDRESS=http://127.0.0.1:4317 cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --resource-recorder http://localhost:8007 --logger-uri http://localhost:8080 --builder-uri http://localhost:8009 --proxy-fqdn local.rs --admin-secret dh9z58jttoes3qvt --local --project-id "01H7WHDK23XYGSESCBG6XWJ1V0" --project <name>
+OTLP_ADDRESS=http://127.0.0.1:4317 cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --resource-recorder http://localhost:8007 --builder-uri http://localhost:8009 --logger-uri http://localhost:8010 --proxy-fqdn local.rs --admin-secret dh9z58jttoes3qvt --local --project-id "01H7WHDK23XYGSESCBG6XWJ1V0" --project <name>
 ```
 
 The `<name>` needs to match the name of the project that will be deployed to this deployer.

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -56,7 +56,7 @@ pub struct Args {
     pub admin_secret: String,
 
     /// Address to reach the authentication service at
-    #[clap(long, default_value = "http://127.0.0.1:8008")]
+    #[clap(long, default_value = "http://auth:8000")]
     pub auth_uri: Uri,
 
     /// Address to reach the builder service at

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -45,9 +45,7 @@ services:
         >&2 echo "The control DB is available - starting shuttle-resource-recorder"
 
         exec /usr/local/bin/service "$${@:0}"
-  auth-dev:
-    ports:
-      - 8006:8000
+  auth:
     depends_on:
       - control-db
     entrypoint:
@@ -74,7 +72,7 @@ services:
       - panamax
   logger:
     ports:
-      - 8080:8000
+      - 8010:8000
     depends_on:
       - auth
       - logger-postgres


### PR DESCRIPTION
## Description of change

The auth service started locally should have the same name as the one found in `docker-compose.yml` for a successful merge between dev and 'prod' compose files.

## How has this been tested? (if applicable)

Did a `make up`, a `project stop/start` and `deploy`.


