### PR TITLE
tests(resource-recorder): allow server time to start

### DIFF
--- a/resource-recorder/tests/integration.rs
+++ b/resource-recorder/tests/integration.rs
@@ -36,7 +36,7 @@ async fn manage_resources() {
 
     let test_future = async {
         // Make sure the server starts first
-        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let mut client = ResourceRecorderClient::connect(format!("http://localhost:{port}"))
             .await


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This should resolve these spurious ci failures: https://app.circleci.com/pipelines/github/shuttle-hq/shuttle/5230/workflows/98babb6a-6d17-4fd8-87c6-2bb78d23e754/jobs/125877

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Locally and in CI.
