### PR TITLE
fix(gateway): handle invalid project names in ScopedUser

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Display, Formatter};
 
-use crossterm::style::{Color, Stylize};
+use crossterm::style::Stylize;
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
@@ -23,7 +23,7 @@ impl Display for ApiError {
             f,
             "{}\nMessage: {}",
             self.status().to_string().bold(),
-            self.message.to_string().with(Color::Red)
+            self.message.to_string().red()
         )
     }
 }

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use shuttle_common::claims::{Claim, Scope};
 use shuttle_common::models::error::InvalidProjectName;
 use shuttle_common::models::project::ProjectName;
-use tracing::{trace, warn, Span};
+use tracing::{trace, Span};
 
 use crate::api::latest::RouterState;
 use crate::{AccountName, Error, ErrorKind};

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -81,10 +81,7 @@ where
             Err(_) => Path::<(ProjectName, String)>::from_request_parts(parts, state)
                 .await
                 .map(|Path((p, _))| p)
-                .map_err(|e| {
-                    warn!(error = ?e, "failed to extract project name for scoped user");
-                    Error::from(ErrorKind::InvalidProjectName(InvalidProjectName))
-                })?,
+                .map_err(|_| Error::from(ErrorKind::InvalidProjectName(InvalidProjectName)))?,
         };
 
         if user.projects.contains(&scope) || user.claim.scopes.contains(&Scope::Admin) {

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -313,7 +313,7 @@ impl GatewayService {
                     .try_get::<SqlxJson<Project>, _>("project_state")
                     .map(|p| p.0)
                     .unwrap_or_else(|e| {
-                        error!("Failed to deser `project_state`: {:?}", e);
+                        error!(error = ?e, "Failed to deser `project_state`");
                         Project::Errored(ProjectError::internal(
                             "Error when trying to deserialize state of project.",
                         ))
@@ -364,7 +364,7 @@ impl GatewayService {
                     row.try_get::<SqlxJson<Project>, _>("project_state")
                         .map(|p| p.0)
                         .unwrap_or_else(|e| {
-                            error!("Failed to deser `project_state`: {:?}", e);
+                            error!(error = ?e, "Failed to deser `project_state`");
                             Project::Errored(ProjectError::internal(
                                 "Error when trying to deserialize state of project.",
                             ))
@@ -459,7 +459,7 @@ impl GatewayService {
                 .try_get::<SqlxJson<Project>, _>("project_state")
                 .map(|p| p.0)
                 .unwrap_or_else(|e| {
-                    error!("Failed to deser `project_state`: {:?}", e);
+                    error!(error = ?e, "Failed to deser `project_state`");
                     Project::Errored(ProjectError::internal(
                         "Error when trying to deserialize state of project.",
                     ))


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Fixes endpoints with ScopedUser that are called with an invalid project name. Returns proper project name error instead of panic. The error is also properly logged instead of a panic printout.

Bonus change: red :red_square: 

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
Before:
```
cs --name äö project status

Getting project status failed

If getting project status failed repeatedly, please check Shuttle status at https://status.shuttle.rs before contacting the team on the Discord server.
Error: 502 Bad Gateway
Message: response from gateway is invalid. Please create a ticket to report this
```
After:
```
cs --name äö project status
INFO: Targeting non-standard API: http://localhost:8001

Getting project status failed

If getting project status failed repeatedly, please check Shuttle status at https://status.shuttle.rs before contacting the team on the Discord server.
Error: 400 Bad Request
Message: Invalid project name. Project names must:
    1. only contain lowercase alphanumeric characters or dashes `-`.
    2. not start or end with a dash.
    3. not be empty.
    4. be shorter than 64 characters.
    5. not contain any profanities.
    6. not be a reserved word.
```

Both of these give 400 instead of no response:
`curl -v -H 'Authorization: Bearer dh9z58jttoes3qvt' localhost:8001/projects/äö`
`curl -v -H 'Authorization: Bearer dh9z58jttoes3qvt' localhost:8001/projects/äö/services/äö`
