### PR TITLE
bug: missing gateway key when trying to get jwt

### DIFF
--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -36,9 +36,6 @@ pub struct StartArgs {
     /// Address to bind the user proxy to
     #[arg(long, default_value = "127.0.0.1:8000")]
     pub user: SocketAddr,
-    /// API key used by the gateway to authorize API keys to JWTs conversion
-    #[arg(long)]
-    pub admin_key: String,
     /// Allows to disable the use of TLS in the user proxy service (DANGEROUS)
     #[arg(long, default_value = "enable")]
     pub use_tls: UseTls,
@@ -77,6 +74,9 @@ pub struct ContextArgs {
     /// The path to the docker daemon socket
     #[arg(long, default_value = "/var/run/docker.sock")]
     pub docker_host: String,
+    /// API key used by the gateway to authorize API keys to JWTs conversion
+    #[arg(long)]
+    pub admin_key: String,
     /// Api key for the user that has rights to start deploys
     #[arg(long, default_value = "gateway4deployes")]
     pub deploys_api_key: String,

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -564,7 +564,6 @@ pub mod tests {
                 user,
                 bouncer,
                 use_tls: UseTls::Disable,
-                admin_key: "dummykey".to_string(),
                 context: ContextArgs {
                     docker_host,
                     image,
@@ -592,6 +591,7 @@ pub mod tests {
                     .unwrap(),
                     network_name,
                     proxy_fqdn: FQDN::from_str("test.shuttleapp.rs").unwrap(),
+                    admin_key: "dummykey".to_string(),
                     deploys_api_key: "gateway".to_string(),
                     cch_container_limit: 1,
                     soft_container_limit: 2,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -179,7 +179,7 @@ async fn start(db: SqlitePool, fs: PathBuf, args: StartArgs) -> io::Result<()> {
 
     let api_handle = api_builder
         .with_default_routes()
-        .with_auth_service(args.context.auth_uri, args.admin_key)
+        .with_auth_service(args.context.auth_uri, args.context.admin_key)
         .with_default_traces()
         .serve();
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -1144,7 +1144,7 @@ impl DockerContext for GatewayContext {
 }
 
 impl GatewayContext {
-    #[instrument(skip(self), fields(auth_key_uri = %self.auth_key_uri, gateway_key = self.gateway_api_key, deploys_key = self.deploys_api_key))]
+    #[instrument(skip(self), fields(auth_key_uri = %self.auth_key_uri))]
     pub async fn get_jwt(&self) -> String {
         let mut req = Request::builder().uri(self.auth_key_uri.clone());
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -13,7 +13,6 @@ use axum::response::Response;
 use bollard::container::StatsOptions;
 use bollard::{Docker, API_DEFAULT_VERSION};
 use fqdn::{Fqdn, FQDN};
-use http::header::AUTHORIZATION;
 use http::Uri;
 use hyper::client::connect::dns::GaiResolver;
 use hyper::client::HttpConnector;


### PR DESCRIPTION
## Description of change
Gateway is unable to start the last deploy when starting idle / stopped projects because it is not getting a JWT from auth. The reason it is not getting a JWT from auth is because auth expects an admin key to be present since #1487 and we missed plugging this flow too :see_no_evil: 


## How has this been tested? (if applicable)
Using the local runner


