### PR TITLE
fix(deployer): handle cargo fetch without blocking logs, use async channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,7 +1137,6 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "crossbeam-channel",
  "crossterm 0.27.0",
  "dialoguer",
  "dirs 5.0.1",
@@ -4505,15 +4504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pipe"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7b8f27da217eb966df4c58d4159ea939431950ca03cf782c22bd7c5c1d8d75"
-dependencies = [
- "crossbeam-channel",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5844,7 +5834,6 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "clap",
- "crossbeam-channel",
  "ctor",
  "flate2",
  "fqdn",
@@ -5856,7 +5845,6 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
- "pipe",
  "portpicker",
  "prost-types",
  "rand 0.8.5",
@@ -6053,7 +6041,6 @@ dependencies = [
  "cap-std",
  "chrono",
  "colored",
- "crossbeam-channel",
  "futures",
  "hyper",
  "portpicker",
@@ -6085,8 +6072,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cargo_metadata",
- "crossbeam-channel",
- "os_pipe",
  "serde",
  "shuttle-common",
  "strfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ cargo_metadata = "0.15.3"
 chrono = { version = "0.4.23", default-features = false }
 colored = "2.0.0"
 clap = { version = "4.2.7", features = ["derive"] }
-crossbeam-channel = "0.5.7"
 crossterm = "0.27.0"
 ctor = "0.1.26"
 dirs = "5.0.0"
@@ -74,7 +73,6 @@ opentelemetry-otlp = "0.12.0"
 opentelemetry-proto = "0.2.0"
 percent-encoding = "2.2"
 pin-project = "1.0.12"
-pipe = "0.4.0"
 portpicker = "0.1.1"
 pretty_assertions = "1.3.0"
 prost = "0.11.8"
@@ -106,7 +104,6 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
   "registry",
 ] }
 ttl_cache = "0.5.1"
-os_pipe = { version = "1.1.4" }
 utoipa = { version = "3.2.1", features = [ "uuid", "chrono" ] }
 utoipa-swagger-ui = { version = "3.1.3", features = ["axum"] }
 ulid = "1.0.0"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -18,7 +18,7 @@ toml = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["default"] }
-os_pipe = { workspace = true }
+os_pipe = "1.1.4"
 ulid = { workspace = true }
 
 [dependencies.shuttle-common]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -15,7 +15,6 @@ cargo_metadata = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 clap_complete = "4.3.1"
