### PR TITLE
feat(service): emit trace with shuttle dependencies

### DIFF
--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -134,7 +134,11 @@ pub async fn build_workspace(
             let mut shuttle_deps = member
                 .dependencies
                 .iter()
-                .filter_map(|d| d.name.starts_with("shuttle-").then(|| d.name.clone()))
+                .filter_map(|d| {
+                    d.name
+                        .starts_with("shuttle-")
+                        .then(|| format!("{} '{}'", d.name, d.req))
+                })
                 .collect::<Vec<_>>();
             shuttle_deps.sort();
             info!(name = member.name, deps = ?shuttle_deps, "Compiled workspace member with shuttle dependencies");

--- a/service/src/runner.rs
+++ b/service/src/runner.rs
@@ -50,9 +50,8 @@ pub async fn start(
     };
 
     info!(
-        "Spawning runtime process: {} {}",
-        runtime_executable.display(),
-        args.join(" ")
+        args = %format!("{} {}", runtime_executable.display(), args.join(" ")),
+        "Spawning runtime process",
     );
     let runtime = process::Command::new(
         dunce::canonicalize(runtime_executable).context("canonicalize path of executable")?,


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Allows collecting traces for analysis of which shuttle crates are being used. Includes semver requirement. Example:

```
2023-12-28T02:07:02.747609Z  INFO shuttle_service::builder: Compiled workspace member with shuttle dependencies name="hello-world" deps=["shuttle-axum '^0.35.0, >=0.34.0'", "shuttle-runtime '^0.35.0'"]
```

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Local run with RUST_LOG produced the above.
