### PR TITLE
fix(gateway): use project_id argument when inserting project

### DIFF
--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -579,7 +579,8 @@ impl GatewayService {
             ),
         ));
 
-        query("INSERT INTO projects (project_id, project_name, account_name, initial_key, project_state) VALUES (ulid(), ?1, ?2, ?3, ?4)")
+        query("INSERT INTO projects (project_id, project_name, account_name, initial_key, project_state) VALUES (?1, ?2, ?3, ?4, ?5)")
+            .bind(&project_id.to_string())
             .bind(&project_name)
             .bind(&account_name)
             .bind(project.initial_key().unwrap())


### PR DESCRIPTION
## Description of change

This should only fix the lowercase Ulid issue, but not the duplicate insertion.


## How has this been tested? (if applicable)

Not at all yet.


