### PR TITLE
fix(resources/shared-db): retry initial connection a few times

### DIFF
--- a/cargo-shuttle/src/provisioner_server.rs
+++ b/cargo-shuttle/src/provisioner_server.rs
@@ -155,6 +155,12 @@ impl LocalProvisioner {
                 .expect("failed to start none running container");
         }
 
+        self.wait_for_ready(&container_name, is_ready_cmd.clone())
+            .await?;
+
+        // The container enters the ready state, runs an init script and then reboots, so we sleep
+        // a little and then check if it's ready again afterwards.
+        sleep(Duration::from_millis(450)).await;
         self.wait_for_ready(&container_name, is_ready_cmd).await?;
 
         let res = DatabaseResponse {


### PR DESCRIPTION
## Description of change

Fixes a bug where running a project with the shared DB for the first time could result in a failure to connect, which could be fixed simply by running it again.

The connection attempt is made too quickly (some would say it's blazingly fast) and the Postgres database doesn't have the time to start accepting connection. A simple wait is enough.

## How has this been tested? (if applicable)

 With the Eurorust demo, 2nd step, and simply doing `cargo shuttle run`. I'm using Podman, and I can consistently hit the bug simply by removing the running PSQL container and trying again.


