### PR TITLE
feat: add limits and tier to jwt claim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -799,9 +799,9 @@ workflows:
     jobs:
       - approve-push-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -799,9 +799,9 @@ workflows:
     jobs:
       - approve-push-unstable:
           type: approval
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -105,7 +105,12 @@ pub(crate) async fn convert_cookie(
         .get::<AccountTier>("account_tier")
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(account_name, account_tier.into(), account_tier);
+    let claim = Claim::new(
+        account_name,
+        account_tier.into(),
+        account_tier,
+        account_tier,
+    );
 
     let token = claim.into_token(key_manager.private_key())?;
 
@@ -129,7 +134,12 @@ pub(crate) async fn convert_key(
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(name.to_string(), account_tier.into(), account_tier);
+    let claim = Claim::new(
+        name.to_string(),
+        account_tier.into(),
+        account_tier,
+        account_tier,
+    );
 
     let token = claim.into_token(key_manager.private_key())?;
 

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    user::{AccountName, AccountTier, Admin, Key, User},
+    user::{AccountName, Admin, Key, User},
 };
 use axum::{
     extract::{Path, State},
@@ -9,7 +9,10 @@ use axum::{
 use axum_sessions::extractors::{ReadableSession, WritableSession};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
-use shuttle_common::{claims::Claim, models::user};
+use shuttle_common::{
+    claims::{AccountTier, Claim},
+    models::user,
+};
 use stripe::CheckoutSession;
 use tracing::instrument;
 
@@ -102,7 +105,12 @@ pub(crate) async fn convert_cookie(
         .get::<AccountTier>("account_tier")
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(account_name, account_tier.into(), Some(account_tier.into()));
+    let claim = Claim::new(
+        account_name,
+        account_tier.into(),
+        Some(account_tier.into()),
+        Some(account_tier),
+    );
 
     let token = claim.into_token(key_manager.private_key())?;
 
@@ -130,6 +138,7 @@ pub(crate) async fn convert_key(
         name.to_string(),
         account_tier.into(),
         Some(account_tier.into()),
+        Some(account_tier),
     );
 
     let token = claim.into_token(key_manager.private_key())?;

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -102,7 +102,7 @@ pub(crate) async fn convert_cookie(
         .get::<AccountTier>("account_tier")
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(account_name, account_tier.into());
+    let claim = Claim::new(account_name, account_tier.into(), Some(account_tier.into()));
 
     let token = claim.into_token(key_manager.private_key())?;
 
@@ -126,7 +126,11 @@ pub(crate) async fn convert_key(
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(name.to_string(), account_tier.into());
+    let claim = Claim::new(
+        name.to_string(),
+        account_tier.into(),
+        Some(account_tier.into()),
+    );
 
     let token = claim.into_token(key_manager.private_key())?;
 

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -105,12 +105,7 @@ pub(crate) async fn convert_cookie(
         .get::<AccountTier>("account_tier")
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(
-        account_name,
-        account_tier.into(),
-        Some(account_tier.into()),
-        Some(account_tier),
-    );
+    let claim = Claim::new(account_name, account_tier.into(), account_tier);
 
     let token = claim.into_token(key_manager.private_key())?;
 
@@ -134,12 +129,7 @@ pub(crate) async fn convert_key(
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
-    let claim = Claim::new(
-        name.to_string(),
-        account_tier.into(),
-        Some(account_tier.into()),
-        Some(account_tier),
-    );
+    let claim = Claim::new(name.to_string(), account_tier.into(), account_tier);
 
     let token = claim.into_token(key_manager.private_key())?;
 

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -7,7 +7,7 @@ mod user;
 use std::{io, str::FromStr, time::Duration};
 
 use args::StartArgs;
-use shuttle_common::ApiKey;
+use shuttle_common::{claims::AccountTier, ApiKey};
 use sqlx::{
     migrate::Migrator,
     query,
@@ -19,7 +19,6 @@ use tracing::info;
 use crate::api::serve;
 pub use api::ApiBuilder;
 pub use args::{Args, Commands, InitArgs};
-pub use user::AccountTier;
 
 pub const COOKIE_EXPIRATION: Duration = Duration::from_secs(60 * 60 * 24); // One day
 

--- a/auth/src/main.rs
+++ b/auth/src/main.rs
@@ -1,11 +1,11 @@
 use std::io;
 
 use clap::Parser;
-use shuttle_common::{backends::tracing::setup_tracing, log::Backend};
+use shuttle_common::{backends::tracing::setup_tracing, claims::AccountTier, log::Backend};
 use sqlx::migrate::Migrator;
 use tracing::{info, trace};
 
-use shuttle_auth::{init, sqlite_init, start, AccountTier, Args, Commands};
+use shuttle_auth::{init, sqlite_init, start, Args, Commands};
 
 pub static MIGRATIONS: Migrator = sqlx::migrate!("./migrations");
 

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -8,12 +8,7 @@ use axum::{
     TypedHeader,
 };
 use serde::{Deserialize, Deserializer, Serialize};
-use shuttle_common::{
-    claims::{Limits, Scope, ScopeBuilder},
-    constants::limits::MAX_PROJECTS_EXTRA,
-    secrets::Secret,
-    ApiKey,
-};
+use shuttle_common::{claims::AccountTier, secrets::Secret, ApiKey};
 use sqlx::{query, sqlite::SqliteRow, FromRow, Row, SqlitePool};
 use tracing::{debug, error, trace, Span};
 
@@ -319,54 +314,6 @@ where
         trace!("got bearer key");
 
         Ok(Key(key))
-    }
-}
-
-#[derive(Clone, Copy, Deserialize, PartialEq, Eq, Serialize, Debug, sqlx::Type, strum::Display)]
-#[sqlx(rename_all = "lowercase")]
-#[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
-#[derive(Default)]
-pub enum AccountTier {
-    #[default]
-    Basic,
-    // A basic user that is pending a payment on the backend.
-    PendingPaymentPro,
-    Pro,
-    Team,
-    Admin,
-    Deployer,
-}
-
-impl From<AccountTier> for Vec<Scope> {
-    fn from(tier: AccountTier) -> Self {
-        let mut builder = ScopeBuilder::new();
-
-        if tier == AccountTier::Deployer {
-            builder = builder.with_deploy_rights();
-        } else {
-            builder = builder.with_basic();
-
-            if tier == AccountTier::Admin {
-                builder = builder.with_admin();
-            } else if tier == AccountTier::Pro {
-                builder = builder.with_pro();
-            }
-        }
-
-        builder.build()
-    }
-}
-
-impl From<AccountTier> for Limits {
-    fn from(value: AccountTier) -> Self {
-        match value {
-            AccountTier::Basic | AccountTier::PendingPaymentPro | AccountTier::Deployer => {
-                Self::default()
-            }
-            AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA),
-            AccountTier::Admin => Self::new(100),
-        }
     }
 }
 

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -9,7 +9,8 @@ use axum::{
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use shuttle_common::{
-    claims::{Scope, ScopeBuilder},
+    claims::{Limits, Scope, ScopeBuilder},
+    constants::limits::MAX_PROJECTS_EXTRA,
     secrets::Secret,
     ApiKey,
 };
@@ -354,6 +355,18 @@ impl From<AccountTier> for Vec<Scope> {
         }
 
         builder.build()
+    }
+}
+
+impl From<AccountTier> for Limits {
+    fn from(value: AccountTier) -> Self {
+        match value {
+            AccountTier::Basic | AccountTier::PendingPaymentPro | AccountTier::Deployer => {
+                Self::default()
+            }
+            AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA),
+            AccountTier::Admin => Self::new(100),
+        }
     }
 }
 

--- a/auth/tests/api/auth.rs
+++ b/auth/tests/api/auth.rs
@@ -42,32 +42,19 @@ async fn convert_api_key_to_jwt() {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
     // GET /auth/key with valid bearer token.
-    let request = Request::builder()
-        .uri("/auth/key")
-        .header(AUTHORIZATION, format!("Bearer {api_key}"))
-        .body(Body::empty())
-        .unwrap();
-
-    let response = app.send_request(request).await;
-
+    let response = app.get_jwt_from_api_key(api_key).await;
     assert_eq!(response.status(), StatusCode::OK);
 
+    // Decode the JWT into a Claim.
     let claim = app.claim_from_response(response).await;
 
-    // Verify the claim subject and tier matches the test user we created.
+    // Verify the claim subject and tier matches the test user we created at the start of the test.
     assert_eq!(claim.sub, "test-user");
     assert_eq!(claim.tier, AccountTier::Basic);
     assert_eq!(claim.project_limit(), 3);
 
     // GET /auth/key with an admin user bearer token.
-    let request = Request::builder()
-        .uri("/auth/key")
-        .header(AUTHORIZATION, format!("Bearer {ADMIN_KEY}"))
-        .body(Body::empty())
-        .unwrap();
-
-    let response = app.send_request(request).await;
-
+    let response = app.get_jwt_from_api_key(ADMIN_KEY).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     let claim = app.claim_from_response(response).await;

--- a/auth/tests/api/auth.rs
+++ b/auth/tests/api/auth.rs
@@ -2,7 +2,7 @@ use http::header::AUTHORIZATION;
 use http::{Request, StatusCode};
 use hyper::Body;
 use serde_json::Value;
-use shuttle_common::claims::{AccountTier, ClaimExt};
+use shuttle_common::claims::AccountTier;
 
 use crate::helpers::{app, ADMIN_KEY};
 
@@ -51,7 +51,7 @@ async fn convert_api_key_to_jwt() {
     // Verify the claim subject and tier matches the test user we created at the start of the test.
     assert_eq!(claim.sub, "test-user");
     assert_eq!(claim.tier, AccountTier::Basic);
-    assert_eq!(claim.project_limit(), 3);
+    assert_eq!(claim.limits.project_limit(), 3);
 
     // GET /auth/key with an admin user bearer token.
     let response = app.get_jwt_from_api_key(ADMIN_KEY).await;
@@ -62,5 +62,5 @@ async fn convert_api_key_to_jwt() {
     // Verify the claim subject and tier matches the admin user.
     assert_eq!(claim.sub, "admin");
     assert_eq!(claim.tier, AccountTier::Admin);
-    assert_eq!(claim.project_limit(), 3);
+    assert_eq!(claim.limits.project_limit(), 3);
 }

--- a/auth/tests/api/auth.rs
+++ b/auth/tests/api/auth.rs
@@ -62,5 +62,5 @@ async fn convert_api_key_to_jwt() {
     // Verify the claim subject and tier matches the admin user.
     assert_eq!(claim.sub, "admin");
     assert_eq!(claim.tier, AccountTier::Admin);
-    assert_eq!(claim.project_limit(), 100);
+    assert_eq!(claim.project_limit(), 3);
 }

--- a/auth/tests/api/auth.rs
+++ b/auth/tests/api/auth.rs
@@ -1,8 +1,10 @@
 use http::header::AUTHORIZATION;
 use http::{Request, StatusCode};
 use hyper::Body;
+use serde_json::Value;
+use shuttle_common::claims::{AccountTier, Claim};
 
-use crate::helpers::{app, ADMIN_KEY};
+use crate::helpers::app;
 
 #[tokio::test]
 async fn convert_api_key_to_jwt() {
@@ -12,6 +14,11 @@ async fn convert_api_key_to_jwt() {
     let response = app.post_user("test-user", "basic").await;
 
     assert_eq!(response.status(), StatusCode::OK);
+
+    // Extract the API key from the response so we can use it in a future request.
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let user: Value = serde_json::from_slice(&body).unwrap();
+    let api_key = user["key"].as_str().unwrap();
 
     // GET /auth/key without bearer token.
     let request = Request::builder()
@@ -37,7 +44,7 @@ async fn convert_api_key_to_jwt() {
     // GET /auth/key with valid bearer token.
     let request = Request::builder()
         .uri("/auth/key")
-        .header(AUTHORIZATION, format!("Bearer {ADMIN_KEY}"))
+        .header(AUTHORIZATION, format!("Bearer {api_key}"))
         .body(Body::empty())
         .unwrap();
 
@@ -45,5 +52,24 @@ async fn convert_api_key_to_jwt() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    // TODO: decode the JWT?
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let convert: Value = serde_json::from_slice(&body).unwrap();
+    let token = convert["token"].as_str().unwrap();
+
+    let request = Request::builder()
+        .uri("/public-key")
+        .method("GET")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.send_request(request).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let public_key = hyper::body::to_bytes(response.into_body()).await.unwrap();
+
+    let claim = Claim::from_token(token, &public_key).unwrap();
+
+    // Verify the claim subject and tier matches the test user we created.
+    assert_eq!(claim.sub, "test-user");
+    assert_eq!(claim.tier, AccountTier::Basic);
 }

--- a/auth/tests/api/helpers.rs
+++ b/auth/tests/api/helpers.rs
@@ -96,6 +96,15 @@ impl TestApp {
         self.send_request(request).await
     }
 
+    pub async fn get_jwt_from_api_key(&self, api_key: &str) -> Response {
+        let request = Request::builder()
+            .uri("/auth/key")
+            .header(AUTHORIZATION, format!("Bearer {api_key}"))
+            .body(Body::empty())
+            .unwrap();
+        self.send_request(request).await
+    }
+
     pub async fn claim_from_response(&self, res: Response) -> Claim {
         let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
         let convert: Value = serde_json::from_slice(&body).unwrap();

--- a/auth/tests/api/helpers.rs
+++ b/auth/tests/api/helpers.rs
@@ -1,13 +1,14 @@
 use std::{net::SocketAddr, str::FromStr};
 
 use axum::{body::Body, extract::Path, response::Response, routing::get, Router};
-use http::header::CONTENT_TYPE;
+use http::{header::CONTENT_TYPE, StatusCode};
 use hyper::{
     http::{header::AUTHORIZATION, Request},
     Server,
 };
 use serde_json::Value;
 use shuttle_auth::{sqlite_init, ApiBuilder};
+use shuttle_common::claims::Claim;
 use sqlx::query;
 use tower::ServiceExt;
 
@@ -93,6 +94,26 @@ impl TestApp {
             .unwrap();
 
         self.send_request(request).await
+    }
+
+    pub async fn claim_from_response(&self, res: Response) -> Claim {
+        let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        let convert: Value = serde_json::from_slice(&body).unwrap();
+        let token = convert["token"].as_str().unwrap();
+
+        let request = Request::builder()
+            .uri("/public-key")
+            .method("GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = self.send_request(request).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let public_key = hyper::body::to_bytes(response.into_body()).await.unwrap();
+
+        Claim::from_token(token, &public_key).unwrap()
     }
 }
 

--- a/auth/tests/api/session.rs
+++ b/auth/tests/api/session.rs
@@ -6,6 +6,7 @@ use shuttle_common::claims::Claim;
 
 use crate::helpers::app;
 
+// This test is ignored because we are not currently using the session flow.
 #[ignore]
 #[tokio::test]
 async fn session_flow() {

--- a/common-tests/src/lib.rs
+++ b/common-tests/src/lib.rs
@@ -57,8 +57,7 @@ where
         req.extensions_mut().insert(Claim::new(
             "test".to_string(),
             self.scopes.clone(),
-            None,
-            None,
+            Default::default(),
         ));
         self.inner.call(req)
     }

--- a/common-tests/src/lib.rs
+++ b/common-tests/src/lib.rs
@@ -2,7 +2,7 @@ pub mod builder;
 pub mod cargo_shuttle;
 pub mod logger;
 
-use shuttle_common::claims::{Claim, Scope};
+use shuttle_common::claims::{AccountTier, Claim, Scope};
 
 /// Layer to set JwtScopes on a request.
 /// For use in other tests
@@ -58,6 +58,7 @@ where
             "test".to_string(),
             self.scopes.clone(),
             Default::default(),
+            AccountTier::default(),
         ));
         self.inner.call(req)
     }

--- a/common-tests/src/lib.rs
+++ b/common-tests/src/lib.rs
@@ -54,8 +54,12 @@ where
     }
 
     fn call(&mut self, mut req: hyper::Request<hyper::Body>) -> Self::Future {
-        req.extensions_mut()
-            .insert(Claim::new("test".to_string(), self.scopes.clone(), None));
+        req.extensions_mut().insert(Claim::new(
+            "test".to_string(),
+            self.scopes.clone(),
+            None,
+            None,
+        ));
         self.inner.call(req)
     }
 }

--- a/common-tests/src/lib.rs
+++ b/common-tests/src/lib.rs
@@ -55,7 +55,7 @@ where
 
     fn call(&mut self, mut req: hyper::Request<hyper::Body>) -> Self::Future {
         req.extensions_mut()
-            .insert(Claim::new("test".to_string(), self.scopes.clone()));
+            .insert(Claim::new("test".to_string(), self.scopes.clone(), None));
         self.inner.call(req)
     }
 }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -64,7 +64,8 @@ backend = [
     "tracing-subscriber/fmt",
     "ttl_cache",
     "sqlx",
-    "sqlx/postgres",                 # Fix for derive macro error when different backends enable sqlite & postgres (mainly for grouped compilation in clippy CI and Docker build)
+    "sqlx/postgres",            # Fix for derive macro error when different backends enable sqlite & postgres (mainly for grouped compilation in clippy CI and Docker build)
+    "sqlx/sqlite",
 ]
 claims = [
     "bytes",

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -477,8 +477,7 @@ mod tests {
         let mut claim = Claim::new(
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
-            None,
-            None,
+            Default::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -501,8 +500,7 @@ mod tests {
         let claim = Claim::new(
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
-            None,
-            None,
+            Default::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -601,8 +599,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-hs256".to_string(),
             vec![Scope::Deployment, Scope::Project],
-            None,
-            None,
+            Default::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -643,8 +640,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-no-alg".to_string(),
             vec![Scope::Deployment, Scope::Project],
-            None,
-            None,
+            Default::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -677,8 +673,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-no-sig".to_string(),
             vec![Scope::Deployment, Scope::Project],
-            None,
-            None,
+            Default::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -702,8 +697,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-iss".to_string(),
             vec![Scope::Deployment, Scope::Project],
-            None,
-            None,
+            Default::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -468,7 +468,7 @@ mod tests {
     use serde_json::json;
     use tower::{ServiceBuilder, ServiceExt};
 
-    use crate::claims::{Claim, Scope};
+    use crate::claims::{AccountTier, Claim, Scope};
 
     use super::{JwtAuthenticationLayer, ScopedLayer};
 
@@ -478,6 +478,7 @@ mod tests {
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
             Default::default(),
+            AccountTier::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -501,6 +502,7 @@ mod tests {
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
             Default::default(),
+            AccountTier::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -600,6 +602,7 @@ mod tests {
             "hacker-hs256".to_string(),
             vec![Scope::Deployment, Scope::Project],
             Default::default(),
+            AccountTier::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -641,6 +644,7 @@ mod tests {
             "hacker-no-alg".to_string(),
             vec![Scope::Deployment, Scope::Project],
             Default::default(),
+            AccountTier::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -674,6 +678,7 @@ mod tests {
             "hacker-no-sig".to_string(),
             vec![Scope::Deployment, Scope::Project],
             Default::default(),
+            AccountTier::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -698,6 +703,7 @@ mod tests {
             "hacker-iss".to_string(),
             vec![Scope::Deployment, Scope::Project],
             Default::default(),
+            AccountTier::default(),
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -477,6 +477,7 @@ mod tests {
         let mut claim = Claim::new(
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -499,6 +500,7 @@ mod tests {
         let claim = Claim::new(
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -597,6 +599,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-hs256".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -637,6 +640,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-no-alg".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -669,6 +673,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-no-sig".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -692,6 +697,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-iss".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -478,6 +478,7 @@ mod tests {
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
             None,
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -500,6 +501,7 @@ mod tests {
         let claim = Claim::new(
             "ferries".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
             None,
         );
 
@@ -600,6 +602,7 @@ mod tests {
             "hacker-hs256".to_string(),
             vec![Scope::Deployment, Scope::Project],
             None,
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -641,6 +644,7 @@ mod tests {
             "hacker-no-alg".to_string(),
             vec![Scope::Deployment, Scope::Project],
             None,
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -674,6 +678,7 @@ mod tests {
             "hacker-no-sig".to_string(),
             vec![Scope::Deployment, Scope::Project],
             None,
+            None,
         );
 
         let doc = signature::Ed25519KeyPair::generate_pkcs8(&rand::SystemRandom::new()).unwrap();
@@ -697,6 +702,7 @@ mod tests {
         let claim = Claim::new(
             "hacker-iss".to_string(),
             vec![Scope::Deployment, Scope::Project],
+            None,
             None,
         );
 

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -254,7 +254,6 @@ impl Default for Limits {
     }
 }
 
-// TODO: this will be expanded and the limits set will vary, use builder pattern?
 impl Limits {
     pub fn new(project_limit: u32) -> Self {
         Self { project_limit }

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -189,11 +189,11 @@ pub enum AccountTier {
 impl From<AccountTier> for Limits {
     fn from(value: AccountTier) -> Self {
         match value {
-            AccountTier::Basic | AccountTier::PendingPaymentPro | AccountTier::Deployer => {
-                Self::default()
-            }
+            AccountTier::Admin
+            | AccountTier::Basic
+            | AccountTier::PendingPaymentPro
+            | AccountTier::Deployer => Self::default(),
             AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA),
-            AccountTier::Admin => Self::new(100),
         }
     }
 }

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -20,7 +20,7 @@ use tower::{Layer, Service};
 use tracing::{error, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::constants::limits::{MAX_PROJECTS_DEFAULT, MAX_PROJECTS_EXTRA};
+use crate::limits::Limits;
 
 /// Minutes before a claim expires
 ///
@@ -186,18 +186,6 @@ pub enum AccountTier {
     Deployer,
 }
 
-impl From<AccountTier> for Limits {
-    fn from(value: AccountTier) -> Self {
-        match value {
-            AccountTier::Admin
-            | AccountTier::Basic
-            | AccountTier::PendingPaymentPro
-            | AccountTier::Deployer => Self::default(),
-            AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA),
-        }
-    }
-}
-
 impl From<AccountTier> for Vec<Scope> {
     fn from(tier: AccountTier) -> Self {
         let mut builder = ScopeBuilder::new();
@@ -238,36 +226,6 @@ pub struct Claim {
     pub limits: Limits,
     /// The account tier of the subject.
     pub tier: AccountTier,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct Limits {
-    /// The amount of projects this user can create.
-    project_limit: u32,
-}
-
-impl Default for Limits {
-    fn default() -> Self {
-        Self {
-            project_limit: MAX_PROJECTS_DEFAULT,
-        }
-    }
-}
-
-impl Limits {
-    pub fn new(project_limit: u32) -> Self {
-        Self { project_limit }
-    }
-}
-
-pub trait ClaimExt {
-    fn project_limit(&self) -> u32;
-}
-
-impl ClaimExt for Claim {
-    fn project_limit(&self) -> u32 {
-        self.limits.project_limit
-    }
 }
 
 impl Claim {

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -230,7 +230,12 @@ pub struct Claim {
 
 impl Claim {
     /// Create a new claim for a user with the given scopes and limits.
-    pub fn new(sub: String, scopes: Vec<Scope>, tier: AccountTier) -> Self {
+    pub fn new(
+        sub: String,
+        scopes: Vec<Scope>,
+        tier: AccountTier,
+        limits: impl Into<Limits>,
+    ) -> Self {
         let iat = Utc::now();
         let exp = iat.add(Duration::minutes(EXP_MINUTES));
 
@@ -242,7 +247,7 @@ impl Claim {
             sub,
             scopes,
             token: None,
-            limits: tier.into(),
+            limits: limits.into(),
             tier,
         }
     }

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -273,12 +273,7 @@ impl ClaimExt for Claim {
 
 impl Claim {
     /// Create a new claim for a user with the given scopes and limits.
-    pub fn new(
-        sub: String,
-        scopes: Vec<Scope>,
-        limits: Option<Limits>,
-        tier: Option<AccountTier>,
-    ) -> Self {
+    pub fn new(sub: String, scopes: Vec<Scope>, tier: AccountTier) -> Self {
         let iat = Utc::now();
         let exp = iat.add(Duration::minutes(EXP_MINUTES));
 
@@ -290,8 +285,8 @@ impl Claim {
             sub,
             scopes,
             token: None,
-            limits: limits.unwrap_or_default(),
-            tier: tier.unwrap_or_default(),
+            limits: tier.into(),
+            tier,
         }
     }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,6 +19,8 @@ pub mod models;
 pub mod resource;
 pub mod secrets;
 pub use secrets::{Secret, SecretStore};
+#[cfg(feature = "claims")]
+pub mod limits;
 #[cfg(feature = "tracing")]
 pub mod tracing;
 #[cfg(feature = "wasm")]

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -57,4 +57,3 @@ impl ClaimExt for Claim {
         self.is_admin() || self.limits.project_limit() > current_count
     }
 }
-// TODO: limits.rs, move limits in here too

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    claims::{AccountTier, Claim, Scope},
+    constants::limits::{MAX_PROJECTS_DEFAULT, MAX_PROJECTS_EXTRA},
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct Limits {
+    /// The amount of projects this user can create.
+    project_limit: u32,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            project_limit: MAX_PROJECTS_DEFAULT,
+        }
+    }
+}
+
+impl Limits {
+    pub fn new(project_limit: u32) -> Self {
+        Self { project_limit }
+    }
+
+    pub fn project_limit(&self) -> u32 {
+        self.project_limit
+    }
+}
+
+impl From<AccountTier> for Limits {
+    fn from(value: AccountTier) -> Self {
+        match value {
+            AccountTier::Admin
+            | AccountTier::Basic
+            | AccountTier::PendingPaymentPro
+            | AccountTier::Deployer => Self::default(),
+            AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA),
+        }
+    }
+}
+
+pub trait ClaimExt {
+    /// Verify that the [Claim] has the [Scope::Admin] scope.
+    fn is_admin(&self) -> bool;
+    /// Verify that the user's current project count is lower than the account limit in [Claim::limits].
+    fn can_create_project(&self, current_count: u32) -> bool;
+}
+
+impl ClaimExt for Claim {
+    fn is_admin(&self) -> bool {
+        self.scopes.contains(&Scope::Admin)
+    }
+
+    fn can_create_project(&self, current_count: u32) -> bool {
+        self.is_admin() || self.limits.project_limit() > current_count
+    }
+}
+// TODO: limits.rs, move limits in here too

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -186,7 +186,7 @@ async fn get_projects_list(
     Ok(AxumJson(projects))
 }
 
-#[instrument(skip_all, fields(%project_name, %claim.tier))]
+#[instrument(skip_all, fields(%project_name))]
 #[utoipa::path(
     post,
     path = "/projects/{project_name}",

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -20,8 +20,7 @@ use serde::{Deserialize, Serialize};
 use shuttle_common::backends::auth::{AuthPublicKey, JwtAuthenticationLayer, ScopedLayer};
 use shuttle_common::backends::cache::CacheManager;
 use shuttle_common::backends::metrics::{Metrics, TraceLayer};
-use shuttle_common::claims::{Scope, EXP_MINUTES};
-use shuttle_common::constants::limits::{MAX_PROJECTS_DEFAULT, MAX_PROJECTS_EXTRA};
+use shuttle_common::claims::{ClaimExt, Scope, EXP_MINUTES};
 use shuttle_common::models::error::axum::CustomErrorPath;
 use shuttle_common::models::error::ErrorKind;
 use shuttle_common::models::{
@@ -210,10 +209,8 @@ async fn create_project(
     let is_admin = claim.scopes.contains(&Scope::Admin);
     let project_limit: Option<u32> = if is_admin {
         None
-    } else if claim.scopes.contains(&Scope::ExtraProjects) {
-        Some(MAX_PROJECTS_EXTRA)
     } else {
-        Some(MAX_PROJECTS_DEFAULT)
+        Some(claim.project_limit())
     };
 
     let project = service

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -186,7 +186,7 @@ async fn get_projects_list(
     Ok(AxumJson(projects))
 }
 
-#[instrument(skip_all, fields(%project_name))]
+#[instrument(skip_all, fields(%project_name, %claim.tier))]
 #[utoipa::path(
     post,
     path = "/projects/{project_name}",

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -675,7 +675,7 @@ pub mod tests {
                         let state = state.lock().unwrap();
 
                         if let Some(scopes) = state.users.get(bearer.token()) {
-                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), None, None);
+                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), Default::default());
                             let token = claim.into_token(&state.encoding_key)?;
                             Ok(serde_json::to_vec(&ConvertResponse { token }).unwrap())
                         } else {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -275,7 +275,7 @@ pub mod tests {
     use rand::distributions::{Alphanumeric, DistString, Distribution, Uniform};
     use ring::signature::{self, Ed25519KeyPair, KeyPair};
     use shuttle_common::backends::auth::ConvertResponse;
-    use shuttle_common::claims::{Claim, Scope};
+    use shuttle_common::claims::{AccountTier, Claim, Scope};
     use shuttle_common::models::project;
     use sqlx::sqlite::SqliteConnectOptions;
     use sqlx::SqlitePool;
@@ -675,7 +675,7 @@ pub mod tests {
                         let state = state.lock().unwrap();
 
                         if let Some(scopes) = state.users.get(bearer.token()) {
-                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), Default::default());
+                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), AccountTier::default(), AccountTier::default());
                             let token = claim.into_token(&state.encoding_key)?;
                             Ok(serde_json::to_vec(&ConvertResponse { token }).unwrap())
                         } else {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -675,7 +675,7 @@ pub mod tests {
                         let state = state.lock().unwrap();
 
                         if let Some(scopes) = state.users.get(bearer.token()) {
-                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), None);
+                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), None, None);
                             let token = claim.into_token(&state.encoding_key)?;
                             Ok(serde_json::to_vec(&ConvertResponse { token }).unwrap())
                         } else {

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -675,7 +675,7 @@ pub mod tests {
                         let state = state.lock().unwrap();
 
                         if let Some(scopes) = state.users.get(bearer.token()) {
-                            let claim = Claim::new(bearer.token().to_string(), scopes.clone());
+                            let claim = Claim::new(bearer.token().to_string(), scopes.clone(), None);
                             let token = claim.into_token(&state.encoding_key)?;
                             Ok(serde_json::to_vec(&ConvertResponse { token }).unwrap())
                         } else {


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Add a `Limits` struct that will hold all the account limits to the JWT `Claim`, and also add the `AccountTier` (moved to shuttle-common) to the `Claim`, so we can use it in instrumentation. I left adding it to instrumentation out of this PR, that will be done in a follow-up.

I used an extension trait for the methods to extract the limits from the `Claim`. This allows us to have the methods for extracting limits from the claim only available where they are needed. An alternative would be to implement the methods on Claim directly, or make the fields of `Claim` public, but that would make us more exposed to [breaking changes](https://github.com/rust-lang/rfcs/blob/master/text/1105-api-evolution.md#structs). I'm not sure that breaking changes will be an issue here, though, since we create the limits from the tier. Thoughts on this subject are very welcome!

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Updated the `auth` test to verify that the limits and tier are correctly set for an admin and for a basic user, and verified that the gateway tests that test project limit still pass. 

Additionally, I tested deploying a hello-world and postgres project to staging on an old deployer, as well as a new deployer (after deploying this branch to staging).


