### PR TITLE
fix(cargo-shuttle): revert shuttle-common-tests to path dep

### DIFF
--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -73,4 +73,5 @@ assert_cmd = "2.0.6"
 rexpect = "0.5.0"
 # Tmp until this branch is merged and released
 tokiotest-httpserver = { git = "https://github.com/shuttle-hq/tokiotest-httpserver", branch = "feat/body" }
+# Publication of this crate will fail if this is changed to a workspace dependency
 shuttle-common-tests = { path = "../common-tests" }

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -73,4 +73,4 @@ assert_cmd = "2.0.6"
 rexpect = "0.5.0"
 # Tmp until this branch is merged and released
 tokiotest-httpserver = { git = "https://github.com/shuttle-hq/tokiotest-httpserver", branch = "feat/body" }
-shuttle-common-tests = { workspace = true }
+shuttle-common-tests = { path = "../common-tests" }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

`cargo-shuttle` failed to publish with `shuttle-common-tests` as a workspace dependency.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested cargo publish with --dry-run, then published the crate on this branch.
