### PR TITLE
ci: fix tests with axum and serenity feature flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,13 +696,11 @@ workflows:
                 - resources/secrets
                 - resources/turso
                 - services/shuttle-actix-web
-                - services/shuttle-axum
                 - services/shuttle-next
                 - services/shuttle-poem
                 - services/shuttle-poise
                 - services/shuttle-rocket
                 - services/shuttle-salvo
-                - services/shuttle-serenity
                 - services/shuttle-thruster
                 - services/shuttle-tide
                 - services/shuttle-tower
@@ -719,6 +717,28 @@ workflows:
                 - "-F mongodb"
                 - "-F postgres"
                 - "-F postgres-rustls"
+      - test-standalone:
+          # Has mutually exclusive features, so we run checks for each feature separately
+          name: "services/shuttle-axum: << matrix.features >>"
+          matrix:
+            alias: test-standalone-services-shuttle-axum
+            parameters:
+              path:
+                - services/shuttle-axum
+              features:
+                - "-F axum"
+                - "-F axum-0-7 --no-default-features"
+      - test-standalone:
+          # Has mutually exclusive features, so we run checks for each feature separately
+          name: "services/shuttle-serenity: << matrix.features >>"
+          matrix:
+            alias: test-standalone-services-shuttle-serenity
+            parameters:
+              path:
+                - services/shuttle-serenity
+              features:
+                - "-F serenity"
+                - "-F serenity-0-12 --no-default-features"
       - test-workspace-member:
           name: << matrix.crate >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,7 +738,7 @@ workflows:
                 - services/shuttle-serenity
               features:
                 - "-F serenity"
-                - "-F serenity-0-12 --no-default-features"
+                - "-F serenity-0-12,serenity-0-12-rustls_backend --no-default-features"
       - test-workspace-member:
           name: << matrix.crate >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,7 +738,7 @@ workflows:
                 - services/shuttle-serenity
               features:
                 - "-F serenity"
-                - "-F serenity-0-12,serenity-0-12-rustls_backend --no-default-features"
+                - "-F serenity-0-12-rustls_backend --no-default-features"
       - test-workspace-member:
           name: << matrix.crate >>
           matrix:

--- a/services/shuttle-axum/README.md
+++ b/services/shuttle-axum/README.md
@@ -2,7 +2,7 @@
 
 ### Example
 
-```rust
+```rust,no_run
 #[cfg(feature = "axum")]
 use axum::{routing::get, Router};
 #[cfg(feature = "axum-0-7")]

--- a/services/shuttle-axum/README.md
+++ b/services/shuttle-axum/README.md
@@ -1,7 +1,7 @@
 ## Shuttle service integration for the Axum web framework.
 
 Axum 0.7 is now supported by using these feature flags:
-```ignore
+```toml,ignore
 axum = "0.7.0"
 shuttle-axum = { version = "0.34.1", default-features = false, features = ["axum-0-7"] }
 ```

--- a/services/shuttle-axum/README.md
+++ b/services/shuttle-axum/README.md
@@ -1,12 +1,15 @@
 ## Shuttle service integration for the Axum web framework.
 
+Axum 0.7 is now supported by using these feature flags:
+```ignore
+axum = "0.7.0"
+shuttle-axum = { version = "0.34.1", default-features = false, features = ["axum-0-7"] }
+```
+
 ### Example
 
-```rust,no_run
-#[cfg(feature = "axum")]
+```rust,ignore
 use axum::{routing::get, Router};
-#[cfg(feature = "axum-0-7")]
-use axum_0_7::{routing::get, Router};
 
 async fn hello_world() -> &'static str {
     "Hello, world!"

--- a/services/shuttle-axum/README.md
+++ b/services/shuttle-axum/README.md
@@ -2,8 +2,11 @@
 
 ### Example
 
-```rust,no_run
+```rust
+#[cfg(feature = "axum")]
 use axum::{routing::get, Router};
+#[cfg(feature = "axum-0-7")]
+use axum_0_7::{routing::get, Router};
 
 async fn hello_world() -> &'static str {
     "Hello, world!"

--- a/services/shuttle-serenity/Cargo.toml
+++ b/services/shuttle-serenity/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "serenity"]
 
 [dependencies]
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "model"], optional = true }
-serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model"], optional = true }
+serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend"], optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.34.1", default-features = false }
 
 [dev-dependencies]

--- a/services/shuttle-serenity/Cargo.toml
+++ b/services/shuttle-serenity/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "serenity"]
 
 [dependencies]
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "model"], optional = true }
-serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model", "rustls_backend"], optional = true }
+serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model"], optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.34.1", default-features = false }
 
 [dev-dependencies]

--- a/services/shuttle-serenity/README.md
+++ b/services/shuttle-serenity/README.md
@@ -1,7 +1,7 @@
 ## Shuttle service integration for the Serenity discord bot framework.
 
 Serenity 0.12 is now supported by using these feature flags (native TLS also available):
-```ignore
+```toml,ignore
 serenity = { version = "0.12.0", features = ["..."] }
 shuttle-serenity = { version = "0.34.1", default-features = false, features = ["serenity-0-12-rustls_backend"] }
 ```

