### PR TITLE
bug: revert turso version update

### DIFF
--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "turso"]
 [dependencies]
 async-trait = "0.1.56"
 dunce = "1.0.4"
-libsql-client = { version = "0.32.0" }
+libsql-client = { version = "0.31.0" }
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.30.1", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
## Description of change
The latest version of Turso fails to compile. So reverting it back to the last working version.

More details are on libsql/libsql-client-rs#52.

## How has this been tested? (if applicable)
Using the local runner


