### PR TITLE
improvement: rocket 0.5.0-rc.4

### DIFF
--- a/services/shuttle-rocket/Cargo.toml
+++ b/services/shuttle-rocket/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "rocket"]
 [workspace]
 
 [dependencies]
-rocket = { version = "0.5.0-rc.2" }
+rocket = { version = "0.5.0-rc.4" }
 shuttle-runtime = { path = "../../runtime", version = "0.32.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Bumped rocket to version 0.5.0-rc.4 in the dependencies section of Cargo.toml, under /services/shuttle-rocket. I studied the list of breaking changes and they don't appear to impact implementation of the Shuttle Service trait for Rocket.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

There don't seem to be any integration tests within the services crate for shuttle-rocket.  There also doesn't seem to be any unit tests. I ran `make test` from the root of my repo, but the tests seemed to fail and I don't quite understand why. Doing a trial PR to trigger CI and see what I get.
