### PR TITLE
fix(provisioner): only delete new rds on failed subscription update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -838,9 +838,9 @@ workflows:
               only: main
       - approve-build-and-push-images-unstable:
           type: approval
-          # filters:
-          #   branches:
-          #     only: main
+          filters:
+            branches:
+              only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

A call should not be mad to provision a database that already exists, but this may change in the future, so I added a safe-guard to ensure only new RDS instances will be deleted if the subscription update fails.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested on staging, a new instance still has its subscription updated as expected.
