### PR TITLE
fix(shuttle-serenity): support serenity 0.12 through feature flag

### DIFF
--- a/services/shuttle-serenity/Cargo.toml
+++ b/services/shuttle-serenity/Cargo.toml
@@ -9,7 +9,8 @@ keywords = ["shuttle-service", "serenity"]
 [workspace]
 
 [dependencies]
-serenity = { version = ">=0.11.5,<0.13", default-features = false, features = ["client", "gateway", "model"] }
+serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "model"], optional = true }
+serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model"], optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.34.1", default-features = false }
 
 [dev-dependencies]
@@ -23,3 +24,5 @@ default = ["rustls_backend"]
 
 rustls_backend = ["serenity/rustls_backend"]
 native_tls_backend = ["serenity/native_tls_backend"]
+serenity-0-12-rustls_backend = ["serenity-0-12/rustls_backend"]
+serenity-0-12-native_tls_backend = ["serenity-0-12/native_tls_backend"]

--- a/services/shuttle-serenity/src/lib.rs
+++ b/services/shuttle-serenity/src/lib.rs
@@ -54,8 +54,13 @@
 use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
+#[cfg(feature = "serenity")]
+use serenity::Client;
+#[cfg(feature = "serenity-0-12")]
+use serenity_0_12::Client;
+
 /// A wrapper type for [serenity::Client] so we can implement [shuttle_runtime::Service] for it.
-pub struct SerenityService(pub serenity::Client);
+pub struct SerenityService(pub Client);
 
 #[shuttle_runtime::async_trait]
 impl shuttle_runtime::Service for SerenityService {
@@ -68,8 +73,8 @@ impl shuttle_runtime::Service for SerenityService {
     }
 }
 
-impl From<serenity::Client> for SerenityService {
-    fn from(router: serenity::Client) -> Self {
+impl From<Client> for SerenityService {
+    fn from(router: Client) -> Self {
         Self(router)
     }
 }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->



## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

tested a newly inited serenity project with patches against this, both with (default + serenity0.11) and with (no default + flag + serenity0.12)

CI fails due to features being mutually exclusive. Can be fixed later.
