### PR TITLE
feat(cargo-shuttle): generate manpage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "clap_mangen",
  "crossterm 0.27.0",
  "dialoguer",
  "dirs 5.0.1",
@@ -1304,6 +1305,16 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3be86020147691e1d2ef58f75346a3d4d94807bfc473e377d52f09f0f7d77f7"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "clru"
@@ -5124,6 +5135,12 @@ dependencies = [
  "rmp",
  "serde",
 ]
+
+[[package]]
+name = "roff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b833d8d034ea094b1ea68aa6d5c740e0d04bad9d16568d08ba6f76823a114316"
 
 [[package]]
 name = "rsa"

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -20,6 +20,7 @@ cargo_metadata = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true, features = ["env"] }
 clap_complete = "4.3.1"
+clap_mangen = "0.2.15"
 crossterm = { workspace = true }
 dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
 dirs = { workspace = true }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -131,7 +131,7 @@ pub enum Command {
     Login(LoginArgs),
     /// Log out of the Shuttle platform
     Logout(LogoutArgs),
-    /// Generate shell completions
+    /// Generate shell completions and manpage
     Generate {
         /// Which shell
         #[arg(short, long, env, default_value_t = Shell::Bash)]
@@ -139,6 +139,10 @@ pub enum Command {
         /// Output to a file (stdout by default)
         #[arg(short, long, env)]
         output: Option<PathBuf>,
+        /// Generate manpage in the directory specified by the `OUT_DIR`
+        /// environment variable (current working directory by default)
+        #[arg(short, long)]
+        manpage: bool,
     },
     /// Open an issue on GitHub and provide feedback
     Feedback,


### PR DESCRIPTION
Add the ability to generate man page for `cargo-shuttle`.

## Description of change
Introduces a new option `--manpage` for the `generate` sub-command to generate man page with [clap-mangen](https://crates.io/crates/clap-mangen).

To verify the changes, we can run the following from the project root `shuttle`:
```sh
cargo run --package cargo-shuttle -- generate --manpage
```
This generates the man page in the current working directory by default. We can set a custom directory by setting the `OUT_DIR` environment variable:
```sh
OUT_DIR=PATH_TO_CUSTOM_DIR cargo run --package cargo-shuttle -- generate --manpage
```
Closes #1377.

## How has this been tested? (if applicable)
Please see the change description above.

