### PR TITLE
bug: delete a project even if the current state is destroyed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5869,6 +5869,7 @@ dependencies = [
  "sqlx",
  "strum 0.25.0",
  "tempfile",
+ "test-context",
  "tokio",
  "tonic 0.10.2",
  "tower",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -65,3 +65,4 @@ portpicker = { workspace = true }
 ring = { workspace = true }
 snailquote = "0.3.1"
 tempfile = { workspace = true }
+test-context = "0.1.4"

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1109,6 +1109,7 @@ pub mod tests {
     use super::*;
     use crate::service::GatewayService;
     use crate::tests::{RequestBuilderExt, World};
+    use crate::worker::Worker;
 
     #[tokio::test]
     async fn api_create_get_delete_projects() -> anyhow::Result<()> {
@@ -1360,6 +1361,117 @@ pub mod tests {
                 .await
                 .unwrap();
         }
+
+        Ok(())
+    }
+
+    macro_rules! timed_loop {
+        (wait: $wait:literal$(, max: $max:literal)?, $block:block) => {{
+            #[allow(unused_mut)]
+            #[allow(unused_variables)]
+            let mut tries = 0;
+            loop {
+                $block
+                    tries += 1;
+                $(if tries > $max {
+                    panic!("timed out in the loop");
+                })?
+                    ::tokio::time::sleep(::std::time::Duration::from_secs($wait)).await;
+            }
+        }};
+    }
+
+    #[tokio::test]
+    async fn api_delete_project_that_is_ready() -> anyhow::Result<()> {
+        let world = World::new().await;
+        let service = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await);
+        let worker = Worker::new();
+
+        let (sender, mut receiver) = channel(256);
+        tokio::spawn({
+            let worker_sender = worker.sender();
+            async move {
+                while let Some(work) = receiver.recv().await {
+                    // Forward tasks to an actual worker
+                    worker_sender
+                        .send(work)
+                        .await
+                        .map_err(|_| "could not send work")
+                        .unwrap();
+                }
+            }
+        });
+
+        let _worker = tokio::spawn(async move {
+            worker.start().await.unwrap();
+        });
+
+        // Allow the spawns to start
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let mut router = ApiBuilder::new()
+            .with_service(Arc::clone(&service))
+            .with_sender(sender)
+            .with_default_routes()
+            .with_auth_service(world.context().auth_uri)
+            .into_router();
+
+        let neo_key = world.create_user("neo");
+
+        let authorization = Authorization::bearer(&neo_key).unwrap();
+
+        // Create a project and put it in the ready state
+        router
+            .call(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/projects/matrix"))
+                    .header("Content-Type", "application/json")
+                    .body("{\"idle_minutes\": 3}".into())
+                    .unwrap()
+                    .with_header(&authorization),
+            )
+            .map_ok(|resp| {
+                assert_eq!(resp.status(), StatusCode::OK);
+            })
+            .await
+            .unwrap();
+
+        timed_loop!(wait: 1, max: 12, {
+            let resp = router
+                .call(
+                    Request::get("/projects/matrix")
+                        .with_header(&authorization)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await.unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body = to_bytes(resp.into_body()).await.unwrap();
+            let project: project::Response = serde_json::from_slice(&body).unwrap();
+
+            if project.state == project::State::Ready {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+
+        router
+            .call(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/projects/matrix/delete"))
+                    .body(Body::empty())
+                    .unwrap()
+                    .with_header(&authorization),
+            )
+            .map_ok(|resp| {
+                assert_eq!(resp.status(), StatusCode::OK);
+            })
+            .await
+            .unwrap();
 
         Ok(())
     }

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1385,9 +1385,7 @@ pub mod tests {
         let world = World::new().await;
 
         let mut router = world.router().await;
-        let neo_key = world.create_user("neo");
-
-        let authorization = Authorization::bearer(&neo_key).unwrap();
+        let authorization = world.create_authorization_bearer("neo");
 
         // Create a project and put it in the ready state
         router

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1396,7 +1396,7 @@ pub mod tests {
             .call(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/projects/matrix/delete"))
+                    .uri("/projects/matrix/delete")
                     .body(Body::empty())
                     .unwrap()
                     .with_header(&authorization),
@@ -1426,7 +1426,7 @@ pub mod tests {
             .call(
                 Request::builder()
                     .method("DELETE")
-                    .uri(format!("/projects/matrix/delete"))
+                    .uri("/projects/matrix/delete")
                     .body(Body::empty())
                     .unwrap()
                     .with_header(&authorization),

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1140,7 +1140,7 @@ pub mod tests {
                 .unwrap()
         };
 
-        let delete_project = |project: &str| {
+        let stop_project = |project: &str| {
             Request::builder()
                 .method("DELETE")
                 .uri(format!("/projects/{project}"))
@@ -1197,7 +1197,7 @@ pub mod tests {
             .unwrap();
 
         router
-            .call(delete_project("matrix").with_header(&authorization))
+            .call(stop_project("matrix").with_header(&authorization))
             .map_ok(|resp| {
                 assert_eq!(resp.status(), StatusCode::OK);
             })
@@ -1223,7 +1223,7 @@ pub mod tests {
             .unwrap();
 
         router
-            .call(delete_project("reloaded").with_header(&authorization))
+            .call(stop_project("reloaded").with_header(&authorization))
             .map_ok(|resp| {
                 assert_eq!(resp.status(), StatusCode::NOT_FOUND);
             })

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -74,4 +74,7 @@ pub struct ContextArgs {
     /// Api key for the user that has rights to start deploys
     #[arg(long, default_value = "gateway4deployes")]
     pub deploys_api_key: String,
+
+    /// Allow tests to set some extra /etc/hosts
+    pub extra_hosts: Vec<String>,
 }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -489,7 +489,6 @@ pub mod tests {
     pub struct WorldContext {
         pub docker: Docker,
         pub container_settings: ContainerSettings,
-        pub hyper: HyperClient<HttpConnector, Body>,
         pub auth_uri: Uri,
     }
 
@@ -642,7 +641,6 @@ pub mod tests {
             WorldContext {
                 docker: self.docker.clone(),
                 container_settings: self.settings.clone(),
-                hyper: self.hyper.clone(),
                 auth_uri: self.auth_uri.clone(),
             }
         }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -623,14 +623,9 @@ pub mod tests {
             user.to_string()
         }
 
+        /// Create with the given name and return the authorization bearer for the user
         pub fn create_authorization_bearer(&self, user: &str) -> Authorization<Bearer> {
-            self.auth_service
-                .lock()
-                .unwrap()
-                .users
-                .insert(user.to_string(), AccountTier::Basic.into());
-
-            let user_key = user.to_string();
+            let user_key = self.create_user(user);
             Authorization::bearer(&user_key).unwrap()
         }
 
@@ -640,6 +635,7 @@ pub mod tests {
             }
         }
 
+        /// Create a router to make API calls against. Also starts up a worker to create actual Docker containers for all requests
         pub async fn router(&self) -> Router {
             let service = Arc::new(GatewayService::init(self.args(), self.pool(), "".into()).await);
             let worker = Worker::new();
@@ -754,6 +750,7 @@ pub mod tests {
         }
     }
 
+    /// Make it easy to perform common requests against the router for testing purposes
     #[async_trait]
     pub trait RouterExt {
         /// Create a project and put it in the ready state
@@ -806,6 +803,7 @@ pub mod tests {
             }
         }
 
+        /// Is this project still available - aka has it been deleted
         pub async fn is_missing(&mut self) -> bool {
             let project_name = &self.project_name;
 
@@ -823,6 +821,7 @@ pub mod tests {
             resp.status() == StatusCode::NOT_FOUND
         }
 
+        /// Destroy / stop a project. Like `cargo shuttle project stop`
         pub async fn destroy_project(&mut self) {
             let TestProject {
                 router,

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -621,6 +621,17 @@ pub mod tests {
             user.to_string()
         }
 
+        pub fn create_authorization_bearer(&self, user: &str) -> Authorization<Bearer> {
+            self.auth_service
+                .lock()
+                .unwrap()
+                .users
+                .insert(user.to_string(), AccountTier::Basic.into());
+
+            let user_key = user.to_string();
+            Authorization::bearer(&user_key).unwrap()
+        }
+
         pub fn set_super_user(&self, user: &str) {
             if let Some(scopes) = self.auth_service.lock().unwrap().users.get_mut(user) {
                 scopes.push(Scope::Admin)

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -1988,7 +1988,7 @@ pub mod tests {
             .unwrap()
             .unwrap();
 
-        let client = world.client(target_addr);
+        let client = World::client(target_addr);
 
         client
             .request(

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -372,7 +372,10 @@ impl Project {
             | Self::Stopping(ProjectStopping { container, .. })
             | Self::Stopped(ProjectStopped { container, .. })
             | Self::Rebooting(ProjectRebooting { container, .. })
-            | Self::Destroying(ProjectDestroying { container }) => Some(container.clone()),
+            | Self::Destroying(ProjectDestroying { container })
+            | Self::Destroyed(ProjectDestroyed {
+                destroyed: Some(container),
+            }) => Some(container.clone()),
             Self::Errored(ProjectError { ctx: Some(ctx), .. }) => ctx.container(),
             Self::Errored(_) | Self::Creating(_) | Self::Destroyed(_) | Self::Deleted => None,
         }

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -792,6 +792,7 @@ impl ProjectCreating {
             builder_host,
             auth_uri,
             fqdn: public,
+            extra_hosts,
             ..
         } = ctx.container_settings();
 
@@ -863,7 +864,8 @@ impl ProjectCreating {
             "MemoryReservation": 4295000000i64, // 4 GiB soft limit, applied if host is low on memory
             // https://docs.docker.com/config/containers/resource_constraints/#cpu
             "CpuPeriod": 100000i64,
-            "CpuQuota": 400000i64
+            "CpuQuota": 400000i64,
+            "ExtraHosts": extra_hosts,
         });
 
         debug!(

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -147,7 +147,7 @@ impl ContainerSettingsBuilder {
         self
     }
 
-    pub fn extra_hosts<S: ToString>(mut self, extra_hosts: &Vec<S>) -> Self {
+    pub fn extra_hosts<S: ToString>(mut self, extra_hosts: &[S]) -> Self {
         self.extra_hosts = Some(extra_hosts.iter().map(ToString::to_string).collect());
         self
     }

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -65,6 +65,7 @@ pub struct ContainerSettingsBuilder {
     auth_uri: Option<String>,
     network_name: Option<String>,
     fqdn: Option<String>,
+    extra_hosts: Option<Vec<String>>,
 }
 
 impl Default for ContainerSettingsBuilder {
@@ -83,6 +84,7 @@ impl ContainerSettingsBuilder {
             auth_uri: None,
             network_name: None,
             fqdn: None,
+            extra_hosts: None,
         }
     }
 
@@ -95,6 +97,7 @@ impl ContainerSettingsBuilder {
             auth_uri,
             image,
             proxy_fqdn,
+            extra_hosts,
             ..
         } = args;
         self.prefix(prefix)
@@ -104,6 +107,7 @@ impl ContainerSettingsBuilder {
             .auth_uri(auth_uri)
             .network_name(network_name)
             .fqdn(proxy_fqdn)
+            .extra_hosts(extra_hosts)
             .build()
             .await
     }
@@ -143,12 +147,18 @@ impl ContainerSettingsBuilder {
         self
     }
 
+    pub fn extra_hosts<S: ToString>(mut self, extra_hosts: &Vec<S>) -> Self {
+        self.extra_hosts = Some(extra_hosts.iter().map(ToString::to_string).collect());
+        self
+    }
+
     pub async fn build(mut self) -> ContainerSettings {
         let prefix = self.prefix.take().unwrap();
         let image = self.image.take().unwrap();
         let provisioner_host = self.provisioner.take().unwrap();
         let builder_host = self.builder.take().unwrap();
         let auth_uri = self.auth_uri.take().unwrap();
+        let extra_hosts = self.extra_hosts.take().unwrap();
 
         let network_name = self.network_name.take().unwrap();
         let fqdn = self.fqdn.take().unwrap();
@@ -161,6 +171,7 @@ impl ContainerSettingsBuilder {
             auth_uri,
             network_name,
             fqdn,
+            extra_hosts,
         }
     }
 }
@@ -174,6 +185,7 @@ pub struct ContainerSettings {
     pub auth_uri: String,
     pub network_name: String,
     pub fqdn: String,
+    pub extra_hosts: Vec<String>,
 }
 
 impl ContainerSettings {


### PR DESCRIPTION
## Description of change
Causes the delete command to start up destroyed (stopped) projects to be able to delete them.


## How has this been tested? (if applicable)
By making new gateway tests. Use the following steps to run them

```
USE_PANAMAX=disable make up # To start up the other service on your local environment
SHUTTLE_TESTS_NETWORK=shuttle-dev_user-net cargo test --package shuttle-gateway # to run all the gateway tests
```

If your tests take too long to run and eventually errors with `503` then make sure your firewall is not blocking any requests. See comments in the code.


