### PR TITLE
bug: compile fails with secrets in resource configs

### DIFF
--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -241,7 +241,7 @@ impl ToTokens for Loader {
                             .get_secrets()
                             .await?
                             .into_iter()
-                            .map(|(key, value)| (format!("secrets.{}", key), value))
+                            .map(|(key, value)| (format!("secrets.{}", key), value.expose().clone()))
                     );
                 )),
                 Some(parse_quote!(

--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -507,7 +507,7 @@ mod tests {
             ) -> ShuttleComplex {
                 use shuttle_runtime::Context;
                 use shuttle_runtime::{Factory, ResourceBuilder};
-                let vars = std::collections::HashMap::from_iter(factory.get_secrets().await?.into_iter().map(|(key, value)| (format!("secrets.{}", key), value)));
+                let vars = std::collections::HashMap::from_iter(factory.get_secrets().await?.into_iter().map(|(key, value)| (format!("secrets.{}", key), value.expose().clone())));
                 let pool = shuttle_runtime::get_resource (
                     shuttle_shared_db::Postgres::new().size(&shuttle_runtime::strfmt("10Gb", &vars)?).public(false),
                     &mut factory,


### PR DESCRIPTION
## Description of change
Fixes compiling failing when using secrets after #925 


## How has this been tested? (if applicable)
By using `cargo check` on a project that uses secrets inside a resource config


