### PR TITLE
feat(cargo-shuttle): support configuration from Cargo.toml

### DIFF
--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -43,7 +43,7 @@ impl BuiltService {
                 debug!(?error, "failed to get service name from Shuttle.toml");
 
                 // Try getting it from {package,workspace}.metadata.shuttle from Cargo.toml
-                if let Some(name) = extract_name_from_crate_metadata(&crate_directory)? {
+                if let Some(name) = extract_name_from_crate_metadata(crate_directory)? {
                     return Ok(ProjectName::from_str(&name)?);
                 }
 


### PR DESCRIPTION
## Description of change

This PR makes it possible to configure the project/service name from [metadata table](https://doc.rust-lang.org/cargo/reference/manifest.html#the-metadata-table) without the need of `Shuttle.toml`. For example:

```toml
[package]
name = "hello-world"
version = "0.1.0"
edition = "2021"

[dependencies]
axum = "0.6.20"
shuttle-axum = "0.29.0"
shuttle-runtime = "0.29.0"
tokio = "1.28.2"

[package.metadata.shuttle]
name = "hello-world-shuttle-app"
```

## How has this been tested? (if applicable)

Tested locally.

Checklist:

- [ ] Add unit tests (not sure how yet, let me know if you any idea)
- [ ] Update examples
- [ ] Update documentation
