### PR TITLE
feat: limit rds access to pro users

### DIFF
--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -15,7 +15,10 @@ use tower::{Layer, Service};
 use tracing::{error, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::claims::{Claim, Scope};
+use crate::{
+    claims::{Claim, Scope},
+    limits::ClaimExt,
+};
 
 use super::{
     cache::{CacheManagement, CacheManager},
@@ -428,6 +431,8 @@ pub trait VerifyClaim {
     type Error;
 
     fn verify(&self, required_scope: Scope) -> Result<(), Self::Error>;
+
+    fn verify_rds_access(&self) -> Result<(), Self::Error>;
 }
 
 #[cfg(feature = "tonic")]
@@ -451,6 +456,21 @@ impl<B> VerifyClaim for tonic::Request<B> {
                     .get_documentation()
                     .unwrap_or("perform this operation")
             )))
+        }
+    }
+
+    fn verify_rds_access(&self) -> Result<(), Self::Error> {
+        let claim = self
+            .extensions()
+            .get::<Claim>()
+            .ok_or_else(|| tonic::Status::internal("could not get claim"))?;
+
+        if claim.can_provision_rds() {
+            Ok(())
+        } else {
+            Err(tonic::Status::permission_denied(
+                "don't have permission to provision rds instances",
+            ))
         }
     }
 }

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -9,23 +9,33 @@ use crate::{
 pub struct Limits {
     /// The amount of projects this user can create.
     project_limit: u32,
+    /// Whether this user has permission to provision RDS instances.
+    rds_access: bool,
 }
 
 impl Default for Limits {
     fn default() -> Self {
         Self {
             project_limit: MAX_PROJECTS_DEFAULT,
+            rds_access: false,
         }
     }
 }
 
 impl Limits {
-    pub fn new(project_limit: u32) -> Self {
-        Self { project_limit }
+    pub fn new(project_limit: u32, rds_limit: bool) -> Self {
+        Self {
+            project_limit,
+            rds_access: rds_limit,
+        }
     }
 
     pub fn project_limit(&self) -> u32 {
         self.project_limit
+    }
+
+    pub fn rds_access(&self) -> bool {
+        self.rds_access
     }
 }
 
@@ -36,7 +46,7 @@ impl From<AccountTier> for Limits {
             | AccountTier::Basic
             | AccountTier::PendingPaymentPro
             | AccountTier::Deployer => Self::default(),
-            AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA),
+            AccountTier::Pro | AccountTier::Team => Self::new(MAX_PROJECTS_EXTRA, true),
         }
     }
 }
