### PR TITLE
fix: tracing fixes and nits

### DIFF
--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -18,7 +18,7 @@ use tracing::{error, instrument};
 
 use super::{builder::KeyManagerState, RouterState, UserManagerState};
 
-#[instrument(skip(user_manager))]
+#[instrument(skip(user_manager), fields(account.name = %account_name))]
 pub(crate) async fn get_user(
     _: Admin,
     State(user_manager): State<UserManagerState>,
@@ -29,7 +29,7 @@ pub(crate) async fn get_user(
     Ok(Json(user.into()))
 }
 
-#[instrument(skip(user_manager))]
+#[instrument(skip(user_manager), fields(account.name = %account_name))]
 pub(crate) async fn post_user(
     _: Admin,
     State(user_manager): State<UserManagerState>,
@@ -40,7 +40,7 @@ pub(crate) async fn post_user(
     Ok(Json(user.into()))
 }
 
-#[instrument(skip(user_manager))]
+#[instrument(skip(user_manager), fields(account.name = %account_name))]
 pub(crate) async fn update_user_tier(
     _: Admin,
     State(user_manager): State<UserManagerState>,
@@ -143,6 +143,7 @@ pub(crate) async fn convert_cookie(
 }
 
 /// Convert a valid API-key bearer token to a JWT.
+#[instrument(skip_all, fields(account.name = tracing::field::Empty))]
 pub(crate) async fn convert_key(
     _: Admin,
     State(RouterState {

--- a/gateway/src/task.rs
+++ b/gateway/src/task.rs
@@ -491,7 +491,7 @@ impl Task<()> for ProjectTask {
 
         let span = info_span!(
             "polling project",
-            ctx.project = ?project_ctx.project_name.to_string(),
+            ctx.project = %project_ctx.project_name,
             ctx.state = project_ctx.state.state(),
             ctx.state_after = field::Empty
         );
@@ -506,7 +506,7 @@ impl Task<()> for ProjectTask {
                     res = &mut poll => res,
                     _ = timeout => {
                         warn!(
-                            project_name = ?self.project_name,
+                            project_name = %self.project_name,
                             "a task has been idling for a long time"
                         );
                         poll.await


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Tracing instrument uses the debug impl by default, and for newtypes that means output like `AccountName("name")`. This PR fixes that by using the display impl instead. Additionally, I added some missing fields in the deployer proxy span, and set the status code to 500 in case of errors. 

For the deployer proxy I added the `shuttle.service` field to the span, since it is being recorded in the function body. We do already have the `service` field, however, which is the same thing, and that is being recorded correctly. I'd like to deduplicate it and have just `shuttle.service`, but I haven't figured out where `service` is actually recorded yet.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

TODO: test this to verify these updates work as expected.
