### PR TITLE
fix(cargo-shuttle): remove newline from errored project state output

### DIFF
--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -132,7 +132,7 @@ impl Display for State {
             State::Destroying => write!(f, "destroying"),
             State::Destroyed => write!(f, "destroyed"),
             State::Errored { message } => {
-                write!(f, "errored\n\tmessage: {message}")
+                write!(f, "errored (message: {message})")
             }
             State::Deleted => write!(f, "deleted"),
         }


### PR DESCRIPTION
## Description of change

Updates `impl Display for State` to remove tab and newline from errored project state, which caused issues with the table output as shown in #1451.
Closes #1451.

## How has this been tested?

The project I would use to test has stopped now, so I don't have one in an errored state, but this change is very localised and does not affect control flow, only text output.

### Sidenote

In future it would be cool to have a testing API url which has a range of dummy projects / states, but that's for another issue :)