### PR TITLE
refactor: delete errored projects

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -52,6 +52,7 @@ pub enum ErrorKind {
     ProjectHasResources(Vec<String>),
     ProjectHasRunningDeployment,
     ProjectHasBuildingDeployment,
+    ProjectCorrupted,
     CustomDomainNotFound,
     InvalidCustomDomain,
     CustomDomainAlreadyExists,
@@ -98,6 +99,10 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::ProjectHasBuildingDeployment => (
                 StatusCode::BAD_REQUEST,
                 "Project currently has a deployment that is busy building. Use `cargo shuttle deployment list` to see it and wait for it to finish"
+            ),
+            ErrorKind::ProjectCorrupted => (
+                StatusCode::BAD_REQUEST,
+                "Tried to get project into a ready state for deletion but failed. Please reach out to Shuttle support for help."
             ),
             ErrorKind::ProjectHasResources(resources) => {
                 let resources = resources.join(", ");

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1113,6 +1113,7 @@ pub mod tests {
     use tower::Service;
 
     use super::*;
+    use crate::project::ProjectError;
     use crate::service::GatewayService;
     use crate::tests::{RequestBuilderExt, TestProject, World};
 
@@ -1438,6 +1439,21 @@ pub mod tests {
         assert_eq!(
             project.router_call(Method::DELETE, "/delete").await,
             StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test_context(TestProject)]
+    #[tokio::test]
+    async fn api_delete_project_that_is_errored(project: &mut TestProject) {
+        project
+            .update_state(Project::Errored(ProjectError::internal(
+                "Mr. Anderson is here",
+            )))
+            .await;
+
+        assert_eq!(
+            project.router_call(Method::DELETE, "/delete").await,
+            StatusCode::OK
         );
     }
 

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -340,6 +340,12 @@ async fn delete_project(
 
         // Wait for the project to be ready
         handle.await;
+
+        let new_state = state.service.find_project(&project_name).await?;
+
+        if !new_state.state.is_ready() {
+            return Err(Error::from_kind(ErrorKind::ProjectCorrupted));
+        }
     }
 
     let service = state.service.clone();

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -327,8 +327,9 @@ async fn delete_project(
     let project_id =
         Ulid::from_string(&project.project_id).expect("stored project id to be a valid ULID");
 
-    // Try to startup a destroyed project first
-    if project.state.is_destroyed() {
+    // Try to startup destroyed or errored projects
+    let project_deletable = project.state.is_ready() || project.state.is_stopped();
+    if !(project_deletable) {
         let handle = state
             .service
             .new_task()

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -994,7 +994,7 @@ pub mod tests {
 
             query("UPDATE projects SET project_state = ?1 WHERE project_name = ?2")
                 .bind(&state)
-                .bind(&project_name)
+                .bind(project_name)
                 .execute(&world.pool)
                 .await
                 .expect("test to update project state");


### PR DESCRIPTION
## Description of change
Handle an errored project automatically when trying to delete it.


## How has this been tested? (if applicable)
By adding new tests


