### PR TITLE
 feat(cargo-shuttle): ability to force a name to be used in init

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -277,6 +277,9 @@ pub struct InitArgs {
     #[arg(default_value = ".", value_parser = OsStringValueParser::new().try_map(parse_init_path))]
     pub path: PathBuf,
 
+    /// Don't check the project name's validity or availability and use it anyways
+    #[arg(long)]
+    pub force_name: bool,
     /// Whether to start the container for this project on Shuttle, and claim the project name
     #[arg(long)]
     pub create_env: bool,
@@ -399,6 +402,7 @@ mod tests {
             from: None,
             subfolder: None,
             create_env: false,
+            force_name: false,
             login_args: LoginArgs { api_key: None },
             path: PathBuf::new(),
         };
@@ -416,6 +420,7 @@ mod tests {
             from: None,
             subfolder: None,
             create_env: false,
+            force_name: false,
             login_args: LoginArgs { api_key: None },
             path: PathBuf::new(),
         };
@@ -433,6 +438,7 @@ mod tests {
             from: None,
             subfolder: None,
             create_env: false,
+            force_name: false,
             login_args: LoginArgs { api_key: None },
             path: PathBuf::new(),
         };
@@ -450,6 +456,7 @@ mod tests {
             from: Some("https://github.com/some/repo".into()),
             subfolder: Some("some/path".into()),
             create_env: false,
+            force_name: false,
             login_args: LoginArgs { api_key: None },
             path: PathBuf::new(),
         };
@@ -467,6 +474,7 @@ mod tests {
             from: None,
             subfolder: None,
             create_env: false,
+            force_name: false,
             login_args: LoginArgs { api_key: None },
             path: PathBuf::new(),
         };

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -225,7 +225,7 @@ pub struct ProjectStartArgs {
     pub idle_minutes: u64,
 }
 
-#[derive(Parser, Clone, Debug)]
+#[derive(Parser, Clone, Debug, Default)]
 pub struct LoginArgs {
     /// API key for the Shuttle platform
     #[arg(long)]
@@ -261,7 +261,7 @@ pub struct RunArgs {
     pub release: bool,
 }
 
-#[derive(Parser, Clone, Debug)]
+#[derive(Parser, Clone, Debug, Default)]
 pub struct InitArgs {
     /// Clone a starter template from Shuttle's official examples
     #[arg(long, short, value_enum, conflicts_with_all = &["from", "subfolder"])]
@@ -401,10 +401,7 @@ mod tests {
             template: Some(InitTemplateArg::Tower),
             from: None,
             subfolder: None,
-            create_env: false,
-            force_name: false,
-            login_args: LoginArgs { api_key: None },
-            path: PathBuf::new(),
+            ..Default::default()
         };
         assert_eq!(
             init_args.git_template().unwrap(),
@@ -419,10 +416,7 @@ mod tests {
             template: Some(InitTemplateArg::Axum),
             from: None,
             subfolder: None,
-            create_env: false,
-            force_name: false,
-            login_args: LoginArgs { api_key: None },
-            path: PathBuf::new(),
+            ..Default::default()
         };
         assert_eq!(
             init_args.git_template().unwrap(),
@@ -437,10 +431,7 @@ mod tests {
             template: Some(InitTemplateArg::None),
             from: None,
             subfolder: None,
-            create_env: false,
-            force_name: false,
-            login_args: LoginArgs { api_key: None },
-            path: PathBuf::new(),
+            ..Default::default()
         };
         assert_eq!(
             init_args.git_template().unwrap(),
@@ -455,10 +446,7 @@ mod tests {
             template: None,
             from: Some("https://github.com/some/repo".into()),
             subfolder: Some("some/path".into()),
-            create_env: false,
-            force_name: false,
-            login_args: LoginArgs { api_key: None },
-            path: PathBuf::new(),
+            ..Default::default()
         };
         assert_eq!(
             init_args.git_template().unwrap(),
@@ -473,10 +461,7 @@ mod tests {
             template: None,
             from: None,
             subfolder: None,
-            create_env: false,
-            force_name: false,
-            login_args: LoginArgs { api_key: None },
-            path: PathBuf::new(),
+            ..Default::default()
         };
         assert_eq!(init_args.git_template().unwrap(), None);
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -344,14 +344,14 @@ impl Shuttle {
             let name: String = if let Some(name) = project_args.name.clone() {
                 name
             } else {
-                // not using `validate_with` due to being blocking. we also need to handle --force
+                // not using `validate_with` due to being blocking.
                 Input::with_theme(&theme)
                     .with_prompt("Project name")
                     .interact()?
             };
-            // handle --force on retires
+            // handle forced name on retires
             let name: String = if let Some(prev_name) = prev_name {
-                if project_args.name.is_none() && name == "--force" {
+                if project_args.name.is_none() && name == prev_name {
                     project_args.name = Some(prev_name);
                     break;
                 } else {
@@ -374,7 +374,7 @@ impl Shuttle {
                 break;
             } else if project_args.name.is_none() {
                 // try again
-                println!(r#"Type `--force` to use "{}" anyways."#, name);
+                println!(r#"Type the same name again to use "{}" anyways."#, name);
                 prev_name = Some(name);
             } else {
                 // don't continue if non-interactive

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -350,10 +350,9 @@ impl Shuttle {
                     .with_prompt("Project name")
                     .interact()?
             };
-            // skip validation if forced, handle forced name on retires
-            if args.force_name
-                || (needs_name && prev_name.as_ref().is_some_and(|prev| prev == &name))
-            {
+            let force_name = args.force_name
+                || (needs_name && prev_name.as_ref().is_some_and(|prev| prev == &name));
+            if force_name {
                 project_args.name = Some(name);
                 break;
             }
@@ -371,7 +370,7 @@ impl Shuttle {
             } else {
                 // don't continue if non-interactive
                 bail!(
-                    "Invalid or taken project name. Use `--force-name` to use this name anyways."
+                    "Invalid or unavailable project name. Use `--force-name` to use this project name anyways."
                 );
             }
         }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -529,11 +529,13 @@ impl Shuttle {
             Ok(true) => {
                 println!("{} {}", "Project name already taken:".red(), name);
                 println!("{}", "Try a different name.".yellow());
-                return false;
+
+                false
             }
             Ok(false) => {
                 project_args.name = Some(name);
-                return true;
+
+                true
             }
             Err(e) => {
                 // If API error contains message regarding format of error name, print that error and prompt again
@@ -552,7 +554,8 @@ impl Shuttle {
                     "{}",
                     "Failed to check if project name is available.".yellow()
                 );
-                return true;
+
+                true
             }
         }
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -374,7 +374,7 @@ impl Shuttle {
                 break;
             } else if project_args.name.is_none() {
                 // try again
-                println!(r#"Type `--force` to use "{}" anyways"#, name);
+                println!(r#"Type `--force` to use "{}" anyways."#, name);
                 prev_name = Some(name);
             } else {
                 // don't continue if non-interactive

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -350,13 +350,10 @@ impl Shuttle {
                     .with_prompt("Project name")
                     .interact()?
             };
-            // handle forced name on retires
-            if needs_name && prev_name.as_ref().is_some_and(|prev| prev == &name) {
-                project_args.name = Some(prev_name.unwrap());
-                break;
-            }
-            // skip validation if forced
-            if args.force_name {
+            // skip validation if forced, handle forced name on retires
+            if args.force_name
+                || (needs_name && prev_name.as_ref().is_some_and(|prev| prev == &name))
+            {
                 project_args.name = Some(name);
                 break;
             }

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -19,11 +19,10 @@ async fn non_interactive_basic_init() {
 
     let args = ShuttleArgs::parse_from([
         "cargo-shuttle",
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "--template",
@@ -48,11 +47,10 @@ async fn non_interactive_rocket_init() {
 
     let args = ShuttleArgs::parse_from([
         "cargo-shuttle",
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "--template",
@@ -75,11 +73,10 @@ async fn non_interactive_init_with_from_url() {
 
     let args = ShuttleArgs::parse_from([
         "cargo-shuttle",
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "--from",
@@ -106,11 +103,10 @@ async fn non_interactive_init_with_from_gh() {
 
     let args = ShuttleArgs::parse_from([
         "cargo-shuttle",
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "--from",
@@ -137,11 +133,10 @@ async fn non_interactive_init_with_from_repo_name() {
 
     let args = ShuttleArgs::parse_from([
         "cargo-shuttle",
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "--from",
@@ -168,11 +163,10 @@ async fn non_interactive_init_with_from_local_path() {
 
     let args = ShuttleArgs::parse_from([
         "cargo-shuttle",
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "--from",
@@ -199,13 +193,7 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
 
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
-    command.args([
-        "--api-url",
-        "http://shuttle.invalid:80",
-        "init",
-        "--api-key",
-        "dh9z58jttoes3qvt",
-    ]);
+    command.args(["init", "--force-name", "--api-key", "dh9z58jttoes3qvt"]);
     let mut session = rexpect::session::spawn_command(command, Some(EXPECT_TIMEOUT_MS))?;
 
     session.exp_string("What do you want to name your project?")?;
@@ -240,13 +228,7 @@ fn interactive_rocket_init_manually_choose_template() -> Result<(), Box<dyn std:
 
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
-    command.args([
-        "--api-url",
-        "http://shuttle.invalid:80",
-        "init",
-        "--api-key",
-        "dh9z58jttoes3qvt",
-    ]);
+    command.args(["init", "--force-name", "--api-key", "dh9z58jttoes3qvt"]);
     let mut session = rexpect::session::spawn_command(command, Some(EXPECT_TIMEOUT_MS))?;
 
     session.exp_string("What do you want to name your project?")?;
@@ -282,9 +264,8 @@ fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::er
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
     command.args([
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
+        "--force-name",
         "--api-key",
         "dh9z58jttoes3qvt",
         "--template",
@@ -319,9 +300,8 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
     command.args([
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
+        "--force-name",
         "--api-key",
         "dh9z58jttoes3qvt",
         "--name",
@@ -361,11 +341,10 @@ fn interactive_rocket_init_prompt_path_dirty_dir() -> Result<(), Box<dyn std::er
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
     command.args([
-        "--api-url",
-        "http://shuttle.invalid:80",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",
+        "--force-name",
         "--name",
         "my-project",
         "-t",


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Useful if you are initing a project with a name that you already own.

`--force-name` arg disabled name validation and taken check.
In interactive, "reply" with the same name again to a failed validation to use the name anyways.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

All combinations of with/without arg and with/without interactive works as expected.
