### PR TITLE
feat(deployer): delete secrets from deployer persistence on secrets resource delete

### DIFF
--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -561,9 +561,9 @@ impl ResourceManager for Persistence {
         }
         // Delete the secrets from the local SQLite persistence.
         else if let Type::Secrets = resource_type {
-            if let Ok(row_count) = self.delete_secrets(service_id).await {
-                info!("deleted {row_count} secrets from deployer persistence")
-            };
+            let row_count = self.delete_secrets(service_id).await?;
+
+            info!("deleted {row_count} secrets from deployer persistence");
         }
 
         let mut delete_resource_req = tonic::Request::new(ResourceIds {


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This ensures that when deleting the secrets resource, the secrets are also deleted from the deployer persistence secrets table.

I still want to explore whether secrets should still be persisted in the deployer, and perhaps if secrets should be deletable by key, but that's for a future PR.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
I first reproduced the bug locally by: deploying with secrets, deleting secrets and removing Secrets.toml, re-deploying and secrets returned.

After my change, this was no longer the case, secrets remained deleted on re-deploy.
