### PR TITLE
feat(gateway/ambulance): parallelize work done by the ambulance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -825,9 +825,9 @@ workflows:
     jobs:
       - approve-push-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -76,6 +76,8 @@ async fn main() -> io::Result<()> {
     }
 }
 
+const AMBULANCE_MAX_PARALLEL_POLL: usize = 8;
+
 async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
     let gateway = Arc::new(GatewayService::init(args.context.clone(), db, fs).await);
 
@@ -128,7 +130,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
 
                         for (project_name, _) in projects {
                             // Wait for completion of next future before enqueuing a new one
-                            if work_set.len() >= 8 {
+                            if work_set.len() >= AMBULANCE_MAX_PARALLEL_POLL {
                                 if let Some(Err(err)) = work_set.join_next().await {
                                     error!(
                                         error = %err,


### PR DESCRIPTION
## Description of change

Uses a `FuturesUnordered` to keep track of 8 tasks in parallel. If we already have more than 8 in progress, it will wait for the first one to be done before moving on.


## How has this been tested? (if applicable)

Testing in progress right now.


