### PR TITLE
feat(gateway): add cch projects idle admin endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,9 +803,9 @@ workflows:
     jobs:
       - approve-push-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -803,9 +803,9 @@ workflows:
     jobs:
       - approve-push-unstable:
           type: approval
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/admin/src/args.rs
+++ b/admin/src/args.rs
@@ -30,6 +30,9 @@ pub enum Command {
     /// Viewing and managing stats
     #[command(subcommand)]
     Stats(StatsCommand),
+
+    /// Forcefully idle CCH projects.
+    IdleCch,
 }
 
 #[derive(Subcommand, Debug)]

--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -22,7 +22,14 @@ impl Client {
     }
 
     pub async fn idle_cch(&self) -> Result<()> {
-        self.post("/admin/idle-cch", Option::<String>::None).await
+        reqwest::Client::new()
+            .post(format!("{}/admin/idle-cch", self.api_url))
+            .bearer_auth(&self.api_key)
+            .send()
+            .await
+            .context("failed to send idle request")?;
+
+        Ok(())
     }
 
     pub async fn acme_account_create(

--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -21,6 +21,10 @@ impl Client {
         self.post("/admin/destroy", Option::<String>::None).await
     }
 
+    pub async fn idle_cch(&self) -> Result<()> {
+        self.post("/admin/idle-cch", Option::<String>::None).await
+    }
+
     pub async fn acme_account_create(
         &self,
         email: &str,
@@ -125,7 +129,7 @@ impl Client {
             .bearer_auth(&self.api_key)
             .send()
             .await
-            .context("failed to make post request")?
+            .context("failed to make get request")?
             .to_json()
             .await
             .context("failed to post text body from response")

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -161,6 +161,10 @@ async fn main() {
                 resp.builds_count, has_capacity
             )
         }
+        Command::IdleCch => match client.idle_cch().await {
+            Ok(_) => "Idled CCH projects".to_string(),
+            Err(err) => format!("failed to idle CCH projects: {}", err),
+        },
     };
 
     println!("{res}");

--- a/admin/src/main.rs
+++ b/admin/src/main.rs
@@ -161,10 +161,10 @@ async fn main() {
                 resp.builds_count, has_capacity
             )
         }
-        Command::IdleCch => match client.idle_cch().await {
-            Ok(_) => "Idled CCH projects".to_string(),
-            Err(err) => format!("failed to idle CCH projects: {}", err),
-        },
+        Command::IdleCch => {
+            client.idle_cch().await.expect("cch projects to be idled");
+            "Idled CCH projects".to_string()
+        }
     };
 
     println!("{res}");

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -334,6 +334,17 @@ impl GatewayService {
         Ok(iter)
     }
 
+    pub async fn iter_cch_projects(
+        &self,
+    ) -> Result<impl ExactSizeIterator<Item = ProjectName>, Error> {
+        let iter = query("SELECT project_name FROM projects WHERE project_name LIKE 'cch23-%'")
+            .fetch_all(&self.db)
+            .await?
+            .into_iter()
+            .map(|row| (row.get("project_name")));
+        Ok(iter)
+    }
+
     /// The number of projects that are currently in the ready state
     pub async fn count_ready_projects(&self) -> Result<u32, Error> {
         let ready_count: u32 =


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Add an admin endpoint to forcefully idle cch projects, so we can idle projects that are not correctly idled by the ambulance task.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

TODO
