### PR TITLE
feat(cargo-shuttle): add --no-confirmation flag to project deletion

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -218,7 +218,11 @@ pub enum ProjectCommand {
         raw: bool,
     },
     /// Delete a project and all linked data
-    Delete,
+    Delete {
+        #[arg(long, default_value_t = false)]
+        /// Skip project delete confirmation
+        no_confirmation: bool,
+    },
 }
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Description of change

Allow to skip confirmation for deleting projects.

