### PR TITLE
feat(runtime): export default tracing subscriber

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tower = { workspace = true }
-tracing-subscriber = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
 wasi-common = { version = "13.0.0", optional = true }
 wasmtime = { version = "13.0.0", optional = true }
 wasmtime-wasi = { version = "13.0.0", optional = true }
@@ -48,6 +48,8 @@ uuid = { workspace = true }
 
 [features]
 default = ["setup-tracing"]
+
+# shuttle-next framework
 next = [
     "cap-std",
     "futures",
@@ -59,8 +61,12 @@ next = [
     "wasmtime-wasi",
     "shuttle-common/wasm",
 ]
+
+# export the default tracing layer
+tracing-subscriber = ["dep:tracing-subscriber"]
+
+# initialze the default tracing layer on startup
 setup-tracing = [
-    "tracing-subscriber/default",
-    "tracing-subscriber/env-filter",
+    "tracing-subscriber",
     "colored",
 ]

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -72,21 +72,12 @@ pub async fn start(loader: impl Loader<ProvisionerFactory> + Send + 'static) {
     // this is handled after arg parsing to not interfere with --version above
     #[cfg(feature = "setup-tracing")]
     {
+        // Initialize our default subscriber
+        use tracing_subscriber::util::SubscriberInitExt;
+        crate::default_tracing_subscriber().init();
+
         use colored::Colorize;
-        use tracing_subscriber::prelude::*;
-
         colored::control::set_override(true); // always apply color
-
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::fmt::layer().without_time())
-            .with(
-                // let user override RUST_LOG in local run if they want to
-                tracing_subscriber::EnvFilter::try_from_default_env()
-                    // otherwise use our default
-                    .or_else(|_| tracing_subscriber::EnvFilter::try_new("info,shuttle=trace"))
-                    .unwrap(),
-            )
-            .init();
 
         println!(
             "{}\n\


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Export it in case someone wants to wrap it and re-use it. Adds a new feature "tracing-subscriber" for achieving this.

Not sure if this is useful

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

TODO
