### PR TITLE
feat(cargo-shuttle): raw table output, fix table column alignment

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -119,7 +119,11 @@ pub enum Command {
     #[command(subcommand)]
     Resource(ResourceCommand),
     /// Manage secrets for this Shuttle service
-    Secrets,
+    Secrets {
+        #[arg(long, default_value_t = false)]
+        /// Output table in `raw` format
+        raw: bool,
+    },
     /// Remove cargo build artifacts in the Shuttle environment
     Clean,
     /// Login to the Shuttle platform
@@ -150,6 +154,10 @@ pub enum DeploymentCommand {
         #[arg(long, default_value = "10")]
         /// How many projects per page to display
         limit: u32,
+
+        #[arg(long, default_value_t = false)]
+        /// Output table in `raw` format
+        raw: bool,
     },
     /// View status of a deployment
     Status {
@@ -161,7 +169,11 @@ pub enum DeploymentCommand {
 #[derive(Parser)]
 pub enum ResourceCommand {
     /// List all the resources for a project
-    List,
+    List {
+        #[arg(long, default_value_t = false)]
+        /// Output table in `raw` format
+        raw: bool,
+    },
     /// Delete a resource
     Delete {
         /// Type of the resource to delete.
@@ -194,6 +206,10 @@ pub enum ProjectCommand {
         #[arg(long, default_value = "10")]
         /// How many projects per page to display
         limit: u32,
+
+        #[arg(long, default_value_t = false)]
+        /// Output table in `raw` format
+        raw: bool,
     },
     /// Delete project. This also deletes associated Secrets and Persist data.
     Delete,

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -1,12 +1,16 @@
 #[cfg(feature = "openapi")]
 use crate::ulid_type;
 use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, CellAlignment, Color,
-    ContentArrangement, Table,
+    modifiers::UTF8_ROUND_CORNERS,
+    presets::{NOTHING, UTF8_FULL},
+    Attribute, Cell, CellAlignment, Color, ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
-use std::fmt::{Display, Formatter};
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 use strum::EnumString;
 
 #[cfg(feature = "openapi")]
@@ -78,7 +82,15 @@ impl Eq for State {}
 
 impl Display for Response {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, r#"Project "{}" is {}"#, self.name, self.state)
+        write!(
+            f,
+            r#"Project "{}" is {}"#,
+            self.name,
+            self.state
+                .to_string()
+                // Unwrap is safe because Color::from_str returns the color white if the argument is not a Color.
+                .with(crossterm::style::Color::from_str(self.state.get_color()).unwrap())
+        )
     }
 }
 
@@ -87,93 +99,80 @@ impl Display for State {
         match self {
             State::Creating { recreate_count } => {
                 if *recreate_count > 0 {
-                    write!(
-                        f,
-                        "{} (attempt {})",
-                        "creating".dark_yellow(),
-                        recreate_count
-                    )
+                    write!(f, "creating (attempt {})", recreate_count)
                 } else {
-                    write!(f, "{}", "creating".cyan())
+                    write!(f, "creating")
                 }
             }
             State::Attaching { recreate_count } => {
                 if *recreate_count > 0 {
-                    write!(
-                        f,
-                        "{} (attempt {})",
-                        "attaching".dark_yellow(),
-                        recreate_count
-                    )
+                    write!(f, "attaching (attempt {})", recreate_count)
                 } else {
-                    write!(f, "{}", "attaching".cyan())
+                    write!(f, "attaching")
                 }
             }
             State::Recreating { recreate_count } => {
                 if *recreate_count > 0 {
-                    write!(
-                        f,
-                        "{} (attempt {})",
-                        "recreating".dark_yellow(),
-                        recreate_count
-                    )
+                    write!(f, "recreating (attempt {})", recreate_count)
                 } else {
-                    write!(f, "{}", "recreating".dark_yellow())
+                    write!(f, "recreating")
                 }
             }
             State::Starting { restart_count } => {
                 if *restart_count > 0 {
-                    write!(
-                        f,
-                        "{} (attempt {})",
-                        "starting".dark_yellow(),
-                        restart_count
-                    )
+                    write!(f, "starting (attempt {})", restart_count)
                 } else {
-                    write!(f, "{}", "starting".cyan())
+                    write!(f, "starting")
                 }
             }
             State::Restarting { restart_count } => {
                 if *restart_count > 0 {
-                    write!(
-                        f,
-                        "{} (attempt {})",
-                        "restarting".dark_yellow(),
-                        restart_count
-                    )
+                    write!(f, "restarting (attempt {})", restart_count)
                 } else {
-                    write!(f, "{}", "restarting".dark_yellow())
+                    write!(f, "restarting")
                 }
             }
-            State::Started => write!(f, "{}", "started".cyan()),
-            State::Ready => write!(f, "{}", "ready".green()),
-            State::Stopping => write!(f, "{}", "stopping".blue()),
-            State::Stopped => write!(f, "{}", "stopped".blue()),
-            State::Rebooting => write!(f, "{}", "rebooting".dark_yellow()),
-            State::Destroying => write!(f, "{}", "destroying".blue()),
-            State::Destroyed => write!(f, "{}", "destroyed".blue()),
+            State::Started => write!(f, "started"),
+            State::Ready => write!(f, "ready"),
+            State::Stopping => write!(f, "stopping"),
+            State::Stopped => write!(f, "stopped"),
+            State::Rebooting => write!(f, "rebooting"),
+            State::Destroying => write!(f, "destroying"),
+            State::Destroyed => write!(f, "destroyed"),
             State::Errored { message } => {
-                writeln!(f, "{}", "errored".red())?;
-                write!(f, "\tmessage: {message}")
+                write!(f, "errored\n\tmessage: {message}")
             }
-            State::Deleted => write!(f, "{}", "deleted".red()),
+            State::Deleted => write!(f, "deleted"),
         }
     }
 }
 
 impl State {
-    pub fn get_color(&self) -> Color {
+    /// We return a &str rather than a Color here, since `comfy-table` re-exports
+    /// crossterm::style::Color and we depend on both `comfy-table` and `crossterm`
+    /// we may end up with two different versions of Color.
+    pub fn get_color(&self) -> &str {
         match self {
+            Self::Creating { recreate_count }
+            | Self::Attaching { recreate_count }
+            | Self::Recreating { recreate_count }
+                if recreate_count > &0usize =>
+            {
+                "dark_yellow"
+            }
+            Self::Starting { restart_count } | Self::Restarting { restart_count }
+                if restart_count > &0usize =>
+            {
+                "dark_yellow"
+            }
             Self::Creating { .. }
             | Self::Attaching { .. }
-            | Self::Recreating { .. }
             | Self::Starting { .. }
-            | Self::Restarting { .. }
-            | Self::Started
-            | Self::Rebooting => Color::Cyan,
-            Self::Ready => Color::Green,
-            Self::Stopped | Self::Stopping | Self::Destroying | Self::Destroyed => Color::Blue,
-            Self::Errored { .. } | Self::Deleted => Color::Red,
+            | Self::Started => "cyan",
+            Self::Recreating { .. } | Self::Restarting { .. } | Self::Rebooting => "dark_yellow",
+            Self::Ready => "green",
+            Self::Stopped | Self::Stopping | Self::Destroying | Self::Destroyed => "blue",
+            Self::Errored { .. } | Self::Deleted => "red",
         }
     }
 }
@@ -192,48 +191,61 @@ pub struct AdminResponse {
     pub account_name: String,
 }
 
-pub fn get_table(projects: &Vec<Response>, page: u32) -> String {
+pub fn get_projects_table(projects: &Vec<Response>, page: u32, raw: bool) -> String {
     if projects.is_empty() {
         // The page starts at 1 in the CLI.
-        if page <= 1 {
-            format!(
-                "{}\n",
-                "No projects are linked to this account".yellow().bold()
-            )
+        let mut s = if page <= 1 {
+            "No projects are linked to this account\n".to_string()
         } else {
-            format!(
-                "{}\n",
-                "No more projects linked to this account".yellow().bold()
-            )
+            "No more projects are linked to this account\n".to_string()
+        };
+        if !raw {
+            s = s.yellow().bold().to_string();
         }
+
+        s
     } else {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .apply_modifier(UTF8_ROUND_CORNERS)
-            .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-            .set_header(vec![
-                Cell::new("Project Name").set_alignment(CellAlignment::Center),
-                Cell::new("Status").set_alignment(CellAlignment::Center),
-            ]);
+
+        if raw {
+            table
+                .load_preset(NOTHING)
+                .set_content_arrangement(ContentArrangement::Disabled)
+                .set_header(vec![
+                    Cell::new("Project Name").set_alignment(CellAlignment::Left),
+                    Cell::new("Status").set_alignment(CellAlignment::Left),
+                ]);
+        } else {
+            table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS)
+                .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+                .set_header(vec![
+                    Cell::new("Project Name")
+                        .set_alignment(CellAlignment::Center)
+                        .add_attribute(Attribute::Bold),
+                    Cell::new("Status")
+                        .set_alignment(CellAlignment::Center)
+                        .add_attribute(Attribute::Bold),
+                ]);
+        }
 
         for project in projects.iter() {
-            table.add_row(vec![
-                Cell::new(&project.name),
-                Cell::new(&project.state)
-                    .fg(project.state.get_color())
-                    .set_alignment(CellAlignment::Center),
-            ]);
+            if raw {
+                table.add_row(vec![Cell::new(&project.name), Cell::new(&project.state)]);
+            } else {
+                table.add_row(vec![
+                    Cell::new(&project.name),
+                    Cell::new(&project.state)
+                        // Unwrap is safe because Color::from_str returns the color white if the argument is not a Color.
+                        .fg(Color::from_str(project.state.get_color()).unwrap())
+                        .set_alignment(CellAlignment::Center),
+                ]);
+            }
         }
 
         format!(
-            r#"
-These projects are linked to this account
-{table}
-
-{}
-"#,
-            "More projects might be available on the next page using --page.".bold()
+            "\nThese projects are linked to this account\n{table}\nMore projects might be available on the next page using --page.\n"
         )
     }
 }

--- a/common/src/models/secret.rs
+++ b/common/src/models/secret.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, CellAlignment,
-    ContentArrangement, Table,
+    modifiers::UTF8_ROUND_CORNERS,
+    presets::{NOTHING, UTF8_FULL},
+    Attribute, Cell, CellAlignment, ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
@@ -17,23 +18,38 @@ pub struct Response {
     pub last_update: DateTime<Utc>,
 }
 
-pub fn get_table(secrets: &Vec<Response>) -> String {
+pub fn get_secrets_table(secrets: &Vec<Response>, raw: bool) -> String {
     if secrets.is_empty() {
-        format!("{}\n", "No secrets are linked to this service".bold())
+        if raw {
+            "No secrets are linked to this service\n".to_string()
+        } else {
+            format!("{}\n", "No secrets are linked to this service".bold())
+        }
     } else {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .apply_modifier(UTF8_ROUND_CORNERS)
-            .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-            .set_header(vec![
-                Cell::new("Key")
-                    .set_alignment(CellAlignment::Center)
-                    .add_attribute(Attribute::Bold),
-                Cell::new("Last updated")
-                    .set_alignment(CellAlignment::Center)
-                    .add_attribute(Attribute::Bold),
-            ]);
+
+        if raw {
+            table
+                .load_preset(NOTHING)
+                .set_content_arrangement(ContentArrangement::Disabled)
+                .set_header(vec![
+                    Cell::new("Key").set_alignment(CellAlignment::Left),
+                    Cell::new("Last updated").set_alignment(CellAlignment::Left),
+                ]);
+        } else {
+            table
+                .load_preset(UTF8_FULL)
+                .apply_modifier(UTF8_ROUND_CORNERS)
+                .set_content_arrangement(ContentArrangement::DynamicFullWidth)
+                .set_header(vec![
+                    Cell::new("Key")
+                        .set_alignment(CellAlignment::Center)
+                        .add_attribute(Attribute::Bold),
+                    Cell::new("Last updated")
+                        .set_alignment(CellAlignment::Center)
+                        .add_attribute(Attribute::Bold),
+                ]);
+        }
 
         for resource in secrets.iter() {
             table.add_row(vec![
@@ -45,10 +61,6 @@ pub fn get_table(secrets: &Vec<Response>) -> String {
             ]);
         }
 
-        format!(
-            r#"These secrets are linked to this service
-{table}
-"#,
-        )
+        format!("These secrets are linked to this service\n{table}\n")
     }
 }


### PR DESCRIPTION
## Description of change

- Closes #1315 by adding `--raw` flag to `deployment list` and `project list` commands, as well as `resource list` and `secrets`
- Closes #962 by removing colouring from `impl Display` for `Project::State`
- Functions `get_table` in two locations renamed to `get_projects_table`/`get_secrets_table` to match naming of `get_deployments_table`
- New `raw` table format ignores terminal width and has no borders
- Project state returns `&str` like Deployment state, `impl Display` for state has no styling, styling done at call site when appropriate
- Commands `--raw` flag do not output styled messages when flag is used

## How has this been tested? (if applicable)

The following commands were run, inspecting the output manually: (nano is a project I have running)

- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs deployment list --name nano`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs deployment list --name nano --raw`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs project list`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs project list --raw`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs resource list --name nano`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs resource list --name nano --raw`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs secrets --name nano`
- `cargo run --bin cargo-shuttle -- --api-url https://api.shuttle.rs secrets --name nano --raw`