### PR TITLE
feat(cargo-shuttle): check project name available

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -250,7 +250,7 @@ pub struct InitArgs {
     #[arg(default_value = ".", value_parser = OsStringValueParser::new().try_map(parse_init_path))]
     pub path: PathBuf,
 
-    /// Whether to create the environment for this project on Shuttle
+    /// Whether to start the container for this project on Shuttle, and claim the project name
     #[arg(long)]
     pub create_env: bool,
     #[command(flatten)]

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -55,6 +55,18 @@ impl Client {
             .context("parsing API version info")
     }
 
+    pub async fn check_project_name(&self, project_name: &ProjectName) -> Result<bool> {
+        let url = format!("{}/projects/name/{project_name}", self.api_url);
+
+        self.client
+            .get(url)
+            .send()
+            .await?
+            .json()
+            .await
+            .context("parsing name check response")
+    }
+
     pub async fn deploy(
         &self,
         project: &ProjectName,

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -363,14 +363,12 @@ impl RequestContext {
     /// Set the API key to the global configuration. Will persist the file.
     pub fn set_api_key(&mut self, api_key: ApiKey) -> Result<()> {
         self.global.as_mut().unwrap().set_api_key(api_key);
-        self.global.save()?;
-        Ok(())
+        self.global.save()
     }
 
     pub fn clear_api_key(&mut self) -> Result<()> {
         self.global.as_mut().unwrap().clear_api_key();
-        self.global.save()?;
-        Ok(())
+        self.global.save()
     }
     /// Get the current project name.
     ///

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -308,7 +308,7 @@ impl Shuttle {
                     Failed,
                 }
                 // TODO replace this with self.client after PR 1275
-                match reqwest::get(format!("{}/project/name/{}", self.ctx.api_url(), p))
+                match reqwest::get(format!("{}/projects/name/{}", self.ctx.api_url(), p))
                     .await
                     .map(|r| match r.status() {
                         reqwest::StatusCode::NOT_FOUND => NameCheck::Available,
@@ -322,10 +322,13 @@ impl Shuttle {
                         break;
                     }
                     NameCheck::Taken => {
-                        println!("Project name already taken: '{}'", p.to_string());
+                        println!("{} {}", "Project name already taken:".red(), p);
                     }
                     NameCheck::Failed => {
-                        println!("Failed to check if project name is available.");
+                        println!(
+                            "{}",
+                            "Failed to check if project name is available.".yellow()
+                        );
                         break;
                     }
                 }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -311,6 +311,7 @@ impl Shuttle {
                 match client.check_project_name(&p).await {
                     Ok(true) => {
                         println!("{} {}", "Project name already taken:".red(), p);
+                        println!("{}", "Try a different name.".yellow());
                     }
                     Ok(false) => {
                         project_args.name = Some(p);

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -314,6 +314,7 @@ impl Shuttle {
                         break;
                     }
                     Err(_) => {
+                        project_args.name = Some(p);
                         println!(
                             "{}",
                             "Failed to check if project name is available.".yellow()

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -264,7 +264,7 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
     // Partial input should be enough to match "rocket"
     session.send_line("roc")?;
     session.exp_string("Creating project")?;
-    session.exp_string("Do you want to create the project environment on Shuttle?")?;
+    session.exp_string("container on Shuttle?")?;
     session.send("n")?;
     session.flush()?;
     session.exp_string("no")?;
@@ -306,7 +306,7 @@ fn interactive_rocket_init_manually_choose_template() -> Result<(), Box<dyn std:
     // Partial input should be enough to match "rocket"
     session.send_line("roc")?;
     session.exp_string("Creating project")?;
-    session.exp_string("Do you want to create the project environment on Shuttle?")?;
+    session.exp_string("container on Shuttle?")?;
     session.send("n")?;
     session.flush()?;
     session.exp_string("no")?;
@@ -344,7 +344,7 @@ fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::er
     session.exp_string("Directory")?;
     session.send_line(temp_dir_path.to_str().unwrap())?;
     session.exp_string("Creating project")?;
-    session.exp_string("Do you want to create the project environment on Shuttle?")?;
+    session.exp_string("container on Shuttle?")?;
     session.send("n")?;
     session.flush()?;
     session.exp_string("no")?;
@@ -385,7 +385,7 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
     // Partial input should be enough to match "rocket"
     session.send_line("roc")?;
     session.exp_string("Creating project")?;
-    session.exp_string("Do you want to create the project environment on Shuttle?")?;
+    session.exp_string("container on Shuttle?")?;
     session.send("n")?;
     session.flush()?;
     session.exp_string("no")?;
@@ -428,7 +428,7 @@ fn interactive_rocket_init_prompt_path_dirty_dir() -> Result<(), Box<dyn std::er
     session.flush()?;
     session.exp_string("yes")?;
     session.exp_string("Creating project")?;
-    session.exp_string("Do you want to create the project environment on Shuttle?")?;
+    session.exp_string("container on Shuttle?")?;
     session.send("n")?;
     session.flush()?;
     session.exp_string("no")?;

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -72,7 +72,7 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::UserAlreadyExists => (StatusCode::BAD_REQUEST, "user already exists"),
             ErrorKind::ProjectNotFound => (
                 StatusCode::NOT_FOUND,
-                "project not found. Run `cargo shuttle project start` to create a new project.",
+                "project not found. Make sure you are the owner of this project name. Run `cargo shuttle project start` to create a new project.",
             ),
             ErrorKind::ProjectNotReady => (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -77,7 +77,7 @@ impl Eq for State {}
 
 impl Display for Response {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "project '{}' is {}", self.name, self.state)
+        write!(f, r#"Project "{}" is {}"#, self.name, self.state)
     }
 }
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -319,13 +319,14 @@ impl GatewayService {
             .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound))
     }
 
-    pub async fn project_name_exists(&self, project_name: &ProjectName) -> Result<(), Error> {
-        query("SELECT project_name FROM projects WHERE project_name=?1")
-            .bind(project_name)
-            .fetch_optional(&self.db)
-            .await?
-            .map(|_| ())
-            .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound))
+    pub async fn project_name_exists(&self, project_name: &ProjectName) -> Result<bool, Error> {
+        Ok(
+            query("SELECT project_name FROM projects WHERE project_name=?1")
+                .bind(project_name)
+                .fetch_optional(&self.db)
+                .await?
+                .is_some(),
+        )
     }
 
     pub async fn iter_user_projects_detailed(

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -320,12 +320,11 @@ impl GatewayService {
     }
 
     pub async fn project_name_exists(&self, project_name: &ProjectName) -> Result<(), Error> {
-        let a = query("SELECT project_name FROM projects WHERE project_name=?1")
+        query("SELECT project_name FROM projects WHERE project_name=?1")
             .bind(project_name)
             .fetch_optional(&self.db)
-            .await?;
-        println!("{}", a.is_some());
-        a.map(|_| ())
+            .await?
+            .map(|_| ())
             .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound))
     }
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -319,6 +319,16 @@ impl GatewayService {
             .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound))
     }
 
+    pub async fn project_name_exists(&self, project_name: &ProjectName) -> Result<(), Error> {
+        let a = query("SELECT project_name FROM projects WHERE project_name=?1")
+            .bind(project_name)
+            .fetch_optional(&self.db)
+            .await?;
+        println!("{}", a.is_some());
+        a.map(|_| ())
+            .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound))
+    }
+
     pub async fn iter_user_projects_detailed(
         &self,
         account_name: &AccountName,


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

![image](https://github.com/shuttle-hq/shuttle/assets/54029719/7cbb59f7-a09a-4231-a22d-3a864faea70c)
![image](https://github.com/shuttle-hq/shuttle/assets/54029719/3ae35c54-b755-4c5d-8b76-4d82b2a11110)

What still remains:
- *Should we allow user to use the name even though it is taken? Prompt y/n for the rename?*
  - It's a bit tricky and not a killer. Using `--name` gets you around this check.

Bonus:
![image](https://github.com/shuttle-hq/shuttle/assets/54029719/a032c32e-d209-4e35-931c-3831d7b98fd0)


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

All 3 scenarios tested locally
Updated tests
