### PR TITLE
fix(cargo-shuttle): cargo shuttle clean response type

### DIFF
--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -140,7 +140,7 @@ impl Client {
             .await
     }
 
-    pub async fn clean_project(&self, project: &str) -> Result<Vec<String>> {
+    pub async fn clean_project(&self, project: &str) -> Result<String> {
         let path = format!("/projects/{project}/clean");
 
         self.post(path, Option::<String>::None)

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -633,7 +633,7 @@ impl Shuttle {
 
     async fn clean(&self) -> Result<CommandOutcome> {
         let client = self.client.as_ref().unwrap();
-        let lines = client
+        let message = client
             .clean_project(self.ctx.project_name())
             .await
             .map_err(|err| {
@@ -644,12 +644,7 @@ impl Shuttle {
                     "cleaning your project or checking its status fail repeatedly",
                 )
             })?;
-
-        for line in lines {
-            println!("{line}");
-        }
-
-        println!("Cleaning done!");
+        println!("{message}");
 
         Ok(CommandOutcome::Ok)
     }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Reported in Discord. Forgot this part of the change when I cleaned up deployer's cargo commands.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Response parsing does not error after the change
