### PR TITLE
fix(cargo-shuttle): fix init login bugs

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -319,16 +319,14 @@ impl Shuttle {
             };
 
             self.login(login_args).await?;
-        } else {
-            if interactive {
-                println!("First, let's log in to your Shuttle account.");
-                self.login(args.login_args.clone()).await?;
-                println!();
-            } else if args.login_args.api_key.is_some() {
-                self.login(args.login_args.clone()).await?;
-            } else if args.create_env {
-                bail!("Tried to login to create a Shuttle environment, but no API key was set.")
-            }
+        } else if interactive {
+            println!("First, let's log in to your Shuttle account.");
+            self.login(args.login_args.clone()).await?;
+            println!();
+        } else if args.login_args.api_key.is_some() {
+            self.login(args.login_args.clone()).await?;
+        } else if args.create_env {
+            bail!("Tried to login to create a Shuttle environment, but no API key was set.")
         }
 
         // 2. Ask for project name

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -303,8 +303,12 @@ impl Shuttle {
         // Turns the template or git args (if present) to a repo+folder.
         let git_templates = args.git_template()?;
 
-        let interactive =
-            project_args.name.is_none() || git_templates.is_none() || !provided_path_to_init;
+        let unauthorized = self.ctx.api_key().is_err() && args.login_args.api_key.is_none();
+
+        let interactive = project_args.name.is_none()
+            || git_templates.is_none()
+            || !provided_path_to_init
+            || unauthorized;
 
         let theme = ColorfulTheme::default();
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -309,7 +309,13 @@ impl Shuttle {
         let theme = ColorfulTheme::default();
 
         // 1. Log in (if not logged in yet)
-        if self.ctx.api_key().is_err() {
+        if let Ok(api_key) = self.ctx.api_key() {
+            let login_args = LoginArgs {
+                api_key: Some(api_key.as_ref().to_string()),
+            };
+
+            self.login(login_args).await?;
+        } else {
             if interactive {
                 println!("First, let's log in to your Shuttle account.");
                 self.login(args.login_args.clone()).await?;


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

`cargo-shuttle` init was not authorizing the client in the event that the api-key was already set in the config. It was also the case that if passing certain args, the interactive flow was disabled, which meant if the user wasn't logged in and didn't pass --api-key in the command, they would get an error about trying to login but failing. I fixed that too, but it does mean the path prompt will be interactive even if given. The init logic is quite complicated, so I'm very open to suggestions here.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested running `cargo run -p cargo-shuttle -- --wd ./  init --from https://github.com/shuttle-hq/eurorust-demo --name unique-name --create-env
 ./unique-name` when logged in with config file, with --api-key, and neither.
