### PR TITLE
Setup datadog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,10 +363,10 @@ jobs:
         description: "Use public registry"
         type: boolean
         default: true
-      production:
-        description: "Push and deploy to production"
-        type: boolean
-        default: false
+      shuttle-env:
+        description: "Push and deploy to the given env"
+        type: string
+        default: staging
     steps:
       - checkout
       - run:
@@ -384,7 +384,7 @@ jobs:
       - run:
           name: Make and push images
           command: |
-            PUSH=true PROD=<< parameters.production >> PLATFORMS=linux/amd64 TAG=$TAG make images
+            PUSH=true SHUTTLE_ENV=<< parameters.shuttle-env >> PLATFORMS=linux/amd64 TAG=$TAG make images
       - save-buildx-cache
   deploy-images:
     executor: machine-ubuntu
@@ -423,10 +423,10 @@ jobs:
       jwt-signing-private-key:
         description: "Auth private key used for JWT signing"
         type: string
-      production:
-        description: "Push and deploy to production"
-        type: boolean
-        default: false
+      shuttle-env:
+        description: "Push and deploy to the given env"
+        type: string
+        default: staging
     steps:
       - checkout
       - run:
@@ -444,7 +444,7 @@ jobs:
           command: |
             DOCKER_HOST=ssh://ec2-user@master.<< parameters.ssh-host >> \
             TAG=$TAG \
-            PROD=<< parameters.production >> \
+            SHUTTLE_ENV=<< parameters.shuttle-env >> \
             USE_TLS=enable \
             POSTGRES_PASSWORD=${<< parameters.postgres-password >>} \
             MONGO_INITDB_ROOT_PASSWORD=${<< parameters.mongodb-password >>} \
@@ -456,15 +456,14 @@ jobs:
             AUTH_JWTSIGNING_PRIVATE_KEY=${<< parameters.jwt-signing-private-key >>} \
             make deploy
       - when:
-          condition: << parameters.production >>
+          condition: << parameters.shuttle-env >> == "production"
           steps:
             - run:
                 name: Pull new deployer image on prod
                 command: |
                   ssh ec2-user@controller.<< parameters.ssh-host >> "docker pull public.ecr.aws/shuttle/deployer:$TAG"
       - when:
-          condition:
-            not: << parameters.production >>
+          condition: << parameters.shuttle-env >> == "staging"
           steps:
             - run:
                 name: Pull new deployer image on dev
@@ -810,7 +809,7 @@ workflows:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID
           aws-secret-access-key: DEV_AWS_SECRET_ACCESS_KEY
-          production: false
+          shuttle-env: staging
           requires:
             - approve-push-unstable
       - deploy-images:
@@ -883,7 +882,7 @@ workflows:
           name: build-and-push-production
           aws-access-key-id: PROD_AWS_ACCESS_KEY_ID
           aws-secret-access-key: PROD_AWS_SECRET_ACCESS_KEY
-          production: true
+          shuttle-env: production
           filters:
             branches:
               only: production
@@ -904,7 +903,7 @@ workflows:
           ssh-fingerprint: 6a:c5:33:fe:5b:c9:06:df:99:64:ca:17:0d:32:18:2e
           ssh-config-script: production-ssh-config.sh
           ssh-host: shuttle.prod.internal
-          production: true
+          shuttle-env: production
           requires:
             - build-and-push-production
             - approve-deploy-production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,22 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514d24875c140ed269eecc2d1b56d7b71b573716922a763c317fb1b1b4b58f15"
