### PR TITLE
refactor: remove generics

### DIFF
--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -242,7 +242,7 @@ impl GatewayContextProvider {
 pub struct GatewayService {
     provider: GatewayContextProvider,
     db: SqlitePool,
-    task_router: TaskRouter<BoxedTask>,
+    task_router: TaskRouter,
     state_location: PathBuf,
 
     /// Maximum number of containers the gateway can start before blocking cch projects
@@ -274,7 +274,7 @@ impl GatewayService {
             format!("{}auth/key", args.auth_uri).parse().unwrap(),
         );
 
-        let task_router = TaskRouter::new();
+        let task_router = TaskRouter::default();
         Self {
             provider,
             db,
@@ -934,7 +934,7 @@ impl GatewayService {
         )
     }
 
-    pub fn task_router(&self) -> TaskRouter<BoxedTask> {
+    pub fn task_router(&self) -> TaskRouter {
         self.task_router.clone()
     }
 

--- a/gateway/src/task.rs
+++ b/gateway/src/task.rs
@@ -243,11 +243,11 @@ impl TaskBuilder {
 pub struct Route<T> {
     project_name: ProjectName,
     inner: Option<T>,
-    router: TaskRouter<T>,
+    router: TaskRouter,
 }
 
 impl<T> Route<T> {
-    pub fn to(project_name: ProjectName, what: T, router: TaskRouter<T>) -> Self {
+    pub fn to(project_name: ProjectName, what: T, router: TaskRouter) -> Self {
         Self {
             project_name,
             inner: Some(what),

--- a/gateway/src/task.rs
+++ b/gateway/src/task.rs
@@ -429,10 +429,10 @@ where
 /// the error. The value returned by the inner tasks upon their
 /// completion is committed back to persistence through
 /// [GatewayService].
-pub struct ProjectTask<T> {
+pub struct ProjectTask {
     project_name: ProjectName,
     service: Arc<GatewayService>,
-    tasks: VecDeque<T>,
+    tasks: VecDeque<BoxedTask<ProjectContext, Project>>,
     tracing_context: HashMap<String, String>,
 }
 
@@ -455,10 +455,7 @@ pub struct ProjectContext {
 pub type BoxedTask<Ctx = (), O = ()> = Box<dyn Task<Ctx, Output = O>>;
 
 #[async_trait]
-impl<T> Task<()> for ProjectTask<T>
-where
-    T: Task<ProjectContext, Output = Project>,
-{
+impl Task<()> for ProjectTask {
     type Output = ();
 
     async fn poll(&mut self, _: ()) -> TaskResult<Self::Output> {

--- a/gateway/src/worker.rs
+++ b/gateway/src/worker.rs
@@ -78,33 +78,12 @@ impl Worker<BoxedTask> {
     }
 }
 
-pub struct TaskRouter<W> {
-    table: Arc<RwLock<HashMap<ProjectName, Sender<W>>>>,
+#[derive(Clone, Default)]
+pub struct TaskRouter {
+    table: Arc<RwLock<HashMap<ProjectName, Sender<BoxedTask>>>>,
 }
 
-impl<W> Clone for TaskRouter<W> {
-    fn clone(&self) -> Self {
-        Self {
-            table: self.table.clone(),
-        }
-    }
-}
-
-impl<W> Default for TaskRouter<W> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<W> TaskRouter<W> {
-    pub fn new() -> Self {
-        Self {
-            table: Arc::new(RwLock::new(HashMap::new())),
-        }
-    }
-}
-
-impl TaskRouter<BoxedTask> {
+impl TaskRouter {
     pub async fn route(
         &self,
         name: &ProjectName,

--- a/gateway/src/worker.rs
+++ b/gateway/src/worker.rs
@@ -12,24 +12,18 @@ use crate::Error;
 
 pub const WORKER_QUEUE_SIZE: usize = 2048;
 
-pub struct Worker<W = BoxedTask> {
-    send: Option<Sender<W>>,
-    recv: Receiver<W>,
+pub struct Worker {
+    send: Option<Sender<BoxedTask>>,
+    recv: Receiver<BoxedTask>,
 }
 
-impl<W> Default for Worker<W>
-where
-    W: Send,
-{
+impl Default for Worker {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<W> Worker<W>
-where
-    W: Send,
-{
+impl Worker {
     pub fn new() -> Self {
         let (send, recv) = channel(WORKER_QUEUE_SIZE);
         Self {
@@ -42,12 +36,10 @@ where
     ///
     /// # Panics
     /// If this worker has already started.
-    pub fn sender(&self) -> Sender<W> {
+    pub fn sender(&self) -> Sender<BoxedTask> {
         Sender::clone(self.send.as_ref().unwrap())
     }
-}
 
-impl Worker<BoxedTask> {
     /// Starts the worker, waiting and processing elements from the
     /// queue until the last sending end for the channel is dropped,
     /// at which point this future resolves.


### PR DESCRIPTION
## Description of change
Removes a bunch of unused generics in the state machine so that it is easier to reason about it. It will be best to review this on a per commit basis


## How has this been tested? (if applicable)
Clippy is still happy


