### PR TITLE
refactor(runtime): hide internals from public-facing API, export tokio

### DIFF
--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -232,7 +232,7 @@ impl ToTokens for Loader {
             None
         } else {
             Some(parse_quote!(
-                use ::shuttle_runtime::__internals::{Factory, ResourceBuilder};
+                use ::shuttle_runtime::{Factory, ResourceBuilder};
             ))
         };
 
@@ -399,7 +399,7 @@ mod tests {
                 mut resource_tracker: ::shuttle_runtime::__internals::ResourceTracker,
             ) -> ShuttleComplex {
                 use ::shuttle_runtime::__internals::Context;
-                use ::shuttle_runtime::__internals::{Factory, ResourceBuilder};
+                use ::shuttle_runtime::{Factory, ResourceBuilder};
                 let pool = ::shuttle_runtime::__internals::get_resource(
                     shuttle_shared_db::Postgres::new(),
                     &mut factory,
@@ -510,7 +510,7 @@ mod tests {
                 mut resource_tracker: ::shuttle_runtime::__internals::ResourceTracker,
             ) -> ShuttleComplex {
                 use ::shuttle_runtime::__internals::Context;
-                use ::shuttle_runtime::__internals::{Factory, ResourceBuilder};
+                use ::shuttle_runtime::{Factory, ResourceBuilder};
                 let vars = std::collections::HashMap::from_iter(factory.get_secrets().await?.into_iter().map(|(key, value)| (format!("secrets.{}", key), value)));
                 let pool = ::shuttle_runtime::__internals::get_resource (
                     shuttle_shared_db::Postgres::new().size(&::shuttle_runtime::__internals::strfmt("10Gb", &vars)?).public(false),

--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -15,12 +15,14 @@ pub(crate) fn r#impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
     quote! {
         fn main() {
-            use ::shuttle_runtime::tokio;
-            #[tokio::main]
-            async fn main() {
-                ::shuttle_runtime::__internals::start(loader).await;
-            }
-            main()
+            // manual expansion of #[tokio::main]
+            ::shuttle_runtime::tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    ::shuttle_runtime::__internals::start(loader).await;
+                })
         }
 
         #loader

--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -14,9 +14,9 @@ pub(crate) fn r#impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let loader = Loader::from_item_fn(&mut fn_decl);
 
     quote! {
-        #[tokio::main]
+        #[shuttle_runtime::tokio::main]
         async fn main() {
-            shuttle_runtime::start(loader).await;
+            shuttle_runtime::__internals::start(loader).await;
         }
 
         #loader
@@ -200,7 +200,7 @@ impl ToTokens for Loader {
                             lit: Lit::Str(str), ..
                         }) => {
                             needs_vars = true;
-                            quote!(&shuttle_runtime::strfmt(#str, &vars)?)
+                            quote!(&shuttle_runtime::__internals::strfmt(#str, &vars)?)
                         }
                         other => quote!(#other),
                     };
@@ -228,7 +228,7 @@ impl ToTokens for Loader {
             None
         } else {
             Some(parse_quote!(
-                use shuttle_runtime::{Factory, ResourceBuilder};
+                use shuttle_runtime::__internals::{Factory, ResourceBuilder};
             ))
         };
 
@@ -254,13 +254,13 @@ impl ToTokens for Loader {
 
         let loader = quote! {
             async fn loader(
-                mut #factory_ident: shuttle_runtime::ProvisionerFactory,
-                mut #resource_tracker_ident: shuttle_runtime::ResourceTracker,
+                mut #factory_ident: shuttle_runtime::__internals::ProvisionerFactory,
+                mut #resource_tracker_ident: shuttle_runtime::__internals::ResourceTracker,
             ) -> #return_type {
-                use shuttle_runtime::Context;
+                use shuttle_runtime::__internals::Context;
                 #extra_imports
                 #vars
-                #(let #fn_inputs = shuttle_runtime::get_resource(
+                #(let #fn_inputs = shuttle_runtime::__internals::get_resource(
                     #fn_inputs_builder::new()#fn_inputs_builder_options,
                     &mut #factory_ident,
                     &mut #resource_tracker_ident,
@@ -323,10 +323,10 @@ mod tests {
         let actual = quote!(#input);
         let expected = quote! {
             async fn loader(
-                mut _factory: shuttle_runtime::ProvisionerFactory,
-                mut _resource_tracker: shuttle_runtime::ResourceTracker,
+                mut _factory: shuttle_runtime::__internals::ProvisionerFactory,
+                mut _resource_tracker: shuttle_runtime::__internals::ResourceTracker,
             ) -> ShuttleSimple {
-                use shuttle_runtime::Context;
+                use shuttle_runtime::__internals::Context;
                 simple().await
             }
         };
@@ -391,17 +391,17 @@ mod tests {
         let actual = quote!(#input);
         let expected = quote! {
             async fn loader(
-                mut factory: shuttle_runtime::ProvisionerFactory,
-                mut resource_tracker: shuttle_runtime::ResourceTracker,
+                mut factory: shuttle_runtime::__internals::ProvisionerFactory,
+                mut resource_tracker: shuttle_runtime::__internals::ResourceTracker,
             ) -> ShuttleComplex {
-                use shuttle_runtime::Context;
-                use shuttle_runtime::{Factory, ResourceBuilder};
-                let pool = shuttle_runtime::get_resource(
+                use shuttle_runtime::__internals::Context;
+                use shuttle_runtime::__internals::{Factory, ResourceBuilder};
+                let pool = shuttle_runtime::__internals::get_resource(
                     shuttle_shared_db::Postgres::new(),
                     &mut factory,
                     &mut resource_tracker,
                 ).await.context(format!("failed to provision {}", stringify!(shuttle_shared_db::Postgres)))?;
-                let redis = shuttle_runtime::get_resource(
+                let redis = shuttle_runtime::__internals::get_resource(
                     shuttle_shared_db::Redis::new(),
                     &mut factory,
                     &mut resource_tracker,
@@ -502,14 +502,14 @@ mod tests {
         let actual = quote!(#input);
         let expected = quote! {
             async fn loader(
-                mut factory: shuttle_runtime::ProvisionerFactory,
-                mut resource_tracker: shuttle_runtime::ResourceTracker,
+                mut factory: shuttle_runtime::__internals::ProvisionerFactory,
+                mut resource_tracker: shuttle_runtime::__internals::ResourceTracker,
             ) -> ShuttleComplex {
-                use shuttle_runtime::Context;
-                use shuttle_runtime::{Factory, ResourceBuilder};
+                use shuttle_runtime::__internals::Context;
+                use shuttle_runtime::__internals::{Factory, ResourceBuilder};
                 let vars = std::collections::HashMap::from_iter(factory.get_secrets().await?.into_iter().map(|(key, value)| (format!("secrets.{}", key), value)));
-                let pool = shuttle_runtime::get_resource (
-                    shuttle_shared_db::Postgres::new().size(&shuttle_runtime::strfmt("10Gb", &vars)?).public(false),
+                let pool = shuttle_runtime::__internals::get_resource (
+                    shuttle_shared_db::Postgres::new().size(&shuttle_runtime::__internals::strfmt("10Gb", &vars)?).public(false),
                     &mut factory,
                     &mut resource_tracker,
                 ).await.context(format!("failed to provision {}", stringify!(shuttle_shared_db::Postgres)))?;

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -39,7 +39,7 @@ use tonic::{
 };
 use tower::ServiceBuilder;
 
-use crate::{print_version, provisioner_factory::ProvisionerFactory, ResourceTracker};
+use crate::__internals::{print_version, ProvisionerFactory, ResourceTracker};
 
 use self::args::Args;
 

--- a/runtime/src/bin/shuttle-next.rs
+++ b/runtime/src/bin/shuttle-next.rs
@@ -5,7 +5,7 @@ use std::{
 
 use shuttle_common::backends::tracing::ExtractPropagationLayer;
 use shuttle_proto::runtime::runtime_server::RuntimeServer;
-use shuttle_runtime::{print_version, AxumWasm, NextArgs};
+use shuttle_runtime::__internals::{print_version, AxumWasm, NextArgs};
 use tonic::transport::Server;
 
 #[tokio::main(flavor = "multi_thread")]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,10 +27,10 @@
 //! be a binary crate with a few dependencies including `shuttle-runtime` and `shuttle-axum`.
 //!
 //! ```toml
-//! shuttle-runtime = "0.30.0"
-//! axum = "0.6.10"
+//! axum = "0.6.20"
 //! shuttle-axum = "0.30.0"
-//! tokio = "1.26"
+//! shuttle-runtime = "0.30.0"
+//! tokio = "1.28.2"
 //! ```
 //!
 //! A boilerplate code for your axum project can also be found in `src/main.rs`:

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -43,8 +43,8 @@
 //! }
 //!
 //! #[shuttle_runtime::main]
-//! async fn axum() -> shuttle_axum::ShuttleAxum {
-//!     let router = Router::new().route("/hello", get(hello_world));
+//! async fn main() -> shuttle_axum::ShuttleAxum {
+//!     let router = Router::new().route("/", get(hello_world));
 //!
 //!     Ok(router.into())
 //! }
@@ -63,8 +63,7 @@
 //! You should see your app build and start on the default port 8000. You can test this using;
 //!
 //! ```bash
-//! $ curl http://localhost:8000/hello
-//!
+//! $ curl http://localhost:8000/
 //! Hello, world!
 //! ```
 //!
@@ -96,7 +95,7 @@
 //! Your service will immediately be available at `{crate_name}.shuttleapp.rs`. For example:
 //!
 //! ```bash
-//! $ curl https://my-axum-app.shuttleapp.rs/hello
+//! $ curl https://my-axum-app.shuttleapp.rs/
 //! Hello, world!
 //! ```
 //!
@@ -129,7 +128,7 @@
 //!
 //! struct MyState(PgPool);
 //!
-//! #[get("/hello")]
+//! #[get("/")]
 //! fn hello(state: &State<MyState>) -> &'static str {
 //!     // Do things with `state.0`...
 //!     "Hello, Postgres!"
@@ -203,9 +202,14 @@
 //! If you have any questions, [join our Discord server](https://discord.gg/shuttle). There's always someone on there that can help!
 //!
 //! You can also [open an issue or a discussion on GitHub](https://github.com/shuttle-hq/shuttle).
-//!
 
+// Public API
 pub use shuttle_codegen::main;
+pub use shuttle_service::{CustomError, Error, Factory, ResourceBuilder, Service};
+
+// Useful re-exports
+pub use async_trait::async_trait;
+pub use tokio;
 
 mod alpha;
 mod args;
@@ -214,26 +218,29 @@ mod next;
 mod provisioner_factory;
 mod resource_tracker;
 
-pub use alpha::{start, Alpha};
-#[cfg(feature = "next")]
-pub use next::{AxumWasm, NextArgs};
-pub use provisioner_factory::ProvisionerFactory;
-pub use resource_tracker::{get_resource, ResourceTracker};
-pub use shuttle_service::{CustomError, Error, Factory, ResourceBuilder, Service};
-
-pub use async_trait::async_trait;
-
-// Dependencies required by the codegen
-pub use anyhow::Context;
-pub use strfmt::strfmt;
-
-#[cfg(feature = "setup-tracing")]
-pub use {colored, tracing_subscriber};
-
 const NAME: &str = env!("CARGO_PKG_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-// Print the version of the runtime.
-pub fn print_version() {
-    println!("{NAME} {VERSION}");
+// Not part of public API
+#[doc(hidden)]
+pub mod __internals {
+    // Internals used by the codegen
+    pub use crate::alpha::{start, Alpha};
+    #[cfg(feature = "next")]
+    pub use crate::next::{AxumWasm, NextArgs};
+    pub use crate::provisioner_factory::ProvisionerFactory;
+    pub use crate::resource_tracker::{get_resource, ResourceTracker};
+
+    // Dependencies required by the codegen
+    pub use anyhow::Context;
+    #[cfg(feature = "setup-tracing")]
+    pub use colored;
+    pub use strfmt::strfmt;
+    #[cfg(feature = "setup-tracing")]
+    pub use tracing_subscriber;
+
+    // Print the version of the runtime.
+    pub fn print_version() {
+        println!("{} {}", crate::NAME, crate::VERSION);
+    }
 }

--- a/runtime/src/resource_tracker.rs
+++ b/runtime/src/resource_tracker.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use shuttle_common::resource::{self, Type};
 use shuttle_service::ResourceBuilder;
 
-use crate::ProvisionerFactory;
+use crate::__internals::ProvisionerFactory;
 
 /// Used to keep track of which resources have been provisioned in the past and what is being provisioned for this deployment
 pub struct ResourceTracker {

--- a/services/shuttle-poise/src/lib.rs
+++ b/services/shuttle-poise/src/lib.rs
@@ -1,7 +1,6 @@
 //! Shuttle service integration for the Poise discord bot framework.
 //! ## Example
 //! ```rust,no_run
-//! use anyhow::Context as _;
 //! use poise::serenity_prelude as serenity;
 //! use shuttle_secrets::SecretStore;
 //! use shuttle_poise::ShuttlePoise;
@@ -22,7 +21,7 @@
 //!     // Get the discord token set in `Secrets.toml`
 //!     let discord_token = secret_store
 //!         .get("DISCORD_TOKEN")
-//!         .context("'DISCORD_TOKEN' was not found")?;
+//!         .expect("'DISCORD_TOKEN' was not found");
 //!
 //!     let framework = poise::Framework::builder()
 //!         .options(poise::FrameworkOptions {

--- a/services/shuttle-poise/src/lib.rs
+++ b/services/shuttle-poise/src/lib.rs
@@ -1,7 +1,6 @@
 //! Shuttle service integration for the Poise discord bot framework.
 //! ## Example
 //! ```rust,no_run
-//! use shuttle_runtime::Context as _;
 //! use poise::serenity_prelude as serenity;
 //! use shuttle_secrets::SecretStore;
 //! use shuttle_poise::ShuttlePoise;
@@ -22,7 +21,7 @@
 //!     // Get the discord token set in `Secrets.toml`
 //!     let discord_token = secret_store
 //!         .get("DISCORD_TOKEN")
-//!         .context("'DISCORD_TOKEN' was not found")?;
+//!         .expect("'DISCORD_TOKEN' was not found");
 //!
 //!     let framework = poise::Framework::builder()
 //!         .options(poise::FrameworkOptions {

--- a/services/shuttle-poise/src/lib.rs
+++ b/services/shuttle-poise/src/lib.rs
@@ -1,6 +1,7 @@
 //! Shuttle service integration for the Poise discord bot framework.
 //! ## Example
 //! ```rust,no_run
+//! use anyhow::Context as _;
 //! use poise::serenity_prelude as serenity;
 //! use shuttle_secrets::SecretStore;
 //! use shuttle_poise::ShuttlePoise;
@@ -21,7 +22,7 @@
 //!     // Get the discord token set in `Secrets.toml`
 //!     let discord_token = secret_store
 //!         .get("DISCORD_TOKEN")
-//!         .expect("'DISCORD_TOKEN' was not found");
+//!         .context("'DISCORD_TOKEN' was not found")?;
 //!
 //!     let framework = poise::Framework::builder()
 //!         .options(poise::FrameworkOptions {


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

*finally a well isolated PR...*

- Move internals into hidden module, which hides them from the cargo doc page (docs.rs).
- Re-export tokio, allows user code to not have tokio in Cargo.toml, unless they need it for something ofc :)

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