@@ -46,6 +56,8 @@ pub trait ClaimExt {
     fn is_admin(&self) -> bool;
     /// Verify that the user's current project count is lower than the account limit in [Claim::limits].
     fn can_create_project(&self, current_count: u32) -> bool;
+    /// Verify that the user has permission to provision RDS instances.
+    fn can_provision_rds(&self) -> bool;
 }
 
 impl ClaimExt for Claim {
@@ -55,5 +67,9 @@ impl ClaimExt for Claim {
 
     fn can_create_project(&self, current_count: u32) -> bool {
         self.is_admin() || self.limits.project_limit() > current_count
+    }
+
+    fn can_provision_rds(&self) -> bool {
+        self.is_admin() || self.limits.rds_access
     }
 }

--- a/provisioner/src/lib.rs
+++ b/provisioner/src/lib.rs
@@ -456,6 +456,8 @@ impl Provisioner for MyProvisioner {
     ) -> Result<Response<DatabaseResponse>, Status> {
         request.verify(Scope::ResourcesWrite)?;
 
+        let can_provision_rds = request.verify_rds_access();
+
         let request = request.into_inner();
         if !ProjectName::is_valid(&request.project_name) {
             return Err(Status::invalid_argument("invalid project name"));
@@ -468,6 +470,7 @@ impl Provisioner for MyProvisioner {
                     .await?
             }
             DbType::AwsRds(AwsRds { engine }) => {
+                can_provision_rds?;
                 self.request_aws_rds(&request.project_name, engine.expect("engine to be set"))
                     .await?
             }

--- a/resource-recorder/src/lib.rs
+++ b/resource-recorder/src/lib.rs
@@ -6,7 +6,7 @@ use shuttle_proto::resource_recorder::{
     self, resource_recorder_server::ResourceRecorder, ProjectResourcesRequest, RecordRequest,
     ResourceIds, ResourceResponse, ResourcesResponse, ResultResponse, ServiceResourcesRequest,
 };
-use std::convert::TryInto;
+use std::{convert::TryInto, str::FromStr};
 use thiserror::Error;
 use tonic::{Request, Response, Status};
 
@@ -134,7 +134,26 @@ where
     ) -> Result<Response<ResultResponse>, Status> {
         request.verify(Scope::ResourcesWrite)?;
 
+        let can_provision_rds = request.verify_rds_access();
+
         let request = request.into_inner();
+
+        if let Err(error) = can_provision_rds {
+            if request.resources.iter().any(|resource| {
+                let Ok(r#type) = shuttle_common::database::Type::from_str(resource.r#type.as_str())
+                else {
+                    return false;
+                };
+
+                matches!(r#type, shuttle_common::database::Type::AwsRds(_))
+            }) {
+                return Ok(Response::new(ResultResponse {
+                    success: false,
+                    message: error.message().to_string(),
+                }));
+            }
+        };
+
         let result = match self.add(request).await {
             Ok(()) => ResultResponse {
                 success: true,


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Adds an `rds_access` field to the `Claim::Limits` struct, which will only be true for pro and team users. This enables us to restrict provisioning of RDS instances to pro/team users.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested with local environment, it errors for free users:
```
2023-11-21T16:08:14.944+01:00 [Deployer]  INFO shuttle_deployer::deployment::run: Loading resources
2023-11-21T16:08:14.944+01:00 [Deployer]  INFO shuttle_deployer::persistence: {service_id="01HFS6P6VQWVCPM8S9B9G4SEFF"} Getting resources from resource-recorder
2023-11-21T16:08:14.952+01:00 [Deployer]  INFO shuttle_deployer::persistence: Got no resources from resource-recorder
2023-11-21T16:08:14.953+01:00 [Deployer]  INFO shuttle_deployer::persistence: {resources="Ok([])"} Local resources
2023-11-21T16:08:14.955+01:00 [Runtime] TRACE shuttle_common::backends::auth: inserting public key from auth service into cache
2023-11-21T16:08:14.955+01:00 [Runtime] TRACE shuttle_common::claims: converting token to claim
2023-11-21T16:08:14.955+01:00 [Runtime] loading alpha service at /opt/shuttle/shuttle-builds/postgres-tide-app/.shuttle-executables/06f47cde-d7fe-4f5f-9641-2d5f282e1c15
2023-11-21T16:08:14.956+01:00 [Runtime] [Resource][database::aws_rds::postgres] Getting resource
2023-11-21T16:08:14.956+01:00 [Runtime] [Resource][database::aws_rds::postgres] Using config: {"local_uri":null}
2023-11-21T16:08:14.956+01:00 [Runtime] [Resource][database::aws_rds::postgres] Past output for config does not exist
2023-11-21T16:08:14.956+01:00 [Runtime] [Resource][database::aws_rds::postgres] Provisioning. This can take a while...
2023-11-21T16:08:15.016+01:00 [Runtime] loading service failed: failed to provision shuttle_aws_rds :: Postgres: failed to provision resource: status: PermissionDenied, message: "don't have permission to provision rds instances", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Tue, 21 Nov 2023 15:08:15 GMT", "content-length": "0"} }
2023-11-21T16:08:15.017+01:00 [Deployer]  INFO shuttle_deployer::persistence: Uploading resources to resource-recorder
2023-11-21T16:08:15.021+01:00 [Deployer] ERROR shuttle_deployer::deployment::run: {error="failed to provision shuttle_aws_rds :: Postgres"} failed to load service
2023-11-21T16:08:15.022+01:00 [Deployer]  INFO Entering Crashed state
2023-11-21T16:08:15.022+01:00 [Deployer]  INFO Cleaning up startup crashed deployment
2023-11-21T16:08:15.022+01:00 [Deployer] ERROR shuttle_deployer::deployment::run: {error="Load error: failed to provision shuttle_aws_rds :: Postgres"} Service startup encountered an error

Deployment crashed

Run the following for more details

cargo shuttle logs 06f47cde-d7fe-4f5f-9641-2d5f282e1c15
```