### PR TITLE
feat(logger): add instrumentation needed for alert

### DIFF
--- a/logger/src/dal.rs
+++ b/logger/src/dal.rs
@@ -80,8 +80,13 @@ impl Postgres {
                         );
 
                         parent_span.in_scope(|| {
-                            if rx.len() > 200 {
-                                warn!("database receiver queue size: {}", rx.len());
+                            if rx.len() >= 200 {
+                                warn!(
+                                    queue_size = rx.len(),
+                                    // This string is matched in a honeycomb trigger, changing it will
+                                    // break the trigger.
+                                    "database receiver queue is filling up"
+                                );
                             } else if !rx.is_empty() {
                                 info!("database receiver queue size: {}", rx.len());
                             }

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -134,12 +134,12 @@ where
 
             loop {
                 match logs_rx.recv().await {
-                    Ok(logs) => {
+                    Ok((logs, _span)) => {
                         if !logs_rx.is_empty() {
                             debug!("stream receiver queue size {}", logs_rx.len())
                         }
 
-                        for log in logs.0 {
+                        for log in logs {
                             if log.deployment_id == deployment_id
                                 && log.tx_timestamp.timestamp() >= last.seconds
                                 && log.tx_timestamp.timestamp_nanos_opt().unwrap_or_default()


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This adds the instrumentation required to track the broadcast queue size warnings happening in the tokio task spawned in `dal::Postgres::from_pool`. 

I set up a trigger in HoneyComb (not in the production environment yet), it will trigger if the count of warning events is >= 10 within a 5 minute duration, and the query is ran every 5 minutes. I am still not set on the numbers here, we may have some false alerts during high load peaks, but I think we can start with this and then fine-tune it. 

For some context, the `warn` event will be triggered when the database receiver queue is >= 200. The database receiver queue will start growing if it cannot write the received logs faster than they are coming in. So it may fill up a bit during spikes (or if the database has problems), but it will empty again. If the high load is sustained, it will keep filling until it reaches capacity, at which point it will start dropping messages. This sustained overload is what we want to be alerted about.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested with honeycomb locally by running a query for `level = WARN`, `parent_span = store_logs` and `name = database receiver queue is filling up`, setting a trigger, and verifying that I got email alerts for both triggered and resolved.
