### PR TITLE
auth: comment healthcheck `start_period` & `start_interval`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,10 @@ services:
       interval: 1m
       timeout: 10s
       retries: 5
-      start_period: 10s
-      start_interval: 2s
+      # These options are pending on an upgrade to Docker Engine version 25.0.
+      # Using them will result in error because they are not handled gracefully.
+      # start_period: 10s
+      # start_interval: 2s
   builder:
     image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"
     depends_on:


### PR DESCRIPTION
## Description of change

CircleCI staging/prod deployment will fail because the `start_period` and `start_interval` configs for `healthcheck` are not handled gracefully when deploying the stack. The deployment will fail due to using a Docker Engine version that does not support the configs.

This PR comments on the configs explaining why, and when we'll upgrade, we can uncomment them.

## How has this been tested? (if applicable)

Releasing on staging for #1402 .



