### PR TITLE
fix(optl): correctly set deployment.environment resource

### DIFF
--- a/common/src/backends/tracing.rs
+++ b/common/src/backends/tracing.rs
@@ -46,12 +46,10 @@ where
                 .tonic()
                 .with_endpoint(otlp_address.clone()),
         )
-        .with_trace_config(
-            trace::config().with_resource(Resource::new(vec![KeyValue::new(
-                "service.name",
-                backend.to_string().to_lowercase(),
-            )])),
-        )
+        .with_trace_config(trace::config().with_resource(Resource::new(vec![
+            KeyValue::new("service.name", backend.to_string().to_lowercase()),
+            KeyValue::new("deployment.environment", shuttle_env.clone()),
+        ])))
         .install_batch(Tokio)
         .unwrap();
 
@@ -61,7 +59,7 @@ where
         .logging()
         .with_log_config(Config::default().with_resource(Resource::new(vec![
             KeyValue::new("service.name", backend.to_string().to_lowercase()),
-            KeyValue::new("deployment.environment", shuttle_env),
+            KeyValue::new("deployment.environment", shuttle_env.clone()),
         ])))
         .with_exporter(
             opentelemetry_otlp::new_exporter()

--- a/extras/otel/otel-collector-config.yaml
+++ b/extras/otel/otel-collector-config.yaml
@@ -46,8 +46,13 @@ processors:
   attributes:
     actions:
       - key: env
-        value: ${env:DD_ENV}
+        value: ${env:SHUTTLE_ENV}
         action: insert
+  resource:
+    attributes:
+      - key: deployment.environment
+        action: upsert
+        value: ${env:SHUTTLE_ENV}
   # See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/1909
   # as for why we need that.
 
@@ -75,5 +80,5 @@ service:
       exporters: [datadog, otlp]
     metrics:
       receivers: [hostmetrics, prometheus/otel, otlp]
-      processors: [batch]
+      processors: [attributes, batch]
       exporters: [datadog]


### PR DESCRIPTION
## Description of change

The issue was that previously I was setting it as an attribute instead of a resource (i.e. a tag in Datadog naming convention). Attributes are at the event levelt, while resources are at the service/host level.




## How has this been tested? (if applicable)

Locally, and it works.


