### PR TITLE
feat(cargo-shuttle): adaptive page hints, non-breaking 

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -730,7 +730,7 @@ impl Shuttle {
             .get_deployments(proj_name, page, limit)
             .await
             .map_err(suggestions::deployment::get_deployments_list_failure)?;
-        let table = get_deployments_table(&deployments, proj_name.as_str(), page);
+        let table = get_deployments_table(&deployments, proj_name.as_str(), page, limit);
 
         println!("{table}");
         println!("Run `cargo shuttle logs <id>` to get logs for a given deployment.");
@@ -1671,7 +1671,7 @@ impl Shuttle {
                 "getting the projects list fails repeteadly",
             )
         })?;
-        let projects_table = project::get_table(&projects, page);
+        let projects_table = project::get_table(&projects, page, limit);
 
         println!("{projects_table}");
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -67,7 +67,12 @@ impl State {
     }
 }
 
-pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, page: u32, limit: u32) -> String {
+pub fn get_deployments_table(
+    deployments: &Vec<Response>,
+    service_name: &str,
+    page: u32,
+    limit: u32,
+) -> String {
     if deployments.is_empty() {
         if page <= 1 {
             format!(
@@ -159,8 +164,9 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, pa
 
         if deployments.len() == limit as usize {
             format!(
-                "{formatted_table}\n\n{page_hint}", 
-                page_hint = "More projects might be available on the next page using --page.".bold()
+                "{formatted_table}\n\n{page_hint}",
+                page_hint =
+                    "More projects might be available on the next page using --page.".bold()
             )
         } else {
             formatted_table

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -67,7 +67,7 @@ impl State {
     }
 }
 
-pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, page: u32) -> String {
+pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, page: u32, limit: u32) -> String {
     if deployments.is_empty() {
         if page <= 1 {
             format!(
@@ -150,18 +150,21 @@ pub fn get_deployments_table(deployments: &Vec<Response>, service_name: &str, pa
             ]);
         }
 
-        format!(
-            r#"
-Most recent {} for {}
-{}
-
-{}
-"#,
+        let formatted_table = format!(
+            "Most recent {} for {}\n{}",
             "deployments".bold(),
             service_name,
             table,
-            "More projects might be available on the next page using --page.".bold()
-        )
+        );
+
+        if deployments.len() == limit as usize {
+            format!(
+                "{formatted_table}\n\n{page_hint}", 
+                page_hint = "More projects might be available on the next page using --page.".bold()
+            )
+        } else {
+            formatted_table
+        }
     }
 }
 

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -229,7 +229,8 @@ pub fn get_table(projects: &Vec<Response>, page: u32, limit: u32) -> String {
         if projects.len() == limit as usize {
             format!(
                 "{formatted_table}\n\n{page_hint}",
-                page_hint = "More projects might be available on the next page using --page.".bold()
+                page_hint =
+                    "More projects might be available on the next page using --page.".bold()
             )
         } else {
             formatted_table

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -190,7 +190,7 @@ pub struct AdminResponse {
     pub account_name: String,
 }
 
-pub fn get_table(projects: &Vec<Response>, page: u32) -> String {
+pub fn get_table(projects: &Vec<Response>, page: u32, limit: u32) -> String {
     if projects.is_empty() {
         // The page starts at 1 in the CLI.
         if page <= 1 {
@@ -224,14 +224,15 @@ pub fn get_table(projects: &Vec<Response>, page: u32) -> String {
             ]);
         }
 
-        format!(
-            r#"
-These projects are linked to this account
-{table}
+        let formatted_table = format!("These projects are linked to this account\n{table}");
 
-{}
-"#,
-            "More projects might be available on the next page using --page.".bold()
-        )
+        if projects.len() == limit as usize {
+            format!(
+                "{formatted_table}\n\n{page_hint}",
+                page_hint = "More projects might be available on the next page using --page.".bold()
+            )
+        } else {
+            formatted_table
+        }
     }
 }

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -233,7 +233,7 @@ impl GatewayService {
     /// * `args` - The [`Args`] with which the service was
     /// started. Will be passed as [`Context`] to workers and state.
     pub async fn init(args: ContextArgs, db: SqlitePool, state_location: PathBuf) -> Self {
-        let docker = Docker::connect_with_unix(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
+        let docker = Docker::connect_with_http(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
 
         let container_settings = ContainerSettings::builder().from_args(&args).await;
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -233,7 +233,7 @@ impl GatewayService {
     /// * `args` - The [`Args`] with which the service was
     /// started. Will be passed as [`Context`] to workers and state.
     pub async fn init(args: ContextArgs, db: SqlitePool, state_location: PathBuf) -> Self {
-        let docker = Docker::connect_with_http(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
+        let docker = Docker::connect_with_unix(&args.docker_host, 60, API_DEFAULT_VERSION).unwrap();
 
         let container_settings = ContainerSettings::builder().from_args(&args).await;
 


### PR DESCRIPTION
## Description of change
Changed the project and deployment commands to only return page hint if the items returned == limit.

Mostly closes https://github.com/shuttle-hq/shuttle/issues/1316

## How has this been tested? (if applicable)
Tested with local setup


