### PR TITLE
feat(cargo-shuttle): adaptive page hints

### DIFF
--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -176,7 +176,7 @@ impl Client {
         self.get(path).await
     }
 
-    pub async fn get_projects_list(&self, page: u32, limit: u32) -> Result<Vec<project::Response>> {
+    pub async fn get_projects_list(&self, page: u32, limit: u32) -> Result<project::Page> {
         let path = format!("/projects?page={}&limit={}", page.saturating_sub(1), limit);
 
         self.get(path).await
@@ -233,7 +233,7 @@ impl Client {
         project: &ProjectName,
         page: u32,
         limit: u32,
-    ) -> Result<Vec<deployment::Response>> {
+    ) -> Result<deployment::Page> {
         let path = format!(
             "/projects/{}/deployments?page={}&limit={}",
             project.as_str(),

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -730,7 +730,7 @@ impl Shuttle {
             .get_deployments(proj_name, page, limit)
             .await
             .map_err(suggestions::deployment::get_deployments_list_failure)?;
-        let table = get_deployments_table(&deployments, proj_name.as_str(), page);
+        let table = get_deployments_table(&deployments, proj_name.as_str(), page, limit);
 
         println!("{table}");
         println!("Run `cargo shuttle logs <id>` to get logs for a given deployment.");
@@ -1671,7 +1671,7 @@ impl Shuttle {
                 "getting the projects list fails repeteadly",
             )
         })?;
-        let projects_table = project::get_table(&projects, page);
+        let projects_table = project::get_table(&projects, page, limit);
 
         println!("{projects_table}");
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -671,7 +671,7 @@ impl Shuttle {
                             "Fetching the latest deployment failed",
                         )
                     })?;
-                let most_recent = deployments.first().context(format!(
+                let most_recent = deployments.data.first().context(format!(
                     "Could not find any deployments for '{proj_name}'. Try passing a deployment ID manually",
                 ))?;
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -24,7 +24,7 @@ const GIT_OPTION_NONE_TEXT: &str = "N/A";
 #[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::deployment::Page))]
 pub struct Page {
     pub data: Vec<Response>,
-    pub has_next_page: bool,
+    pub count: u32,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -75,7 +75,7 @@ impl State {
     }
 }
 
-pub fn get_deployments_table(page: &Page, service_name: &str, page_num: u32) -> String {
+pub fn get_deployments_table(page: &Page, service_name: &str, page_num: u32, limit: u32) -> String {
     if page.data.is_empty() {
         if page_num <= 1 {
             format!(
@@ -165,7 +165,7 @@ pub fn get_deployments_table(page: &Page, service_name: &str, page_num: u32) -> 
             table
         );
 
-        if page.has_next_page {
+        if page.count > page_num * limit {
             format!(
                 "{formatted_table}{notice}",
                 notice = "More deployments available on the next page using --page.".bold()

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -25,7 +25,7 @@ pub const fn default_idle_minutes() -> u64 {
 #[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::project::Page))]
 pub struct Page {
     pub data: Vec<Response>,
-    pub has_next_page: bool,
+    pub count: u32,
 }
 
 #[derive(Deserialize, Serialize, Clone)]
@@ -198,7 +198,7 @@ pub struct AdminResponse {
     pub account_name: String,
 }
 
-pub fn get_table(page: &Page, page_num: u32) -> String {
+pub fn get_table(page: &Page, page_num: u32, limit: u32) -> String {
     if page.data.is_empty() {
         // The page starts at 1 in the CLI.
         if page_num <= 1 {
@@ -233,7 +233,7 @@ pub fn get_table(page: &Page, page_num: u32) -> String {
         }
 
         let formatted_table = format!("These projects are linked to this account\n{table}");
-        if page.has_next_page {
+        if page.count > page_num * limit {
             format!(
                 "{formatted_table}\n\n{notice}",
                 notice = "More projects available on the next page using --page.".bold()

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -533,7 +533,6 @@ pub async fn get_deployments(
     if let Some(service) = persistence.get_service_by_name(&project_name).await? {
         let limit = limit.unwrap_or(u32::MAX);
         let page = page.unwrap_or(0);
-        tracing::info!("test l = {} p = {}", limit, page);
         let deployments = persistence
             .get_deployments(&service.id, page * limit, limit)
             .await?;

--- a/deployer/src/persistence/deployment.rs
+++ b/deployer/src/persistence/deployment.rs
@@ -23,6 +23,7 @@ pub struct Deployment {
     pub git_commit_msg: Option<String>,
     pub git_branch: Option<String>,
     pub git_dirty: Option<bool>,
+    pub count: Option<u32>,
 }
 
 impl FromRow<'_, SqliteRow> for Deployment {
@@ -51,6 +52,7 @@ impl FromRow<'_, SqliteRow> for Deployment {
             git_commit_msg: row.try_get("git_commit_msg")?,
             git_branch: row.try_get("git_branch")?,
             git_dirty: row.try_get("git_dirty")?,
+            count: row.try_get("cnt").ok(),
         })
     }
 }

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -248,10 +248,14 @@ impl Persistence {
         offset: u32,
         limit: u32,
     ) -> Result<Vec<Deployment>> {
-        let mut query = QueryBuilder::new("SELECT * FROM deployments WHERE service_id = ");
+        let mut query =
+            QueryBuilder::new("SELECT *, (SELECT COUNT(*) FROM deployments WHERE service_id = ");
 
+        let service_id = service_id.to_string();
         query
-            .push_bind(service_id.to_string())
+            .push_bind(&service_id)
+            .push(") as cnt FROM deployments WHERE service_id = ")
+            .push_bind(&service_id)
             .push(" ORDER BY last_update DESC LIMIT ")
             .push_bind(limit);
 
@@ -766,6 +770,7 @@ mod tests {
                 git_commit_msg: None,
                 git_branch: None,
                 git_dirty: None,
+                count: None,
             })
             .collect();
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -334,12 +334,14 @@ impl GatewayService {
         account_name: &AccountName,
         offset: u32,
         limit: u32,
-    ) -> Result<impl Iterator<Item = (String, ProjectName, Project)>, Error> {
+    ) -> Result<impl Iterator<Item = (String, ProjectName, Project, u32)>, Error> {
         let mut query = QueryBuilder::new(
-            "SELECT project_id, project_name, project_state FROM projects WHERE account_name = ",
+            "SELECT project_id, project_name, project_state, (SELECT COUNT(*) FROM projects WHERE account_name = ",
         );
 
         query
+            .push_bind(account_name)
+            .push(") as cnt FROM projects WHERE account_name = ")
             .push_bind(account_name)
             .push(" ORDER BY project_id DESC, project_name LIMIT ")
             .push_bind(limit);
@@ -366,6 +368,7 @@ impl GatewayService {
                                 "Error when trying to deserialize state of project.",
                             ))
                         }),
+                    row.get("cnt"),
                 )
             });
         Ok(iter)


### PR DESCRIPTION
## Description of change
Changed the project and deployment list endpoints to return a `Page` struct that contains the original Vec of data, but also a `has_next_page` variable to indicate to the client whether there is another page that can be fetched. This value is determined by simply extending the `limit` by 1 and checking if the number of returned values matches that increased limit, this means we do not have to use a `COUNT` query or even any other queries at all. However, to ensure we return the proper number of values to the client we call `pop` on the Vec so that the extra value we requested is removed. There are a couple other small changes but they are all more self-explanatory than what I discussed.

Closes #1316 



## How has this been tested? (if applicable)
Only tested on a local setup, should be fine as there are no breaking changes besides the data returned from the 2 relevant endpoints, however those endpoints seem to only be used by the 2 relevant commands so that should not be an issue.


