### PR TITLE
chore(editorconfig): add indentation settings for shell scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
+# Indentation settings for shell scripts
+[*.sh]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Description of change

Add indentation settings for shell scripts (e.g. for `install.sh`)

## How has this been tested? (if applicable)

I ran `editorconfig-checker` locally.
