### PR TITLE
test(cargo-shuttle): add debug assertion for command-line arguments

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -355,9 +355,14 @@ pub(crate) fn parse_init_path(path: OsString) -> Result<PathBuf, io::Error> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::path_from_workspace_root;
-
     use super::*;
+    use crate::tests::path_from_workspace_root;
+    use clap::CommandFactory;
+
+    #[test]
+    fn test_shuttle_args() {
+        ShuttleArgs::command().debug_assert();
+    }
 
     #[test]
     fn test_init_args_framework() {


### PR DESCRIPTION
## Description of change

See https://docs.rs/clap/latest/clap/struct.Command.html#method.debug_assert

## How has this been tested? (if applicable)

`cargo test -- "test_shuttle_args"`
