### PR TITLE
ci: bump docker-rust rust version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ commands:
       - run:
           name: Install Rust
           command: |
-            which cargo || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.72.0
+            which cargo || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.74.0
       - run: rustup target add wasm32-wasi
   install-protoc:
     steps:
@@ -489,7 +489,7 @@ jobs:
       - run: sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install -y libssl-dev musl-tools clang
       - run:
           name: Install Rust
-          command: curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.72.0 --target << parameters.target >>
+          command: curl --proto '=https' --tlsv1.3 https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.74.0 --target << parameters.target >>
       - run:
           name: Build
           command: |
@@ -512,7 +512,7 @@ jobs:
           name: Install Rust
           command: |
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
-            C:\rustup-init.exe -y --default-toolchain 1.72.0 --target x86_64-pc-windows-msvc
+            C:\rustup-init.exe -y --default-toolchain 1.74.0 --target x86_64-pc-windows-msvc
           shell: powershell.exe
       - run:
           name: Build
@@ -535,7 +535,7 @@ jobs:
       - macos/install-rosetta
       - run:
           name: Install Rust
-          command: curl --proto '=https' https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.72.0 --target x86_64-apple-darwin
+          command: curl --proto '=https' https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain 1.74.0 --target x86_64-apple-darwin
       - run:
           name: Build
           command: |
@@ -646,7 +646,7 @@ jobs:
           name: Install Rust
           command: |
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
-            C:\rustup-init.exe -y --default-toolchain 1.72.0 --target x86_64-pc-windows-msvc
+            C:\rustup-init.exe -y --default-toolchain 1.74.0 --target x86_64-pc-windows-msvc
       - run:
           name: "Install Shuttle"
           command: ..\.cargo\bin\cargo.exe install cargo-shuttle --path ./cargo-shuttle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ orbs:
 executors:
   docker-rust:
     docker:
-      - image: cimg/rust:1.72.0
+      - image: cimg/rust:1.74.0
     resource_class: small
   machine-ubuntu:
     machine:


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This fixes the recent [CI errors](https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/5032/workflows/da1d8d48-aabe-446d-87a7-eaf5c709f51b/jobs/119097) caused by serenity needing rust 1.74, and also bumps the rust version used for other jobs and bin builds.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

CI passes after the change.
