### PR TITLE
feat: adapative page hints (client-side only)

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -734,13 +734,20 @@ impl Shuttle {
             println!();
             return Ok(CommandOutcome::Ok);
         }
+        let limit = limit + 1;
 
         let proj_name = self.ctx.project_name();
-        let deployments = client
+        let mut deployments = client
             .get_deployments(proj_name, page, limit)
             .await
             .map_err(suggestions::deployment::get_deployments_list_failure)?;
-        let table = get_deployments_table(&deployments, proj_name.as_str(), page, raw);
+        let page_hint = if deployments.len() == limit as usize {
+            deployments.pop();
+            true
+        } else {
+            false
+        };
+        let table = get_deployments_table(&deployments, proj_name.as_str(), page, raw, page_hint);
 
         println!("{table}");
         println!("Run `cargo shuttle logs <id>` to get logs for a given deployment.");
@@ -1695,8 +1702,9 @@ impl Shuttle {
             println!();
             return Ok(CommandOutcome::Ok);
         }
+        let limit = limit + 1;
 
-        let projects = client.get_projects_list(page, limit).await.map_err(|err| {
+        let mut projects = client.get_projects_list(page, limit).await.map_err(|err| {
             suggestions::project::project_request_failure(
                 err,
                 "Getting projects list failed",
@@ -1704,7 +1712,13 @@ impl Shuttle {
                 "getting the projects list fails repeteadly",
             )
         })?;
-        let projects_table = project::get_projects_table(&projects, page, raw);
+        let page_hint = if projects.len() == limit as usize {
+            projects.pop();
+            true
+        } else {
+            false
+        };
+        let projects_table = project::get_projects_table(&projects, page, raw, page_hint);
 
         println!("{projects_table}");
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -76,6 +76,7 @@ pub fn get_deployments_table(
     service_name: &str,
     page: u32,
     raw: bool,
+    page_hint: bool,
 ) -> String {
     if deployments.is_empty() {
         // The page starts at 1 in the CLI.
@@ -196,9 +197,12 @@ pub fn get_deployments_table(
             }
         }
 
-        format!(
-            "\nMost recent deployments for {service_name}\n{table}\nMore projects might be available on the next page using --page.\n",
-        )
+        let formatted_table = format!("\nMost recent deployments for {service_name}\n{table}\n");
+        if page_hint {
+            format!("{formatted_table}More projects might be available on the next page using --page.\n")
+        } else {
+            formatted_table
+        }
     }
 }
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -199,7 +199,10 @@ pub fn get_deployments_table(
 
         let formatted_table = format!("\nMost recent deployments for {service_name}\n{table}\n");
         if page_hint {
-            format!("{formatted_table}More projects might be available on the next page using --page.\n")
+            format!(
+                "{formatted_table}More deployments are available on the next page using `--page {}`\n",
+                page + 1
+            )
         } else {
             formatted_table
         }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -191,7 +191,12 @@ pub struct AdminResponse {
     pub account_name: String,
 }
 
-pub fn get_projects_table(projects: &Vec<Response>, page: u32, raw: bool) -> String {
+pub fn get_projects_table(
+    projects: &Vec<Response>,
+    page: u32,
+    raw: bool,
+    page_hint: bool,
+) -> String {
     if projects.is_empty() {
         // The page starts at 1 in the CLI.
         let mut s = if page <= 1 {
@@ -244,8 +249,11 @@ pub fn get_projects_table(projects: &Vec<Response>, page: u32, raw: bool) -> Str
             }
         }
 
-        format!(
-            "\nThese projects are linked to this account\n{table}\nMore projects might be available on the next page using --page.\n"
-        )
+        let formatted_table = format!("\nThese projects are linked to this account\n{table}\n");
+        if page_hint {
+            format!("{formatted_table}More projects might be available on the next page using --page.\n")
+        } else {
+            formatted_table
+        }
     }
 }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -251,7 +251,10 @@ pub fn get_projects_table(
 
         let formatted_table = format!("\nThese projects are linked to this account\n{table}\n");
         if page_hint {
-            format!("{formatted_table}More projects might be available on the next page using --page.\n")
+            format!(
+                "{formatted_table}More projects are available on the next page using `--page {}`\n",
+                page + 1
+            )
         } else {
             formatted_table
         }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Adds adaptive page hints to cargo-shuttle by adding 1 to the specified limit and checking if we reach that adjusted limit. This is not breaking as it requires no API changes and is just a small change to client-side logic. Only thing worth mentioning is technically you can only specify a limit up `u32::MAX - 1` because we always adjust the limit to be `limit + 1` however I cannot really see a case where someone would ever need that high of a limit so it is basically irrelevant.

Closes issue #1316 
Also can close my other 2 PRs #1334 and #1320 as this resolves all the issues addressed in those.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
Tested with local setup

