### PR TITLE
improvement: unpin libsql-client, bump to v0.32.0

### DIFF
--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "turso"]
 [dependencies]
 async-trait = "0.1.56"
 dunce = "1.0.4"
-libsql-client = { version = "=0.30.1" }
+libsql-client = { version = "0.32.0" }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.29.0", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Unpinned the libsql-client in the Shuttle Turso crate and bumped it to version 0.32.0, per issue #1324 

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Ran unit tests from within the Shuttle Turso crate, tests were all green.