--- a/services/shuttle-serenity/README.md
+++ b/services/shuttle-serenity/README.md
@@ -1,26 +1,19 @@
 ## Shuttle service integration for the Serenity discord bot framework.
 
+Serenity 0.12 is now supported by using these feature flags (native TLS also available):
+```ignore
+serenity = { version = "0.12.0", features = ["..."] }
+shuttle-serenity = { version = "0.34.1", default-features = false, features = ["serenity-0-12-rustls_backend"] }
+```
+
 ### Example
 
-```rust,no_run
+```rust,ignore
 use anyhow::anyhow;
-#[cfg(feature = "serenity-0-12")]
-use serenity_0_12::async_trait;
-#[cfg(feature = "serenity-0-12")]
-use serenity_0_12::model::channel::Message;
-#[cfg(feature = "serenity-0-12")]
-use serenity_0_12::model::gateway::Ready;
-#[cfg(feature = "serenity-0-12")]
-use serenity_0_12::prelude::*;
-#[cfg(feature = "serenity")]
 use serenity::async_trait;
-#[cfg(feature = "serenity")]
 use serenity::model::channel::Message;
-#[cfg(feature = "serenity")]
 use serenity::model::gateway::Ready;
-#[cfg(feature = "serenity")]
 use serenity::prelude::*;
-
 use shuttle_secrets::SecretStore;
 use tracing::{error, info};
 

--- a/services/shuttle-serenity/README.md
+++ b/services/shuttle-serenity/README.md
@@ -4,10 +4,23 @@
 
 ```rust,no_run
 use anyhow::anyhow;
+#[cfg(feature = "serenity-0-12")]
+use serenity_0_12::async_trait;
+#[cfg(feature = "serenity-0-12")]
+use serenity_0_12::model::channel::Message;
+#[cfg(feature = "serenity-0-12")]
+use serenity_0_12::model::gateway::Ready;
+#[cfg(feature = "serenity-0-12")]
+use serenity_0_12::prelude::*;
+#[cfg(feature = "serenity")]
 use serenity::async_trait;
+#[cfg(feature = "serenity")]
 use serenity::model::channel::Message;
+#[cfg(feature = "serenity")]
 use serenity::model::gateway::Ready;
+#[cfg(feature = "serenity")]
 use serenity::prelude::*;
+
 use shuttle_secrets::SecretStore;
 use tracing::{error, info};
 


### PR DESCRIPTION
## Description of change
With Axum 0.7 and Serenity 0.12 the pipeline has been failing a couple of checks. Hopefully, this resolves them by breaking them into a feature check for each feature. I was not sure about adding rustls_backend to the serenity cargo.toml, Was the only way I could get the check to pass. I could not figure out how to pass two to the -F/--feature flag.



## How has this been tested? (if applicable)
Made sure the commands generated by the pipeline pass.