+dependencies = [
+ "async-trait",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.5",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
@@ -4243,6 +4259,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c4bd073648dae8ac45cfc81588d74b3dc5f334119ac08567ddcbfe16f2d809"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.21.0",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-contrib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e448fc8ad3687b1dd9073087941834f54093624c015a7fbd1f1efc5a38a7737"
+dependencies = [
+ "async-trait",
+ "http",
+ "indexmap 1.9.3",
+ "lazy_static",
+ "opentelemetry 0.12.0",
+ "opentelemetry-http 0.1.0",
+ "rmp",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a853d37ac1c02889211517007a99b2a90d3d7e89526f9af037ada84f1326a1"
+dependencies = [
+ "async-trait",
+ "http",
+ "opentelemetry 0.12.0",
+ "thiserror",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4251,7 +4309,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry",
+ "opentelemetry 0.21.0",
 ]
 
 [[package]]
@@ -4263,7 +4321,7 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -4279,7 +4337,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "opentelemetry_sdk",
  "prost 0.11.9",
  "tonic 0.9.2",
@@ -4291,7 +4349,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
- "opentelemetry",
+ "opentelemetry 0.21.0",
 ]
 
 [[package]]
@@ -4307,10 +4365,11 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "ordered-float",
  "percent-encoding",
  "rand 0.8.5",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5664,7 +5723,7 @@ dependencies = [
  "http",
  "hyper",
  "jsonwebtoken",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "pem 2.0.1",
  "portpicker",
  "rand 0.8.5",
@@ -5744,8 +5803,9 @@ dependencies = [
  "hyper",
  "jsonwebtoken",
  "once_cell",
- "opentelemetry",
- "opentelemetry-http",
+ "opentelemetry 0.21.0",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-http 0.10.0",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pin-project",
@@ -5766,6 +5826,7 @@ dependencies = [
  "tower",
  "tower-http 0.4.4",
  "tracing",
+ "tracing-core",
  "tracing-fluent-assertions",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5812,8 +5873,8 @@ dependencies = [
  "hyper",
  "hyper-reverse-proxy",
  "once_cell",
- "opentelemetry",
- "opentelemetry-http",
+ "opentelemetry 0.21.0",
+ "opentelemetry-http 0.10.0",
  "portpicker",
  "prost-types",
  "rand 0.8.5",
@@ -5867,8 +5928,9 @@ dependencies = [
  "lazy_static",
  "num_cpus",
  "once_cell",
- "opentelemetry",
- "opentelemetry-http",
+ "opentelemetry 0.21.0",
+ "opentelemetry-contrib",
+ "opentelemetry-http 0.10.0",
  "pem 1.1.1",
  "pin-project",
  "portpicker",
@@ -7159,7 +7221,7 @@ checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.21.0",
  "opentelemetry_sdk",
  "smallvec",
  "tracing",
@@ -7167,6 +7229,16 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]
@@ -7179,12 +7251,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -8622,3 +8697,75 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "shuttle-actix-web"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-aws-rds"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-axum"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-metadata"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-next"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-persist"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-poem"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-poise"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-rocket"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-salvo"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-secrets"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-serenity"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-shared-db"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-thruster"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-tide"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-tower"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-turso"
+version = "0.34.1"
+
+[[patch.unused]]
+name = "shuttle-warp"
+version = "0.34.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,10 +67,12 @@ hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", 
 jsonwebtoken = "9.0.0"
 once_cell = "1.16.0"
 opentelemetry = "0.21.0"
-opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio", "logs"] }
 opentelemetry-http = "0.10.0"
-opentelemetry-otlp = "0.14.0"
+opentelemetry-otlp = { version =  "0.14.0", features = ["logs", "grpc-tonic"] }
 opentelemetry-proto = "0.4.0"
+opentelemetry-contrib = { version = "0.4.0", features = ["datadog"] }
+opentelemetry-appender-tracing = "0.2.0"
 percent-encoding = "2.2"
 pin-project = "1.0.12"
 portpicker = "0.1.1"
@@ -98,9 +100,11 @@ tonic = "0.10.2"
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = { version = "0.1.37", default-features = false }
+tracing-core = { version = "0.1.32", default-features = false }
 tracing-opentelemetry = "0.22.0"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
   "registry",
+  "json"
 ] }
 ttl_cache = "0.5.1"
 utoipa = { version = "4.0.0", features = [ "uuid", "chrono" ] }

--- a/Containerfile
+++ b/Containerfile
@@ -97,7 +97,7 @@ RUN for target_platform in "linux/arm64" "linux/arm64/v8"; do \
     if [ "$TARGETPLATFORM" = "$target_platform" ]; then \
       mv /usr/lib/ulid0_aarch64.so /usr/lib/ulid0.so; fi; done
 # Used as env variable in prepare script
-ARG PROD
+ARG SHUTTLE_ENV
 # Easy way to check if you are running in Shuttle's container
 ARG SHUTTLE=true
 ENV SHUTTLE=${SHUTTLE}

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ PANAMAX_EXTRA_PATH?=./extras/panamax
 PANAMAX_TAG?=1.0.12
 
 OTEL_EXTRA_PATH?=./extras/otel
-OTEL_TAG?=0.72.0
+OTEL_TAG?=0.90.1
 
 USE_PANAMAX?=enable
 ifeq ($(USE_PANAMAX), enable)

--- a/Makefile
+++ b/Makefile
@@ -48,13 +48,13 @@ MONGO_INITDB_ROOT_PASSWORD?=password
 STRIPE_SECRET_KEY?=""
 AUTH_JWTSIGNING_PRIVATE_KEY?=""
 
-ifeq ($(PROD),true)
+DD_ENV=$(SHUTTLE_ENV)
+ifeq ($(SHUTTLE_ENV),production)
 DOCKER_COMPOSE_FILES=docker-compose.yml
 STACK=shuttle-prod
 APPS_FQDN=shuttleapp.rs
 DB_FQDN=db.shuttle.rs
 CONTAINER_REGISTRY=public.ecr.aws/shuttle
-DD_ENV=production
 # make sure we only ever go to production with `--tls=enable`
 USE_TLS=enable
 CARGO_PROFILE=release
@@ -65,7 +65,6 @@ STACK?=shuttle-dev
 APPS_FQDN=unstable.shuttleapp.rs
 DB_FQDN=db.unstable.shuttle.rs
 CONTAINER_REGISTRY=public.ecr.aws/shuttle-dev
-DD_ENV=unstable
 USE_TLS?=disable
 # default for local run
 CARGO_PROFILE?=debug
@@ -141,7 +140,8 @@ DOCKER_COMPOSE_ENV=\
 	DD_ENV=$(DD_ENV)\
 	USE_TLS=$(USE_TLS)\
 	COMPOSE_PROFILES=$(COMPOSE_PROFILES)\
-	DOCKER_SOCK=$(DOCKER_SOCK)
+	DOCKER_SOCK=$(DOCKER_SOCK)\
+	SHUTTLE_ENV=$(SHUTTLE_ENV)
 
 .PHONY: clean cargo-clean images the-shuttle-images shuttle-% postgres panamax otel deploy test docker-compose.rendered.yml up down
 
@@ -162,7 +162,7 @@ shuttle-%:
 		--build-arg folder=$(*) \
 		--build-arg crate=$(@) \
 		--build-arg prepare_args=$(PREPARE_ARGS) \
-		--build-arg PROD=$(PROD) \
+		--build-arg SHUTTLE_ENV=$(SHUTTLE_ENV) \
 		--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
 		--build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
 		--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,6 +25,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-appender-tracing = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
@@ -42,6 +43,7 @@ tonic = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 tracing = { workspace = true, features = ["std"], optional = true }
+tracing-core = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ttl_cache = { workspace = true, optional = true }
@@ -58,6 +60,7 @@ backend = [
     "claims",
     "hyper/client",
     "opentelemetry_sdk",
+    "opentelemetry-appender-tracing",
     "opentelemetry-otlp",
     "rustrict", # only ProjectName model uses it
     "thiserror",
@@ -66,6 +69,7 @@ backend = [
     "tower-http",
     "tracing-subscriber/env-filter",
     "tracing-subscriber/fmt",
+    "tracing-core",
     "ttl_cache",
 ]
 claims = [

--- a/common/src/backends/metrics.rs
+++ b/common/src/backends/metrics.rs
@@ -185,6 +185,8 @@ macro_rules! request_span {
         tracing::info_span!(
             "request",
             http.uri = %$request.uri(),
+            // Used by Datadog by default
+            http.route = path,
             http.method = %$request.method(),
             http.status_code = tracing::field::Empty,
             // A bunch of extra things for metrics

--- a/common/src/backends/mod.rs
+++ b/common/src/backends/mod.rs
@@ -4,3 +4,4 @@ mod future;
 pub mod headers;
 pub mod metrics;
 pub mod tracing;
+mod otlp_tracing_bridge;

--- a/common/src/backends/otlp_tracing_bridge.rs
+++ b/common/src/backends/otlp_tracing_bridge.rs
@@ -1,0 +1,154 @@
+// Taken from
+// https://github.com/open-telemetry/opentelemetry-rust/blob/e640051b8bd5d56bb058ec6caabadf2bee5244a9/opentelemetry-appender-tracing/src/layer.rs,
+// waiting for https://github.com/open-telemetry/opentelemetry-rust/pull/1394 to be merged.
+// This is under Apache License 2.0
+
+use opentelemetry::{
+    logs::{LogRecord, Logger, LoggerProvider, Severity, TraceContext},
+    trace::{SpanContext, TraceFlags, TraceState},
+};
+use std::borrow::Cow;
+use tracing_core::{Level, Subscriber};
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::{registry::LookupSpan, Layer};
+
+const INSTRUMENTATION_LIBRARY_NAME: &str = "opentelemetry-appender-tracing";
+
+/// Visitor to record the fields from the event record.
+struct EventVisitor<'a> {
+    log_record: &'a mut LogRecord,
+}
+
+impl<'a> tracing::field::Visit for EventVisitor<'a> {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.log_record.body = Some(format!("{value:?}").into());
+        } else if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), format!("{value:?}").into()));
+        } else {
+            let vec = vec![(field.name().into(), format!("{value:?}").into())];
+            self.log_record.attributes = Some(vec);
+        }
+    }
+
+    fn record_str(&mut self, field: &tracing_core::Field, value: &str) {
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.to_owned().into()));
+        } else {
+            let vec = vec![(field.name().into(), value.to_owned().into())];
+            self.log_record.attributes = Some(vec);
+        }
+    }
+
+    fn record_bool(&mut self, field: &tracing_core::Field, value: bool) {
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.into()));
+        } else {
+            let vec = vec![(field.name().into(), value.into())];
+            self.log_record.attributes = Some(vec);
+        }
+    }
+
+    fn record_f64(&mut self, field: &tracing::field::Field, value: f64) {
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.into()));
+        } else {
+            let vec = vec![(field.name().into(), value.into())];
+            self.log_record.attributes = Some(vec);
+        }
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        if let Some(ref mut vec) = self.log_record.attributes {
+            vec.push((field.name().into(), value.into()));
+        } else {
+            let vec = vec![(field.name().into(), value.into())];
+            self.log_record.attributes = Some(vec);
+        }
+    }
+
+    // TODO: Remaining field types from AnyValue : Bytes, ListAny, Boolean
+}
+
+pub struct OpenTelemetryTracingBridge<P, L>
+where
+    P: LoggerProvider<Logger = L> + Send + Sync,
+    L: Logger + Send + Sync,
+{
+    logger: L,
+    _phantom: std::marker::PhantomData<P>, // P is not used.
+}
+
+impl<P, L> OpenTelemetryTracingBridge<P, L>
+where
+    P: LoggerProvider<Logger = L> + Send + Sync,
+    L: Logger + Send + Sync,
+{
+    pub fn new(provider: &P) -> Self {
+        OpenTelemetryTracingBridge {
+            logger: provider.versioned_logger(
+                INSTRUMENTATION_LIBRARY_NAME,
+                Some(Cow::Borrowed(env!("CARGO_PKG_VERSION"))),
+                None,
+                None,
+            ),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<S, P, L> Layer<S> for OpenTelemetryTracingBridge<P, L>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    P: LoggerProvider<Logger = L> + Send + Sync + 'static,
+    L: Logger + Send + Sync + 'static,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let meta = event.metadata();
+        let mut log_record: LogRecord = LogRecord::default();
+        log_record.severity_number = Some(severity_of_level(meta.level()));
+        log_record.severity_text = Some(meta.level().to_string().into());
+
+        // Extract the trace_id & span_id from the opentelemetry extension.
+        if let Some((trace_id, span_id)) = ctx.lookup_current().and_then(|span| {
+            span.extensions()
+                .get::<OtelData>()
+                .and_then(|ext| ext.builder.trace_id.zip(ext.builder.span_id))
+        }) {
+            log_record.trace_context = Some(TraceContext::from(&SpanContext::new(
+                trace_id,
+                span_id,
+                TraceFlags::default(),
+                false,
+                TraceState::default(),
+            )));
+        }
+
+        // add the `name` metadata to attributes
+        // TBD - Propose this to be part of log_record metadata.
+        let vec = vec![
+            ("level", meta.level().to_string()),
+            ("target", meta.target().to_string()),
+        ];
+        log_record.attributes = Some(vec.into_iter().map(|(k, v)| (k.into(), v.into())).collect());
+
+        // Not populating ObservedTimestamp, instead relying on OpenTelemetry
+        // API to populate it with current time.
+
+        let mut visitor = EventVisitor {
+            log_record: &mut log_record,
+        };
+        event.record(&mut visitor);
+        self.logger.emit(log_record);
+    }
+}
+
+const fn severity_of_level(level: &Level) -> Severity {
+    match *level {
+        Level::TRACE => Severity::Trace,
+        Level::DEBUG => Severity::Debug,
+        Level::INFO => Severity::Info,
+        Level::WARN => Severity::Warn,
+        Level::ERROR => Severity::Error,
+    }
+}

--- a/deployer/prepare.sh
+++ b/deployer/prepare.sh
@@ -7,7 +7,7 @@
 # Patch crates to be on same versions
 mkdir -p $CARGO_HOME
 touch $CARGO_HOME/config.toml
-if [[ $PROD != "true" ]]; then
+if [[ "$SHUTTLE_ENV" != "production" ]]; then
     bash scripts/apply-patches.sh $CARGO_HOME/config.toml /usr/src/shuttle
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - auth-vol:/var/lib/shuttle-auth
     environment:
       - RUST_LOG=${RUST_LOG}
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
     command:
       - "--state=/var/lib/shuttle-auth"
       - "start"
@@ -90,6 +91,7 @@ services:
       - builder-store-vol:/nix/store
     environment:
       - RUST_LOG=${RUST_LOG}
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
     command:
       - "--address=0.0.0.0:8000"
       - "--auth-uri=http://auth:8000"
@@ -126,6 +128,7 @@ services:
       - ${DOCKER_SOCK}:/var/run/docker.sock
     environment:
       - RUST_LOG=${RUST_LOG}
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
     command:
       - "--state=/var/lib/shuttle"
       - "start"
@@ -172,6 +175,7 @@ services:
       default:
     environment:
       - RUST_LOG=${RUST_LOG}
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
     command:
       - "--address=0.0.0.0:8000"
       - "--db-connection-uri=${LOGGER_POSTGRES_URI}"
@@ -184,6 +188,7 @@ services:
       - auth
     environment:
       - RUST_LOG=${RUST_LOG}
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
     networks:
       user-net:
     deploy:
@@ -216,6 +221,7 @@ services:
       - auth
     environment:
       - RUST_LOG=${RUST_LOG}
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
     networks:
       user-net:
     volumes:
@@ -278,6 +284,7 @@ services:
     networks:
       user-net:
     environment:
+      - SHUTTLE_ENV=${SHUTTLE_ENV}
       - DD_API_KEY=${DD_API_KEY}
       - DD_ENV=${DD_ENV}
       - HONEYCOMB_API_KEY=${HONEYCOMB_API_KEY}

--- a/extras/otel/otel-collector-config.yaml
+++ b/extras/otel/otel-collector-config.yaml
@@ -27,10 +27,10 @@ receivers:
   prometheus/otel:
     config:
       scrape_configs:
-      - job_name: 'otelcol'
-        scrape_interval: 10s
-        static_configs:
-        - targets: ['0.0.0.0:8888']
+        - job_name: "otelcol"
+          scrape_interval: 10s
+          static_configs:
+            - targets: ["0.0.0.0:8888"]
   docker_stats:
     endpoint: unix:///var/run/docker.sock
     timeout: 20s
@@ -45,15 +45,32 @@ processors:
     timeout: 10s
   attributes:
     actions:
-      - key: env
+      - key: deployment.environment
         value: ${env:DD_ENV}
         action: insert
+  # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1909
+  # as for why we need that.
+  transform:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          # DataDog cannot pick up the span name as resource on
+          # Service Entry Spans. We append it here. This might have a
+          # side effect to overwrite an application that is instrumented with
+          # DataDog SDK. However, as long as OpenTelemetry SDK is used to
+          # instrument, this transformation will help.
+          - set(attributes["resource.name"], name)
+          # - set(attributes["service"], attributes["otel.service"])
 
 exporters:
   datadog:
     api:
       site: datadoghq.eu
       key: ${env:DD_API_KEY}
+    traces:
+      span_name_as_resource_name: true
+      # peer_tags_aggregation: true
   otlp:
     endpoint: "api.honeycomb.io:443"
     headers:
@@ -62,7 +79,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [attributes, batch]
+      processors: [attributes, batch, transform]
       exporters: [datadog, otlp]
     logs:
       receivers: [otlp]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -31,6 +31,7 @@ lazy_static = "1.4.0"
 num_cpus = "1.15.0"
 once_cell = { workspace = true }
 opentelemetry = { workspace = true }
+opentelemetry-contrib = { workspace = true }
 opentelemetry-http = { workspace = true }
 pem = "1.1.1"
 pin-project = { workspace = true }


### PR DESCRIPTION
## Description of change

The `SHUTTLE_ENV` thing isn't really required anymore. Started doing that because I wanted to switch the log based on the env, and also wanted to setup a different environment when using Datadog locally (`dev`) to be able to test it. I can revert or split it up in an other PR if needed. This is only the first commit.

The main changes are in the other ones.

- Log correlation + correctly named spans.
![image](https://github.com/shuttle-hq/shuttle/assets/59063/78350062-6fa0-45eb-ba67-3505c54dc59c)

- Right resource, right service in the traces.
![image](https://github.com/shuttle-hq/shuttle/assets/59063/6ee0ae2b-01c9-4621-a8a2-4dc46bda89d7)

- Actual logs, correlated, with the right service.
![image](https://github.com/shuttle-hq/shuttle/assets/59063/30cc7213-113b-4a6c-a127-cdaed262262d)





## How has this been tested? (if applicable)

Ran it locally, connected to Datadog.


