### PR TITLE
feat: protect ourselves from going over the 1k limit

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -132,7 +132,7 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::Forbidden => (StatusCode::FORBIDDEN, "Forbidden"),
             ErrorKind::NotReady => (StatusCode::INTERNAL_SERVER_ERROR, "Service not ready"),
             ErrorKind::DeleteProjectFailed => (StatusCode::INTERNAL_SERVER_ERROR, "Deleting project failed"),
-            ErrorKind::ContainerLimit => (StatusCode::INTERNAL_SERVER_ERROR, "Our server is full and cannot create / start projects at this time"),
+            ErrorKind::ContainerLimit => (StatusCode::SERVICE_UNAVAILABLE, "Our server is full and cannot create / start projects at this time"),
         };
         Self {
             message: error_message.to_string(),

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -61,6 +61,7 @@ pub enum ErrorKind {
     NotReady,
     ServiceUnavailable,
     DeleteProjectFailed,
+    ContainerLimit,
 }
 
 impl From<ErrorKind> for ApiError {
@@ -131,6 +132,7 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::Forbidden => (StatusCode::FORBIDDEN, "Forbidden"),
             ErrorKind::NotReady => (StatusCode::INTERNAL_SERVER_ERROR, "Service not ready"),
             ErrorKind::DeleteProjectFailed => (StatusCode::INTERNAL_SERVER_ERROR, "Deleting project failed"),
+            ErrorKind::ContainerLimit => (StatusCode::INTERNAL_SERVER_ERROR, "Our server is full and cannot create / start projects at this time"),
         };
         Self {
             message: error_message.to_string(),

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -310,6 +310,11 @@ pub mod name {
                 && name.bytes().all(is_valid_char)
                 && is_profanity_free(name)
         }
+
+        /// Is this a cch project
+        pub fn is_cch_project(&self) -> bool {
+            self.starts_with("cch23-")
+        }
     }
 
     impl std::ops::Deref for ProjectName {

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1125,7 +1125,7 @@ pub mod tests {
     use super::*;
     use crate::project::ProjectError;
     use crate::service::GatewayService;
-    use crate::tests::{RequestBuilderExt, TestProject, World};
+    use crate::tests::{RequestBuilderExt, TestGateway, TestProject, World};
 
     #[tokio::test]
     async fn api_create_get_delete_projects() -> anyhow::Result<()> {
@@ -1379,6 +1379,15 @@ pub mod tests {
         }
 
         Ok(())
+    }
+
+    #[test_context(TestGateway)]
+    #[tokio::test]
+    async fn api_create_project_above_node_limits(gateway: &mut TestGateway) {
+        let _ = gateway.create_project("cch23-first").await;
+        let code = gateway.try_create_project("cch23-second").await;
+
+        assert_eq!(code, StatusCode::INTERNAL_SERVER_ERROR);
     }
 
     #[test_context(TestProject)]

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -219,6 +219,14 @@ async fn create_project(
             .saturating_sub(cch_modifier as u32),
     );
 
+    if cch_modifier {
+        let current_container_count = service.count_ready_projects().await?;
+
+        if current_container_count >= service.container_limit() {
+            return Err(Error::from_kind(ErrorKind::ContainerLimit));
+        }
+    }
+
     let project = service
         .create_project(
             project_name.clone(),

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1410,7 +1410,7 @@ pub mod tests {
         let _ = gateway.create_project("matrix").await;
         let cch_code = gateway.try_create_project("cch23-project").await;
 
-        assert_eq!(cch_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(cch_code, StatusCode::SERVICE_UNAVAILABLE);
 
         let normal_code = gateway.try_create_project("project").await;
 
@@ -1455,7 +1455,7 @@ pub mod tests {
             .router_call(Method::GET, "/services/cch23-project")
             .await;
 
-        assert_eq!(cch_code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(cch_code, StatusCode::SERVICE_UNAVAILABLE);
 
         let normal_code = normal_idle_project
             .router_call(Method::GET, "/services/project")

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -442,6 +442,16 @@ async fn route_project(
     req: Request<Body>,
 ) -> Result<Response<Body>, Error> {
     let project_name = scoped_user.scope;
+    let cch_modifier = project_name.starts_with("cch23-");
+
+    if cch_modifier {
+        let current_container_count = service.count_ready_projects().await?;
+
+        if current_container_count >= service.container_limit() {
+            return Err(Error::from_kind(ErrorKind::ContainerLimit));
+        }
+    }
+
     let project = service.find_or_start_project(&project_name, sender).await?;
     service
         .route(&project.state, &project_name, &scoped_user.user.name, req)

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -77,6 +77,9 @@ pub struct ContextArgs {
     /// Api key for the user that has rights to start deploys
     #[arg(long, default_value = "gateway4deployes")]
     pub deploys_api_key: String,
+    /// Maxixmum number of containers to start on this node
+    #[arg(long, default_value = "1000")]
+    pub container_limit: u32,
 
     /// Allow tests to set some extra /etc/hosts
     pub extra_hosts: Vec<String>,

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -78,7 +78,7 @@ pub struct ContextArgs {
     #[arg(long, default_value = "gateway4deployes")]
     pub deploys_api_key: String,
     /// Maximum number of containers to start on this node
-    #[arg(long, default_value = "1000")]
+    #[arg(long, default_value = "900")]
     pub container_limit: u32,
 
     /// Allow tests to set some extra /etc/hosts

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -77,7 +77,7 @@ pub struct ContextArgs {
     /// Api key for the user that has rights to start deploys
     #[arg(long, default_value = "gateway4deployes")]
     pub deploys_api_key: String,
-    /// Maxixmum number of containers to start on this node
+    /// Maximum number of containers to start on this node
     #[arg(long, default_value = "1000")]
     pub container_limit: u32,
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -579,6 +579,7 @@ pub mod tests {
                     network_name,
                     proxy_fqdn: FQDN::from_str("test.shuttleapp.rs").unwrap(),
                     deploys_api_key: "gateway".to_string(),
+                    container_limit: 1,
 
                     // Allow access to the auth on the host
                     extra_hosts: vec!["host.docker.internal:host-gateway".to_string()],

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -327,6 +327,7 @@ impl GatewayService {
         Ok(iter)
     }
 
+    /// The number of projects that are currently in the ready state
     pub async fn count_ready_projects(&self) -> Result<u32, Error> {
         let ready_count: u32 =
             query("SELECT COUNT(*) FROM projects, JSON_EACH(project_state) WHERE key = 'ready'")

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -244,6 +244,9 @@ pub struct GatewayService {
     task_router: TaskRouter<BoxedTask>,
     state_location: PathBuf,
 
+    /// Maximum number of containers the gateway can start
+    container_limit: u32,
+
     // We store these because we'll need them for the health checks
     provisioner_host: Endpoint,
     auth_host: Uri,
@@ -275,6 +278,7 @@ impl GatewayService {
             provisioner_host: Endpoint::new(format!("http://{}:8000", args.provisioner_host))
                 .expect("to have a valid provisioner endpoint"),
             auth_host: args.auth_uri,
+            container_limit: args.container_limit,
         }
     }
 
@@ -321,6 +325,16 @@ impl GatewayService {
             .into_iter()
             .map(|row| (row.get("project_name"), row.get("account_name")));
         Ok(iter)
+    }
+
+    pub async fn count_ready_projects(&self) -> Result<u32, Error> {
+        let ready_count: u32 =
+            query("SELECT COUNT(*) FROM projects, JSON_EACH(project_state) WHERE key = 'ready'")
+                .fetch_one(&self.db)
+                .await?
+                .get::<_, usize>(0);
+
+        Ok(ready_count)
     }
 
     pub async fn find_project(
@@ -923,6 +937,11 @@ impl GatewayService {
     }
     pub fn auth_uri(&self) -> &Uri {
         &self.auth_host
+    }
+
+    /// Maximum number of containers that can be started by gateway
+    pub fn container_limit(&self) -> u32 {
+        self.container_limit
     }
 }
 


### PR DESCRIPTION
## Description of change
Stop the creation of new cch projects or the starting of idle cch projects when we are close to hitting our active container limits.

## How has this been tested? (if applicable)
By adding new tests

