### PR TITLE
fix: gateway container startup on apple m1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -95,7 +95,9 @@ RUN /prepare.sh "${prepare_args}"
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-deployer /usr/local/bin/service
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-next /usr/local/cargo/bin/
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then mv /usr/lib/ulid0_aarch64.so /usr/lib/ulid0.so; fi
+RUN for target_platform in "linux/arm64" "linux/arm64/v8"; do \
+    if [ "$TARGETPLATFORM" = "$target_platform" ]; then \
+      mv /usr/lib/ulid0_aarch64.so /usr/lib/ulid0.so; fi; done
 FROM shuttle-deployer AS shuttle-deployer-dev
 # Source code needed for compiling with [patch.crates-io]
 COPY --from=chef-planner /build /usr/src/shuttle/
@@ -107,7 +109,9 @@ COPY ${folder}/*.so /usr/lib/
 ENV LD_LIBRARY_PATH=/usr/lib/
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-gateway /usr/local/bin/service
 ARG TARGETPLATFORM
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then mv /usr/lib/ulid0_aarch64.so /usr/lib/ulid0.so; fi
+RUN for target_platform in "linux/arm64" "linux/arm64/v8"; do \
+    if [ "$TARGETPLATFORM" = "$target_platform" ]; then \
+      mv /usr/lib/ulid0_aarch64.so /usr/lib/ulid0.so; fi; done
 FROM shuttle-gateway AS shuttle-gateway-dev
 # For testing certificates locally
 COPY --from=chef-planner /build/*.pem /usr/src/shuttle/


### PR DESCRIPTION
## Description of change
Allows shuttle to start in docker on M1 Pro MacBooks, there might be additional change needed for other Apple CPUs, I have no way to test.
This change achieves this by adding the `TARGETPLATFORM` value used by Docker on the mentioned MacBook to the list of platforms for which an arm64 version of the `ulid0.so` should be used.


## How has this been tested? (if applicable)
Before this change gateway container wouldn't start on an M1 Pro MacBook during the `make up` step of the [running-locally](https://github.com/shuttle-hq/shuttle/blob/main/DEVELOPING.md#running-locally) guide, now it does.
I was able to successfully deploy an example locally after the change.
