### PR TITLE
feat: posthog tracking of deployment starts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-posthog"
+version = "0.2.3"
+source = "git+https://github.com/shuttle-hq/posthog-rs?branch=main#4a8299fde3080bff550620c0853be9b83fee8f44"
+dependencies = [
+ "posthog-core",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "async-session"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,8 +1275,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
 
@@ -4660,6 +4675,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "posthog-core"
+version = "0.1.0"
+source = "git+https://github.com/shuttle-hq/posthog-rs?branch=main#4a8299fde3080bff550620c0853be9b83fee8f44"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5919,6 +5945,7 @@ name = "shuttle-deployer"
 version = "0.35.1"
 dependencies = [
  "anyhow",
+ "async-posthog",
  "async-trait",
  "axum",
  "bytes",

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -57,6 +57,7 @@ utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 ulid = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+async-posthog = { git = "https://github.com/shuttle-hq/posthog-rs", branch = "main" }
 
 [dev-dependencies]
 ctor = { workspace = true }

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -55,6 +55,10 @@ pub struct Args {
     #[clap(long)]
     pub admin_secret: String,
 
+    // Posthog client key
+    #[clap(long)]
+    pub posthog_key: String,
+
     /// Address to reach the authentication service at
     #[clap(long, default_value = "http://auth:8000")]
     pub auth_uri: Uri,

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -44,6 +44,7 @@ pub async fn start(
             >,
         >,
     >,
+    posthog_client: async_posthog::Client,
     args: Args,
 ) {
     // when _set is dropped once axum exits, the deployment tasks will be aborted.
@@ -57,6 +58,7 @@ pub async fn start(
         .builder_client(builder_client)
         .queue_client(GatewayClient::new(args.gateway_uri))
         .log_fetcher(log_fetcher)
+        .posthog_client(posthog_client)
         .build();
 
     persistence.cleanup_invalid_states().await.unwrap();

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -1,5 +1,6 @@
-use std::process::exit;
+use std::{process::exit, time::Duration};
 
+use async_posthog::ClientOptions;
 use clap::Parser;
 use shuttle_common::{
     backends::tracing::setup_tracing,
@@ -59,6 +60,14 @@ async fn main() {
         }
     };
 
+    let ph_client_options = ClientOptions::new(
+        args.posthog_key.to_string(),
+        "https://eu.posthog.com".to_string(),
+        Duration::from_millis(800),
+    );
+
+    let posthog_client = async_posthog::client(ph_client_options);
+
     setup_tracing(
         tracing_subscriber::registry()
             .with(StateChangeLayer {
@@ -84,7 +93,7 @@ async fn main() {
         _ = start_proxy(args.proxy_address, args.proxy_fqdn.clone(), persistence.clone()) => {
             error!("Proxy stopped.")
         },
-        _ = start(persistence, runtime_manager, logger_batcher, logger_client, builder_client, args) => {
+        _ = start(persistence, runtime_manager, logger_batcher, logger_client, builder_client, posthog_client, args) => {
             error!("Deployment service stopped.")
         },
     }


### PR DESCRIPTION
## Description of change
The idea was to implement tracking for 2 user actions: Logging in via CLI and project deployment.
Deployment part is pretty straightforward and is included in this PR.

Logging in is a bit tricky: We already track login actions in console, and we have a restriction that we cannot add tracking actions to the CLI itself (maybe we could come around this idea later?).

Anyways, logging in works in 2 ways from the CLI: if you provide you api key upfront, the request does not go anywhere and we cannot track it since it all happens inside cargo-shuttle.
Otherwise user is redirected to console to log in, which we already track.


## How has this been tested? (if applicable)
`shuttle_api_start_deployment` was ingested by PostHog client.


