### PR TITLE
fix(common): type conversion from str for a custom resource

### DIFF
--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -56,6 +56,7 @@ impl FromStr for Type {
                 "metadata" => Ok(Self::Metadata),
                 "persist" => Ok(Self::Persist),
                 "turso" => Ok(Self::Turso),
+                "custom" => Ok(Self::Custom),
                 _ => Err(format!("'{s}' is an unknown resource type")),
             }
         }


### PR DESCRIPTION
## Description of change

We're missing the `Custom` resource type conversion from `str`.

## How has this been tested? (if applicable)

Reproduced when I deployed the `custom-resource/pdo` example.
TODO: test the project deployment again after the fix.


