### PR TITLE
refactor(auth): add postgresql enum type for account_tier

### DIFF
--- a/auth/migrations/0001_add_enum_type.sql
+++ b/auth/migrations/0001_add_enum_type.sql
@@ -1,0 +1,5 @@
+-- The order of the variants gives the ordering for the type, so it would be best to keep them in lexicographical order.
+CREATE TYPE tier AS ENUM ('admin', 'basic', 'cancelledpro', 'deployer', 'pendingpaymentpro', 'pro', 'team');
+ALTER TABLE users ALTER COLUMN account_tier DROP DEFAULT;
+ALTER TABLE users ALTER COLUMN account_tier TYPE tier USING account_tier::tier;
+ALTER TABLE users ALTER COLUMN account_tier SET DEFAULT 'basic';

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Formatter, io::ErrorKind, str::FromStr};
+use std::{fmt::Formatter, str::FromStr};
 
 use async_trait::async_trait;
 use axum::{
@@ -50,7 +50,7 @@ impl UserManagement for UserManager {
         query("INSERT INTO users (account_name, key, account_tier) VALUES ($1, $2, $3)")
             .bind(&name)
             .bind(&key)
-            .bind(tier.to_string())
+            .bind(tier)
             .execute(&self.pool)
             .await?;
 
@@ -84,7 +84,7 @@ impl UserManagement for UserManager {
             let rows_affected = query(
                 "UPDATE users SET account_tier = $1, subscription_id = $2 WHERE account_name = $3",
             )
-            .bind(AccountTier::Pro.to_string())
+            .bind(AccountTier::Pro)
             .bind(subscription_id)
             .bind(name)
             .execute(&self.pool)
@@ -105,7 +105,7 @@ impl UserManagement for UserManager {
     // Update tier leaving the subscription_id untouched.
     async fn update_tier(&self, name: &AccountName, tier: AccountTier) -> Result<(), Error> {
         let rows_affected = query("UPDATE users SET account_tier = $1 WHERE account_name = $2")
-            .bind(tier.to_string())
+            .bind(tier)
             .bind(name)
             .execute(&self.pool)
             .await?
@@ -274,12 +274,7 @@ impl FromRow<'_, PgRow> for User {
         Ok(User {
             name: row.try_get("account_name").unwrap(),
             key: Secret::new(row.try_get("key").unwrap()),
-            account_tier: AccountTier::from_str(row.try_get("account_tier").unwrap()).map_err(
-                |err| sqlx::Error::ColumnDecode {
-                    index: "account_tier".to_string(),
-                    source: Box::new(std::io::Error::new(ErrorKind::Other, err.to_string())),
-                },
-            )?,
+            account_tier: row.try_get("account_tier").unwrap(),
             subscription_id: row
                 .try_get("subscription_id")
                 .ok()

--- a/auth/tests/api/helpers.rs
+++ b/auth/tests/api/helpers.rs
@@ -44,7 +44,7 @@ pub(crate) async fn app() -> TestApp {
     query("INSERT INTO users (account_name, key, account_tier) VALUES ($1, $2, $3)")
         .bind("admin")
         .bind(ADMIN_KEY)
-        .bind(AccountTier::Admin.to_string())
+        .bind(AccountTier::Admin)
         .execute(&pg_pool)
         .await
         .unwrap();

--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -173,8 +173,15 @@ impl Default for ScopeBuilder {
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "display", derive(strum::Display))]
 #[cfg_attr(feature = "persist", derive(sqlx::Type))]
-#[cfg_attr(feature = "persist", sqlx(rename_all = "lowercase"))]
+#[cfg_attr(
+    feature = "persist",
+    sqlx(type_name = "tier", rename_all = "lowercase")
+)]
 #[cfg_attr(feature = "display", strum(serialize_all = "lowercase"))]
+/// This enum represents the Shuttle account tiers. It gets persisted especially into
+/// our auth service database, which is PostgreSQL based, and for data validity reason
+/// is backed in PostgreSQL by an enum type, which must mirror the same enum variants
+/// we see in this Rust enum.
 pub enum AccountTier {
     #[default]
     Basic,


### PR DESCRIPTION
## Description of change

Applied the recommendations here: https://docs.rs/sqlx/latest/sqlx/postgres/types/index.html#enumerations. Also important from a data integrity standpoint, to link PostgreSQL and Rust types.

There are also official PostgreSQL docs referring to type safety, ordering, and implementation details (e.g. how to alter the enum type after it is created): https://www.postgresql.org/docs/current/datatype-enum.html. 

## How has this been tested? (if applicable)

TODO on staging.


