### PR TITLE
feat: remove panamax registry override from deployers

### DIFF
--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -26,19 +26,3 @@ curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-
 
 # Common cargo build tools
 cargo binstall -y --locked trunk@0.17.5
-
-while getopts "p," o; do
-case $o in
-    "p") # if panamax is used, the '-p' parameter is passed
-        # Make future crates requests to our own mirror
-        # This is done after shuttle-next install in order to not sabotage it
-        echo '
-[source.shuttle-crates-io-mirror]
-registry = "sparse+http://panamax:8080/index/"
-[source.crates-io]
-replace-with = "shuttle-crates-io-mirror"' >> $CARGO_HOME/config.toml
-            ;;
-        *)
-            ;;
-    esac
-done


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Remove the panamax registry override from the deployers. This PR does not remove panamax entirely, we should hold off on that until we are confident in our migration to crates.io.


