### PR TITLE
feat(cargo-shuttle): state MSRV in Cargo.toml

### DIFF
--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 description = "A cargo command for the shuttle platform (https://www.shuttle.rs/)"
 homepage = "https://www.shuttle.rs"
+rust-version = "1.70"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Should allow cargo to deny the install if outdated.
TODO: eventually add CI for checking this when we care more about it.

ref: https://github.com/shuttle-hq/shuttle-docs/pull/210

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Installing with 1.69 fails, 1.70 works :heavy_check_mark: 