### PR TITLE
feat(cargo-shuttle): --raw flag on logs

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -113,6 +113,9 @@ pub enum Command {
         #[arg(short, long)]
         /// Follow log output
         follow: bool,
+        #[arg(long)]
+        /// Don't display timestamps and log origin tags
+        raw: bool,
     },
     /// List or manage projects on Shuttle
     #[command(subcommand)]

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -90,6 +90,10 @@ impl LogItem {
             }
         }
     }
+
+    pub fn get_raw_line(&self) -> &str {
+        &self.line
+    }
 }
 
 #[cfg(feature = "display")]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

--raw does not display timestamp or log origin. Makes the logs a lot clearer if needed for parsing in some way.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested against prod (client change only)
