### PR TITLE
docs(readme): add instructions for installing on Alpine Linux

### DIFF
--- a/cargo-shuttle/README.md
+++ b/cargo-shuttle/README.md
@@ -68,6 +68,14 @@ cargo install cargo-shuttle
 pacman -S cargo-shuttle
 ```
 
+#### Alpine Linux
+
+`cargo-shuttle` is available for [Alpine Edge](https://pkgs.alpinelinux.org/packages?name=cargo-shuttle&branch=edge). It can be installed via [apk](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper) after enabling the [testing repository](https://wiki.alpinelinux.org/wiki/Repositories).
+
+```sh
+apk add cargo-shuttle
+```
+
 ---
 
 <!-- markdownlint-disable-next-line -->


### PR DESCRIPTION
## Description of change

I packaged `cargo-shuttle` for [Alpine Linux](https://alpinelinux.org/): https://pkgs.alpinelinux.org/packages?name=cargo-shuttle

This PR simply updates README.md about installation instructions.

## How has this been tested? (if applicable)

N/a
