### PR TITLE
feat(cargo-shuttle): change no_confirmation flag to -y/--yes, add it to resource delete

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -194,6 +194,8 @@ pub enum ResourceCommand {
         /// Use the string in the 'Type' column as displayed in the `resource list` command.
         /// For example, 'database::shared::postgres'.
         resource_type: resource::Type,
+        #[command(flatten)]
+        confirmation: ConfirmationArgs,
     },
 }
 
@@ -226,11 +228,14 @@ pub enum ProjectCommand {
         raw: bool,
     },
     /// Delete a project and all linked data
-    Delete {
-        #[arg(long, default_value_t = false)]
-        /// Skip project delete confirmation
-        no_confirmation: bool,
-    },
+    Delete(ConfirmationArgs),
+}
+
+#[derive(Parser, Debug)]
+pub struct ConfirmationArgs {
+    #[arg(long, short, default_value_t = false)]
+    /// Skip confirmations and proceed
+    pub yes: bool,
 }
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Nice to have before the feature is released.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

checked that help pages are printed correctly