-crossbeam-channel = { workspace = true }
 crossterm = { workspace = true }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dirs = { workspace = true }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -51,6 +51,8 @@ impl ProjectArgs {
     pub fn workspace_path(&self) -> anyhow::Result<PathBuf> {
         let path = MetadataCommand::new()
             .current_dir(&self.working_directory)
+            // don't fetch crates in blocking part of code, let other cargo commands do it
+            .other_options(vec!["--offline".into()])
             .exec()
             .context("failed to get cargo metadata")?
             .workspace_root
@@ -64,8 +66,10 @@ impl ProjectArgs {
 
         let meta = MetadataCommand::new()
             .current_dir(&workspace_path)
+            // don't fetch crates in blocking part of code, let other cargo commands do it
+            .other_options(vec!["--offline".into()])
             .exec()
-            .unwrap();
+            .context("failed to get cargo metadata")?;
         let package_name = if let Some(root_package) = meta.root_package() {
             root_package.name.clone().parse()?
         } else {

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -49,10 +49,9 @@ pub struct ProjectArgs {
 
 impl ProjectArgs {
     pub fn workspace_path(&self) -> anyhow::Result<PathBuf> {
+        // NOTE: If crates cache is missing this blocks for several seconds during download
         let path = MetadataCommand::new()
             .current_dir(&self.working_directory)
-            // don't fetch crates in blocking part of code, let other cargo commands do it
-            .other_options(vec!["--offline".into()])
             .exec()
             .context("failed to get cargo metadata")?
             .workspace_root
@@ -64,10 +63,9 @@ impl ProjectArgs {
     pub fn project_name(&self) -> anyhow::Result<ProjectName> {
         let workspace_path = self.workspace_path()?;
 
+        // NOTE: If crates cache is missing this blocks for several seconds during download
         let meta = MetadataCommand::new()
             .current_dir(&workspace_path)
-            // don't fetch crates in blocking part of code, let other cargo commands do it
-            .other_options(vec!["--offline".into()])
             .exec()
             .context("failed to get cargo metadata")?;
         let package_name = if let Some(root_package) = meta.root_package() {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -39,7 +39,6 @@ use shuttle_service::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use cargo_metadata::Message;
 use clap::{parser::ValueSource, CommandFactory, FromArgMatches};
 use clap_complete::{generate, Shell};
 use config::RequestContext;
@@ -1100,15 +1099,10 @@ impl Shuttle {
     async fn pre_local_run(&self, run_args: &RunArgs) -> Result<Vec<BuiltService>> {
         trace!("starting a local run for a service: {run_args:?}");
 
-        let (tx, rx): (crossbeam_channel::Sender<Message>, _) = crossbeam_channel::bounded(0);
-        tokio::task::spawn_blocking(move || {
-            while let Ok(message) = rx.recv() {
-                match message {
-                    Message::TextLine(line) => println!("{line}"),
-                    message => {
-                        trace!("skipping cargo line: {message:?}")
-                    }
-                }
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(256);
+        tokio::task::spawn(async move {
+            while let Some(line) = rx.recv().await {
+                println!("{line}");
             }
         });
 
@@ -1140,6 +1134,7 @@ impl Shuttle {
 
     #[cfg(target_family = "unix")]
     async fn local_run(&self, mut run_args: RunArgs) -> Result<CommandOutcome> {
+        debug!("starting local run");
         let services = self.pre_local_run(&run_args).await?;
         let (provisioner_server, provisioner_port) = Shuttle::setup_local_provisioner().await?;
         let mut sigterm_notif =

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -13,7 +13,6 @@ bytes = { workspace = true }
 cargo_metadata = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
-crossbeam-channel = { workspace = true }
 flate2 = { workspace = true }
 fqdn = { workspace = true }
 futures = { workspace = true }
@@ -23,7 +22,6 @@ hyper-reverse-proxy = { workspace = true }
 once_cell = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry-http = { workspace = true }
-pipe = { workspace = true }
 prost-types = { workspace = true }
 portpicker = { workspace = true }
 rmp-serde = { workspace = true }

--- a/deployer/src/error.rs
+++ b/deployer/src/error.rs
@@ -40,8 +40,6 @@ pub enum Error {
 pub enum TestError {
     #[error("The deployed application's tests failed")]
     Failed,
-    #[error("Failed to setup tests run: {0}")]
-    Setup(#[from] anyhow::Error),
     #[error("Failed to run tests: {0}")]
     Run(#[from] std::io::Error),
 }

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -39,7 +39,6 @@ use shuttle_common::models::secret;
 use shuttle_common::project::ProjectName;
 use shuttle_common::{request_span, LogItem};
 use shuttle_proto::logger::LogsRequest;
-use shuttle_service::builder::clean_crate;
 
 use crate::persistence::{Deployment, Persistence, SecretGetter, State};
 use crate::{
@@ -203,7 +202,7 @@ impl RouterBuilder {
 
     pub fn into_router(self) -> Router {
         self.router
-            .route("/projects/:project_name/status", get(get_status))
+            .route("/projects/:project_name/status", get(|| async { "Ok" }))
             .route_layer(from_extractor::<Metrics>())
             .layer(
                 TraceLayer::new(|request| {
@@ -254,7 +253,6 @@ pub async fn get_services(
 }
 
 #[instrument(skip_all, fields(%project_name, %service_name))]
-#[instrument(skip_all)]
 #[utoipa::path(
     get,
     path = "/projects/{project_name}/services/{service_name}",
@@ -504,7 +502,7 @@ pub async fn stop_service(
     Ok(Json(response))
 }
 
-#[instrument(skip(persistence))]
+#[instrument(skip_all, fields(%project_name, page, limit))]
 #[utoipa::path(
     get,
     path = "/projects/{project_name}/deployments",
@@ -540,7 +538,6 @@ pub async fn get_deployments(
 }
 
 #[instrument(skip_all, fields(%project_name, %deployment_id))]
-#[instrument(skip(persistence))]
 #[utoipa::path(
     get,
     path = "/projects/{project_name}/deployments/{deployment_id}",
@@ -671,6 +668,8 @@ pub async fn get_logs(
     }
 }
 
+// don't instrument id to prevent it from showing up in deployment log
+#[instrument(skip_all, fields(%project_name))]
 #[utoipa::path(
     get,
     path = "/projects/{project_name}/ws/deployments/{deployment_id}/logs",
@@ -685,7 +684,7 @@ pub async fn get_logs(
 pub async fn get_logs_subscribe(
     Extension(deployment_manager): Extension<DeploymentManager>,
     Extension(claim): Extension<Claim>,
-    Path((_project_name, deployment_id)): Path<(String, Uuid)>,
+    Path((project_name, deployment_id)): Path<(String, Uuid)>,
     ws_upgrade: ws::WebSocketUpgrade,
 ) -> axum::response::Response {
     ws_upgrade
@@ -795,6 +794,7 @@ pub async fn get_secrets(
     }
 }
 
+#[instrument(skip_all, fields(%project_name))]
 #[utoipa::path(
     post,
     path = "/projects/{project_name}/clean",
@@ -809,8 +809,8 @@ pub async fn get_secrets(
 pub async fn clean_project(
     Extension(deployment_manager): Extension<DeploymentManager>,
     Path(project_name): Path<String>,
-) -> Result<Json<Vec<String>>> {
-    let lines = clean_crate(
+) -> Result<Json<String>> {
+    shuttle_service::builder::clean_crate(
         deployment_manager
             .builds_path()
             .join(project_name)
@@ -818,11 +818,7 @@ pub async fn clean_project(
     )
     .await?;
 
-    Ok(Json(lines))
-}
-
-async fn get_status() -> String {
-    "Ok".to_string()
+    Ok(Json("Cleaning done".into()))
 }
 
 pub struct Rmp<T>(T);

--- a/deployer/src/persistence/error.rs
+++ b/deployer/src/persistence/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
     ResourceRecorder(tonic::Status),
     #[error("Sending the state event failed: {0}")]
     ChannelSendError(#[from] tokio::sync::mpsc::error::SendError<DeploymentState>),
-    #[error("Sending the state event failed: sync sender thread panicked")]
+    #[error("Sending the state event failed: channel closed")]
     ChannelSendThreadError,
     #[error("Parsing error: {0}")]
     ParseError(String),

--- a/deployer/src/persistence/error.rs
+++ b/deployer/src/persistence/error.rs
@@ -7,7 +7,9 @@ pub enum Error {
     #[error("Resource recorder error: {0}")]
     ResourceRecorder(tonic::Status),
     #[error("Sending the state event failed: {0}")]
-    CrossbeamChannelSendError(#[from] crossbeam_channel::SendError<DeploymentState>),
+    ChannelSendError(#[from] tokio::sync::mpsc::error::SendError<DeploymentState>),
+    #[error("Sending the state event failed: sync sender thread panicked")]
+    ChannelSendThreadError,
     #[error("Parsing error: {0}")]
     ParseError(String),
     #[error("Provisioner request failed: {0}")]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,7 +24,7 @@ strfmt = { workspace = true }
 thiserror = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-stream = "0.1.11"
+tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
 cap-std = { workspace = true, optional = true }
@@ -50,7 +50,6 @@ workspace = true
 workspace = true
 
 [dev-dependencies]
-crossbeam-channel = { workspace = true }
 portpicker = "0.1.1"
 futures = { workspace = true }
 shuttle-service = { workspace = true, features = ["builder"] }

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -38,7 +38,7 @@ pub async fn spawn_runtime(project_path: String, service_name: &str) -> Result<T
     let runtime_port = portpicker::pick_unused_port().unwrap();
     let runtime_address = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), runtime_port);
 
-    let (tx, _) = crossbeam_channel::unbounded();
+    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let runtimes = build_workspace(Path::new(&project_path), false, tx, false).await?;
     let service = runtimes[0].clone();
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -17,7 +17,7 @@ cargo_metadata = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 strfmt = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["process"], optional = true }
+tokio = { workspace = true, features = ["process", "io-util", "sync", "time"], optional = true }
 toml = { workspace = true, optional = true  }
 tracing = { workspace = true, optional = true }
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -14,8 +14,6 @@ doctest = false
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 cargo_metadata = { workspace = true, optional = true }
-crossbeam-channel = { workspace = true, optional = true }
-os_pipe = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 strfmt = { workspace = true }
 thiserror = { workspace = true }
@@ -33,4 +31,4 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 [features]
 default = []
 
-builder = ["cargo_metadata", "crossbeam-channel", "os_pipe", "tokio", "toml", "tracing"]
+builder = ["cargo_metadata", "tokio", "toml", "tracing"]

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -91,7 +91,7 @@ pub async fn build_workspace(
         let tx = tx.clone();
         async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-            tx.send("      Fetching crates...".into())
+            tx.send("      Downloading crates...".into())
                 .await
                 .expect("log receiver to exist");
         }

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -78,6 +78,7 @@ pub async fn build_workspace(
 
     // Cargo's "Downloading ..." lines are quite verbose.
     // Instead, a custom message is printed if the download takes significant time.
+    // Cargo seems to have similar logic, where it prints nothing if this step takes little time.
     let mut command = tokio::process::Command::new("cargo");
     command
         .arg("fetch")
@@ -103,8 +104,8 @@ pub async fn build_workspace(
     notification.abort();
 
     let metadata = {
-        // Modified implementaion of `MetadataCommand::exec` (v0.15.3).
-        // Uses tokio command instead of std
+        // Modified implementaion of `cargo_metadata::MetadataCommand::exec` (from v0.15.3).
+        // Uses tokio Command instead of std, to make this operation non-blocking.
         let mut cmd = tokio::process::Command::from(
             cargo_metadata::MetadataCommand::new()
                 .manifest_path(&manifest_path)

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -1,16 +1,14 @@
 use std::fs::read_to_string;
-use std::io::BufRead;
 use std::path::{Path, PathBuf};
-use std::process::Output;
+use std::process::Stdio;
 
 use anyhow::{anyhow, bail, Context};
-use cargo_metadata::Message;
 use cargo_metadata::{Package, Target};
-use crossbeam_channel::Sender;
 use shuttle_common::{
     constants::{NEXT_NAME, RUNTIME_NAME},
     project::ProjectName,
 };
+use tokio::io::AsyncBufReadExt;
 use tracing::{debug, error, trace};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -69,22 +67,63 @@ fn extract_shuttle_toml_name(path: PathBuf) -> anyhow::Result<String> {
 pub async fn build_workspace(
     project_path: &Path,
     release_mode: bool,
-    tx: Sender<Message>,
+    tx: tokio::sync::mpsc::Sender<String>,
     deployment: bool,
 ) -> anyhow::Result<Vec<BuiltService>> {
     let project_path = project_path.to_owned();
-
     let manifest_path = project_path.join("Cargo.toml");
-
     if !manifest_path.exists() {
-        bail!(
-            "failed to read the Shuttle project manifest: {}",
-            manifest_path.display()
-        );
+        bail!("Cargo manifest file not found: {}", manifest_path.display());
     }
-    let metadata = cargo_metadata::MetadataCommand::new()
-        .manifest_path(&manifest_path)
-        .exec()?;
+
+    // Cargo's "Downloading ..." lines are quite verbose.
+    // Instead, a custom message is printed if the download takes significant time.
+    let mut command = tokio::process::Command::new("cargo");
+    command
+        .arg("fetch")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("--color=always")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let notification = tokio::spawn({
+        let tx = tx.clone();
+        async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            tx.send("      Fetching crates...".into())
+                .await
+                .expect("log receiver to exist");
+        }
+    });
+    if !command.status().await?.success() {
+        tx.send("      Failed to fetch crates".into())
+            .await
+            .expect("log receiver to exist");
+    }
+    notification.abort();
+
+    let metadata = {
+        // Modified implementaion of `MetadataCommand::exec` (v0.15.3).
+        // Uses tokio command instead of std
+        let mut cmd = tokio::process::Command::from(
+            cargo_metadata::MetadataCommand::new()
+                .manifest_path(&manifest_path)
+                .cargo_command(),
+        );
+
+        let output = cmd.output().await?;
+        if !output.status.success() {
+            return Err(cargo_metadata::Error::CargoMetadata {
+                stderr: String::from_utf8(output.stderr)?,
+            })?;
+        }
+        let json = std::str::from_utf8(&output.stdout)?
+            .lines()
+            .find(|line| line.starts_with('{'))
+            .ok_or(cargo_metadata::Error::NoJson)?;
+        cargo_metadata::MetadataCommand::parse(json)?
+    };
+
     trace!("Cargo metadata parsed");
 
     let mut alpha_packages = Vec::new();
@@ -137,33 +176,25 @@ pub async fn build_workspace(
     Ok(runtimes)
 }
 
-pub async fn clean_crate(project_path: &Path) -> anyhow::Result<Vec<String>> {
+// Only used in deployer
+pub async fn clean_crate(project_path: &Path) -> anyhow::Result<()> {
     let manifest_path = project_path.join("Cargo.toml");
     if !manifest_path.exists() {
-        bail!("failed to read the Shuttle project manifest");
+        bail!("Cargo manifest file not found: {}", manifest_path.display());
     }
-    let Output {
-        status,
-        stdout,
-        stderr,
-    } = tokio::process::Command::new("cargo")
+    if !tokio::process::Command::new("cargo")
         .arg("clean")
         .arg("--manifest-path")
-        .arg(manifest_path.to_str().unwrap())
-        .output()
-        .await
-        .unwrap();
-
-    if status.success() {
-        let lines = vec![String::from_utf8(stderr)?, String::from_utf8(stdout)?];
-        Ok(lines)
-    } else {
-        Err(anyhow!(
-            "cargo clean failed with exit code {} and error {}",
-            status.to_string(),
-            String::from_utf8(stderr)?
-        ))
+        .arg(&manifest_path)
+        .arg("--offline")
+        .status()
+        .await?
+        .success()
+    {
+        bail!("cargo clean failed");
     }
+
+    Ok(())
 }
 
 fn is_next(package: &Package) -> bool {
@@ -209,64 +240,52 @@ async fn compile(
     project_path: PathBuf,
     target_path: impl Into<PathBuf>,
     deployment: bool,
-    tx: Sender<Message>,
+    tx: tokio::sync::mpsc::Sender<String>,
 ) -> anyhow::Result<Vec<BuiltService>> {
     let manifest_path = project_path.join("Cargo.toml");
     if !manifest_path.exists() {
-        bail!("failed to read the Shuttle project manifest");
+        bail!("Cargo manifest file not found: {}", manifest_path.display());
     }
     let target_path = target_path.into();
 
-    let mut cargo = tokio::process::Command::new("cargo");
-    cargo
-        .arg("build")
+    let mut cmd = tokio::process::Command::new("cargo");
+    cmd.arg("build")
         .arg("--manifest-path")
         .arg(manifest_path)
         .arg("--color=always") // piping disables auto color, but we want it
         .current_dir(project_path.as_path());
 
     if deployment {
-        cargo.arg("--jobs=4");
+        cmd.arg("--jobs=4");
     }
 
     for package in &packages {
-        cargo.arg("--package").arg(package.name.as_str());
+        cmd.arg("--package").arg(package.name.as_str());
     }
 
     let profile = if release_mode {
-        cargo.arg("--release");
+        cmd.arg("--release");
         "release"
     } else {
         "debug"
     };
 
     if wasm {
-        cargo.arg("--target").arg("wasm32-wasi");
+        cmd.arg("--target").arg("wasm32-wasi");
     }
 
-    let (reader, writer) = os_pipe::pipe()?;
-    let writer_clone = writer.try_clone()?;
-    cargo.stdout(writer);
-    cargo.stderr(writer_clone);
-
-    let mut handle = cargo.spawn()?;
-
-    tokio::task::spawn_blocking(move || {
-        let reader = std::io::BufReader::new(reader);
-        for line in reader.lines() {
-            if let Ok(line) = line {
-                if let Err(error) = tx.send(Message::TextLine(line)) {
-                    error!("failed to send cargo message on channel: {error}");
-                };
-            } else {
-                error!("Failed to read Cargo log messages");
-            };
+    cmd.stderr(Stdio::piped());
+    cmd.stdout(Stdio::null());
+    let mut handle = cmd.spawn()?;
+    let reader = tokio::io::BufReader::new(handle.stderr.take().unwrap());
+    tokio::spawn(async move {
+        let mut lines = reader.lines();
+        while let Some(line) = lines.next_line().await.unwrap() {
+            let _ = tx.send(line).await.map_err(|e| error!("{e}"));
         }
     });
-
-    let command = handle.wait().await?;
-
-    if !command.success() {
+    let status = handle.wait().await?;
+    if !status.success() {
         bail!("Build failed. Is the Shuttle runtime missing?");
     }
 

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -5,7 +5,7 @@ use shuttle_service::builder::{build_workspace, BuiltService};
 #[tokio::test]
 #[should_panic(expected = "Build failed. Is the Shuttle runtime missing?")]
 async fn not_shuttle() {
-    let (tx, _) = crossbeam_channel::unbounded();
+    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!("{}/tests/resources/not-shuttle", env!("CARGO_MANIFEST_DIR"));
     build_workspace(Path::new(&project_path), false, tx, false)
         .await
@@ -15,7 +15,7 @@ async fn not_shuttle() {
 #[tokio::test]
 #[should_panic(expected = "Your Shuttle project must be a binary.")]
 async fn not_bin() {
-    let (tx, _) = crossbeam_channel::unbounded();
+    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!("{}/tests/resources/not-bin", env!("CARGO_MANIFEST_DIR"));
     match build_workspace(Path::new(&project_path), false, tx, false).await {
         Ok(_) => {}
@@ -25,7 +25,7 @@ async fn not_bin() {
 
 #[tokio::test]
 async fn is_bin() {
-    let (tx, _) = crossbeam_channel::unbounded();
+    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!("{}/tests/resources/is-bin", env!("CARGO_MANIFEST_DIR"));
 
     assert_eq!(
@@ -45,7 +45,7 @@ async fn is_bin() {
 #[tokio::test]
 #[should_panic(expected = "failed to read the Shuttle project manifest")]
 async fn not_found() {
-    let (tx, _) = crossbeam_channel::unbounded();
+    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!(
         "{}/tests/resources/non-existing",
         env!("CARGO_MANIFEST_DIR")
@@ -58,7 +58,7 @@ async fn not_found() {
 // Test that alpha and next projects are compiled correctly. Any shared library crates should not be compiled too
 #[tokio::test]
 async fn workspace() {
-    let (tx, _) = crossbeam_channel::unbounded();
+    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!("{}/tests/resources/workspace", env!("CARGO_MANIFEST_DIR"));
 
     assert_eq!(

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -43,7 +43,7 @@ async fn is_bin() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "failed to read the Shuttle project manifest")]
+#[should_panic(expected = "Cargo manifest file not found")]
 async fn not_found() {
     let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!(
@@ -58,7 +58,12 @@ async fn not_found() {
 // Test that alpha and next projects are compiled correctly. Any shared library crates should not be compiled too
 #[tokio::test]
 async fn workspace() {
-    let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(256);
+    tokio::spawn(async move {
+        while let Some(l) = rx.recv().await {
+            println!("{l}");
+        }
+    });
     let project_path = format!("{}/tests/resources/workspace", env!("CARGO_MANIFEST_DIR"));
 
     assert_eq!(


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Fixes #1322 and some more

- Using blocking crossbeam channels was causing logs to be delayed. Switched over to tokio channels everywhere possible.
  - Initial logs from deployment now appear instantly, and one line is printed if the fetching takes time.
- Do a manual cargo fetch when building, and don't let metadata commands fetch. (this is causing CI fail, will look for compromise.)

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Local run works as usual, with and without crates cached.
Deployment works for axum hello world with and without --no-test, with and without failing test.