### PR TITLE
fix(cargo-shuttle): spam less requests when waiting for project ready

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1635,6 +1635,8 @@ impl Shuttle {
 
             progress_bar.set_message(format!("{project}"));
             project = client.get_project(project_name).await?;
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
         }
         progress_bar.finish_and_clear();
         println!("{project}");


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Still looks very smooth, but now does not spam 100s of requests while waiting.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Works locally.
