### PR TITLE
misc(auth): added service healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,8 +55,8 @@ services:
       - "--stripe-secret-key=${STRIPE_SECRET_KEY}"
     healthcheck:
       test: curl --fail http://localhost:8000/ || exit 1
-      interval: 1m
-      timeout: 15s
+      interval: 15s
+      timeout: 10s
       retries: 15
   builder:
     image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,9 +55,11 @@ services:
       - "--stripe-secret-key=${STRIPE_SECRET_KEY}"
     healthcheck:
       test: curl --fail http://localhost:8000/ || exit 1
-      interval: 15s
+      interval: 1m
       timeout: 10s
-      retries: 15
+      retries: 5
+      start_period: 10s
+      start_interval: 2s
   builder:
     image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,11 @@ services:
       - "start"
       - "--address=0.0.0.0:8000"
       - "--stripe-secret-key=${STRIPE_SECRET_KEY}"
+    healthcheck:
+      test: curl --fail http://localhost:8000/ || exit 1
+      interval: 1m
+      timeout: 15s
+      retries: 15
   builder:
     image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"
     depends_on:


### PR DESCRIPTION
## Description of change

Use an auth service health-check when deploying the stack.


## How has this been tested? (if applicable)

Locally, by querying the container state before and after the health check addition.
E.g. before the health-check, this `docker inspect --format='{{json .State.Health}}' <container_id>`, returns `null`,  while after adding the healthcheck, it shows something along:
```
{"Status":"healthy","FailingStreak":0,"Log":[{"Start":"2023-11-16T15:10:22.278007509Z","End":"2023-11-16T15:10:22.362298051Z","ExitCode":0,"Output":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n"},{"Start":"2023-11-16T15:11:22.371958801Z","End":"2023-11-16T15:11:22.447879968Z","ExitCode":0,"Output":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n"},{"Start":"2023-11-16T15:12:22.456275676Z","End":"2023-11-16T15:12:22.543789593Z","ExitCode":0,"Output":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n"},{"Start":"2023-11-16T15:14:17.750973049Z","End":"2023-11-16T15:14:17.832457424Z","ExitCode":0,"Output":"  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\n"}]}
```


