### PR TITLE
feat(shuttle-serenity): support serenity 0.12 and 0.11, optional native tls feature

### DIFF
--- a/services/shuttle-serenity/Cargo.toml
+++ b/services/shuttle-serenity/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "serenity"]
 [workspace]
 
 [dependencies]
-serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
+serenity = { version = ">=0.11.5,<0.13", default-features = false, features = ["client", "gateway", "model"] }
 shuttle-runtime = { path = "../../runtime", version = "0.33.0", default-features = false }
 
 [dev-dependencies]
@@ -17,3 +17,9 @@ anyhow = "1.0.69"
 shuttle-secrets = { path = "../../resources/secrets" }
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.37"
+
+[features]
+default = ["rustls_backend"]
+
+rustls_backend = ["serenity/rustls_backend"]
+native_tls_backend = ["serenity/native_tls_backend"]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Serenity has entered RC stage for 0.12. We only use their `Client`, and there is no breaking changes in that interface.
Also moved rustls to a default feature to allow native tls.
Having this released ahead of time means that we will support serenity 0.12 from the same moment it is released.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Compiled serenity hello world with 0.11 and their 0.12-rc branch, both worked.
