### PR TITLE
fix: database uri password hiding, runtime version check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5763,6 +5763,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ttl_cache",
+ "url",
  "utoipa",
  "uuid",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,6 @@ ttl_cache = "0.5.1"
 utoipa = { version = "4.0.0", features = [ "uuid", "chrono" ] }
 utoipa-swagger-ui = { version = "4.0.0", features = ["axum"] }
 ulid = "1.0.0"
+url = "2.4.0"
 uuid = "1.2.2"
 zeroize = "1.6.0"

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -63,7 +63,7 @@ tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
 ] }
-url = "2.3.1"
+url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 walkdir = "2.3.3"
 webbrowser = "0.8.2"

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -14,12 +14,11 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::str::FromStr;
 
-use shuttle_common::models::error::ApiError;
 use shuttle_common::{
     claims::{ClaimService, InjectPropagation},
     constants::{
         API_URL_DEFAULT, EXECUTABLE_DIRNAME, SHUTTLE_CLI_DOCS_URL, SHUTTLE_GH_ISSUE_URL,
-        SHUTTLE_IDLE_DOCS_URL, SHUTTLE_LOGIN_URL, STORAGE_DIRNAME,
+        SHUTTLE_IDLE_DOCS_URL, SHUTTLE_INSTALL_DOCS_URL, SHUTTLE_LOGIN_URL, STORAGE_DIRNAME,
     },
     deployment::{DEPLOYER_END_MESSAGES_BAD, DEPLOYER_END_MESSAGES_GOOD},
     models::{
@@ -27,8 +26,9 @@ use shuttle_common::{
             get_deployments_table, DeploymentRequest, CREATE_SERVICE_BODY_LIMIT,
             GIT_STRINGS_MAX_LENGTH,
         },
+        error::ApiError,
         project::{self, DEFAULT_IDLE_MINUTES},
-        resource::get_resources_table,
+        resource::get_resource_tables,
         secret,
     },
     resource, semvers_are_compatible, ApiKey, LogItem, VersionInfo,
@@ -781,7 +781,7 @@ impl Shuttle {
             .get_service_resources(self.ctx.project_name())
             .await
             .map_err(suggestions::resources::get_service_resources_failure)?;
-        let table = get_resources_table(&resources, self.ctx.project_name(), raw, show_secrets);
+        let table = get_resource_tables(&resources, self.ctx.project_name(), raw, show_secrets);
 
         println!("{table}");
 
@@ -915,18 +915,24 @@ impl Shuttle {
                     if mismatch.shuttle_runtime > mismatch.cargo_shuttle {
                         // The runtime is newer than cargo-shuttle so we
                         // should help the user to update cargo-shuttle.
-                        println!(
-                            "[HINT]: You should update cargo-shuttle. \
-                            Check out the installation docs for how to update: \
-                            https://docs.shuttle.rs/getting-started/installation"
-                        );
+                        printdoc! {"
+                            Hint: A newer version of cargo-shuttle is available.
+                                  Check out the installation docs for how to update: {SHUTTLE_INSTALL_DOCS_URL}",
+                        };
                     } else {
-                        println!(
-                            "[HINT]: A newer version of shuttle-runtime is available. \
-                            Change its version to {} in this project's Cargo.toml to update it.",
+                        printdoc! {"
+                            Hint: A newer version of shuttle-runtime is available.
+                                  Change its version to {} in Cargo.toml to update it.",
                             mismatch.cargo_shuttle
-                        );
+                        };
                     }
+                } else {
+                    return Err(err.context(
+                        format!(
+                            "Failed to verify the version of shuttle-runtime in {}. Is cargo targeting the correct binary?",
+                            service.executable_path.display()
+                        )
+                    ));
                 }
             }
             service.executable_path.clone()
@@ -1006,7 +1012,7 @@ impl Shuttle {
 
         println!(
             "{}",
-            get_resources_table(&resources, service_name.as_str(), false, false)
+            get_resource_tables(&resources, service_name.as_str(), false, false)
         );
 
         let addr = SocketAddr::new(
@@ -1622,7 +1628,7 @@ impl Shuttle {
         let resources = client
             .get_service_resources(self.ctx.project_name())
             .await?;
-        let resources = get_resources_table(&resources, self.ctx.project_name(), false, false);
+        let resources = get_resource_tables(&resources, self.ctx.project_name(), false, false);
 
         println!("{resources}{service}");
 
@@ -1990,6 +1996,11 @@ fn is_dirty(repo: &Repository) -> Result<()> {
 }
 
 fn check_version(runtime_path: &Path) -> Result<()> {
+    debug!(
+        "Checking version of runtime binary at {}",
+        runtime_path.display()
+    );
+
     // should always be a valid semver
     let my_version = semver::Version::from_str(VERSION).unwrap();
 
@@ -2001,16 +2012,16 @@ fn check_version(runtime_path: &Path) -> Result<()> {
     let runtime_version = std::process::Command::new(runtime_path)
         .arg("--version")
         .output()
-        .context("failed to check the shuttle-runtime version")?
+        .context("failed to run the shuttle-runtime binary to check its version")?
         .stdout;
 
     // Parse the version, splitting the version from the name and
     // and pass it to `to_semver()`.
     let runtime_version = semver::Version::from_str(
         std::str::from_utf8(&runtime_version)
-            .expect("shuttle-runtime version should be valid utf8")
+            .context("shuttle-runtime version should be valid utf8")?
             .split_once(' ')
-            .expect("shuttle-runtime version should be in the `name version` format")
+            .context("shuttle-runtime version should be in the `name version` format")?
             .1
             .trim(),
     )

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -44,6 +44,7 @@ tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ttl_cache = { workspace = true, optional = true }
 utoipa = { workspace = true, optional = true }
+url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 zeroize = { workspace = true }
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -17,6 +17,7 @@ pub const API_URL_DEFAULT: &str = API_URL_PRODUCTION;
 pub const SHUTTLE_STATUS_URL: &str = "https://status.shuttle.rs";
 pub const SHUTTLE_LOGIN_URL: &str = "https://console.shuttle.rs/new-project";
 pub const SHUTTLE_GH_ISSUE_URL: &str = "https://github.com/shuttle-hq/shuttle/issues/new/choose";
+pub const SHUTTLE_INSTALL_DOCS_URL: &str = "https://docs.shuttle.rs/getting-started/installation";
 pub const SHUTTLE_CLI_DOCS_URL: &str = "https://docs.shuttle.rs/getting-started/shuttle-commands";
 pub const SHUTTLE_IDLE_DOCS_URL: &str = "https://docs.shuttle.rs/getting-started/idle-projects";
 pub const SHUTTLE_EXAMPLES_README: &str =

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -127,26 +127,32 @@ impl DatabaseReadyInfo {
             address_public,
         }
     }
+    /// For connecting to the db from inside the Shuttle network
     pub fn connection_string_private(&self) -> String {
         format!(
             "{}://{}:{}@{}:{}/{}",
             self.engine,
             self.role_name,
             self.role_password.expose(),
-            self.address_private,
+            self.address_public,
             self.port,
-            self.database_name
+            self.database_name,
         )
     }
-    pub fn connection_string_public(&self) -> String {
+    /// For connecting to the db from the Internet
+    pub fn connection_string_public(&self, show_password: bool) -> String {
         format!(
             "{}://{}:{}@{}:{}/{}",
             self.engine,
             self.role_name,
-            self.role_password.redacted(),
+            if show_password {
+                self.role_password.expose()
+            } else {
+                self.role_password.redacted()
+            },
             self.address_public,
             self.port,
-            self.database_name
+            self.database_name,
         )
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -134,7 +134,7 @@ impl DatabaseReadyInfo {
             self.engine,
             self.role_name,
             self.role_password.expose(),
-            self.address_public,
+            self.address_private,
             self.port,
             self.database_name,
         )

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -165,7 +165,7 @@ pub mod runtime {
             .context("creating runtime client endpoint")?
             .connect_timeout(Duration::from_secs(5));
 
-        // Wait for the spawned process to open the endpoint port.
+        // Wait for the spawned process to open the control port.
         // Connecting instantly does not give it enough time.
         let channel = tokio::time::timeout(Duration::from_millis(7000), async move {
             let mut ms = 5;
@@ -173,14 +173,14 @@ pub mod runtime {
                 if let Ok(channel) = conn.connect().await {
                     break channel;
                 }
-                trace!("waiting for runtime endpoint to open");
+                trace!("waiting for runtime control port to open");
                 // exponential backoff
                 tokio::time::sleep(Duration::from_millis(ms)).await;
                 ms *= 2;
             }
         })
         .await
-        .context("runtime client endpoint did not open in time")?;
+        .context("runtime control port did not open in time")?;
 
         let channel = ServiceBuilder::new()
             .layer(ClaimLayer)


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- resource list with show secrets now shows correct hostname
- a db url coming from c-s local provisioner is now shown
- if local_uri is a valid URL, its password is now hidden at runtime

- Checking for the runtime's version now errors if the check fails, for instance if the binary is not using shuttle-runtime or if the cargo config targets the wrong binary.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested all of the above on local projects
