### PR TITLE
fix(cargo-shuttle): increase runtime version check timeout

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -2072,7 +2072,7 @@ async fn check_version(runtime_path: &Path) -> Result<()> {
 
     // Get runtime version from shuttle-runtime cli
     // It should print the version and exit immediately, so a timeout is used to not launch servers with non-Shuttle setups
-    let stdout = tokio::time::timeout(Duration::from_millis(500), async move {
+    let stdout = tokio::time::timeout(Duration::from_millis(1000), async move {
         tokio::process::Command::new(runtime_path)
             .arg("--version")
             .kill_on_drop(true) // if the binary does not halt on its own, not killing it will leak child processes

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -2072,7 +2072,7 @@ async fn check_version(runtime_path: &Path) -> Result<()> {
 
     // Get runtime version from shuttle-runtime cli
     // It should print the version and exit immediately, so a timeout is used to not launch servers with non-Shuttle setups
-    let stdout = tokio::time::timeout(Duration::from_millis(1000), async move {
+    let stdout = tokio::time::timeout(Duration::from_millis(3000), async move {
         tokio::process::Command::new(runtime_path)
             .arg("--version")
             .kill_on_drop(true) // if the binary does not halt on its own, not killing it will leak child processes


### PR DESCRIPTION
## Description of change
I found on my machine running `cargo shuttle run` on the latest version i was getting a time out as described in #1436 and not allowing me to run my project. After finding the location of the error and moving it up from a timeout of `500` to `1000` my project runs and the check passes. Open to any suggestions on possible chnages to PR or issue. Thank you!



## How has this been tested? (if applicable)
Verfied the timeout resolved my issule and the project could run after the change

