### PR TITLE
ci: fix deploy-images conditional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -825,16 +825,16 @@ workflows:
     jobs:
       - approve-push-unstable:
           type: approval
-          # filters:
-          #   branches:
-          #     only: main
-      # - build-and-push:
-      #     name: build-and-push-unstable
-      #     aws-access-key-id: DEV_AWS_ACCESS_KEY_ID
-      #     aws-secret-access-key: DEV_AWS_SECRET_ACCESS_KEY
-      #     shuttle-env: staging
-      #     requires:
-      #       - approve-push-unstable
+          filters:
+            branches:
+              only: main
+      - build-and-push:
+          name: build-and-push-unstable
+          aws-access-key-id: DEV_AWS_ACCESS_KEY_ID
+          aws-secret-access-key: DEV_AWS_SECRET_ACCESS_KEY
+          shuttle-env: staging
+          requires:
+            - approve-push-unstable
       - deploy-images:
           name: Deploy images to unstable
           postgres-password: DEV_POSTGRES_PASSWORD
@@ -844,8 +844,8 @@ workflows:
           logger-postgres-uri: DEV_LOGGER_POSTGRES_URI
           stripe-secret-key: DEV_STRIPE_SECRET_KEY
           jwt-signing-private-key: DEV_AUTH_JWTSIGNING_PRIVATE_KEY
-          # requires:
-          #   - build-and-push-unstable
+          requires:
+            - build-and-push-unstable
   release:
     jobs:
       - linux-qa:


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

The deploy-images job correctly set the services with the 'staging' shuttle_env variable for a staging deployment, but the conditional that determines which deployer to pull pulls the production one.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested in CI: https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/5215/workflows/0e318273-38ea-4db4-9f35-c3b1c5123ca7/jobs/125342
