### PR TITLE
feat(installer): add windows installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ On Linux and macOS, you can use this install script, which will automatically in
 curl -sSfL https://www.shuttle.rs/install | bash
 ```
 
+On Windows, you can use this install script to do the same:
+
+```powershell
+Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://www.shuttle.rs/install-win").Content
+```
+
 Our binaries can also be installed using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
 To install with `cargo-binstall`, run:
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ curl -sSfL https://www.shuttle.rs/install | bash
 On Windows, you can use this install script to do the same:
 
 ```powershell
-Set-ExecutionPolicy Unrestricted -Scope Process; iex (iwr "https://www.shuttle.rs/install-win").Content
+iwr "https://www.shuttle.rs/install-win" | iex
 ```
 
 Our binaries can also be installed using [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).

--- a/install.ps1
+++ b/install.ps1
@@ -68,7 +68,7 @@ else {
 	if ($Arch -in "AMD64", "x86") {
 		Write-Host "Could not find cargo.exe, Rust may not be installed" -ForegroundColor Red
 		$Confirm = Read-Host -Prompt "Would you like to install Rust via Rustup? [y/N]"
-		if ($Confirm -notin "y", "yes") {
+		if ($Confirm -inotin "y", "yes") {
 			Write-Host "Skipping rustup install, cargo-shuttle not installed"
 			[Environment]::Exit(1)
 		}

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,7 @@
-$ErrorActionPreference = "Stop"
+function Install-Cargo-Shuttle {
+	$RepoUrl = "https://github.com/shuttle-hq/shuttle"
 
-$RepoUrl = "https://github.com/shuttle-hq/shuttle"
-
-Write-Host @"
+	Write-Host @"
      _           _   _   _
  ___| |__  _   _| |_| |_| | ___
 / __| '_ \| | | | __| __| |/ _ \
@@ -16,80 +15,87 @@ Please file an issue if you encounter any problems!
 ===================================================
 "@
 
-if (Get-Command -CommandType Application -ErrorAction SilentlyContinue cargo-binstall.exe) {
-	Write-Host "Installing cargo-shuttle using cargo binstall"
-	cargo-binstall.exe cargo-shuttle -y
-	if ($?) {
-		Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
-		[Environment]::Exit(0)
-	}
-	else {
-		Write-Host "Could not install from release using cargo binstall, trying manual binary download" -ForegroundColor Red
-	}
-}
-else {
-	Write-Host "cargo binstall not found, trying manual binary download" -ForegroundColor Red
-}
-
-$CargoHome = if ($null -ne $Env:CARGO_HOME) { $Env:CARGO_HOME } else { "$HOME\.cargo" }
-$TempDir = $Env:TEMP
-$Arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
-if (($Arch -eq "AMD64") -and (Get-Command -CommandType Application -ErrorAction SilentlyContinue tar.exe)) {
-	(Invoke-WebRequest "$RepoUrl/releases/latest" -Headers @{ "Accept" = "application/json" }).Content -match '"tag_name":"([^"]*)"' | Out-Null
-	$LatestRelease = $Matches.1
-	$BinaryUrl = "$RepoUrl/releases/download/$LatestRelease/cargo-shuttle-$LatestRelease-x86_64-pc-windows-msvc.tar.gz"
-	Invoke-WebRequest $BinaryUrl -OutFile "$TempDir\cargo-shuttle.tar.gz"
-	New-Item -ItemType Directory -Force "$TempDir\cargo-shuttle"
-	tar.exe -xzf "$TempDir\cargo-shuttle.tar.gz" -C "$TempDir\cargo-shuttle"
-	Move-Item -Force "$TempDir\cargo-shuttle\cargo-shuttle-x86_64-pc-windows-msvc-$LatestRelease\cargo-shuttle.exe" "$CargoHome\bin\cargo-shuttle.exe"
-	Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$TempDir\cargo-shuttle.tar.gz", "$TempDir\cargo-shuttle"
-	Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
-	[Environment]::Exit(0)
-}
-elseif ($Arch -ne "AMD64") {
-	Write-Host "Unsupported Architecture: Binaries are not currently built for $Arch, skipping manual binary download" -ForegroundColor Red
-}
-else {
-	Write-Host "Could not find tar.exe, skipping manual binary download (required to extract the release asset)" -ForegroundColor Red
-}
-
-if (Get-Command -CommandType Application -ErrorAction SilentlyContinue cargo.exe) {
-	cargo.exe install cargo-shuttle --locked
-	if ($?) {
-		Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
-		[Environment]::Exit(0)
-	}
-	else {
-		Write-Host "Could not install cargo-shuttle using cargo" -ForegroundColor Red
-		[Environment]::Exit(1)
-	}
-}
-else {
-	if ($Arch -in "AMD64", "x86") {
-		Write-Host "Could not find cargo.exe, Rust may not be installed" -ForegroundColor Red
-		$Confirm = Read-Host -Prompt "Would you like to install Rust via Rustup? [y/N]"
-		if ($Confirm -inotin "y", "yes") {
-			Write-Host "Skipping rustup install, cargo-shuttle not installed"
-			[Environment]::Exit(1)
-		}
-		$RustupUrl = if ($Arch -eq "AMD64") { "https://win.rustup.rs/x86_64" } else { "https://win.rustup.rs/i686" }
-		Invoke-WebRequest $RustupUrl -OutFile "$TempDir\rustup.exe"
-		& "$TempDir\rustup.exe" toolchain install stable
+	if (Get-Command -CommandType Application -ErrorAction SilentlyContinue cargo-binstall.exe) {
+		Write-Host "Installing cargo-shuttle using cargo binstall"
+		cargo-binstall.exe cargo-shuttle --no-confirm
 		if ($?) {
-			Remove-Item -ErrorAction SilentlyContinue "$TempDir\rustup.exe"
-			Write-Host "Rust installed via Rustup, please re-run this script, you may need reopen your terminal" -ForegroundColor Green
-			[Environment]::Exit(0)
+			Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
+			return
 		}
 		else {
-			Remove-Item -ErrorAction SilentlyContinue "$TempDir\rustup.exe"
-			Write-Host "Rust install via Rustup failed, please install Rust manually: https://rustup.rs/" -ForegroundColor Red
-			[Environment]::Exit(0)
+			Write-Host "Could not install from release using cargo binstall, trying manual binary download" -ForegroundColor Red
 		}
 	}
 	else {
-		Write-Host "Could not find cargo.exe, Rust may not be installed." -ForegroundColor Red
-		Write-Host "Rustup is only provided for x86 and x86_64, not $Arch" -ForegroundColor Red
-		Write-Host "Please install Rust manually, more info at: https://rust-lang.github.io/rustup/installation/other.html" -ForegroundColor Red
-		[Environment]::Exit(1)
+		Write-Host "cargo binstall not found, trying manual binary download" -ForegroundColor Red
+	}
+
+	$CargoHome = if ($null -ne $Env:CARGO_HOME) { $Env:CARGO_HOME } else { "$HOME\.cargo" }
+	$TempDir = $Env:TEMP
+	$Arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
+	if (($Arch -eq "AMD64") -and (Get-Command -CommandType Application -ErrorAction SilentlyContinue tar.exe)) {
+	(Invoke-WebRequest "$RepoUrl/releases/latest" -Headers @{ "Accept" = "application/json" }).Content -match '"tag_name":"([^"]*)"' | Out-Null
+		$LatestRelease = $Matches.1
+		$BinaryUrl = "$RepoUrl/releases/download/$LatestRelease/cargo-shuttle-$LatestRelease-x86_64-pc-windows-msvc.tar.gz"
+		Invoke-WebRequest $BinaryUrl -OutFile "$TempDir\cargo-shuttle.tar.gz"
+		New-Item -ItemType Directory -Force "$TempDir\cargo-shuttle"
+		tar.exe -xzf "$TempDir\cargo-shuttle.tar.gz" -C "$TempDir\cargo-shuttle"
+		Move-Item -Force "$TempDir\cargo-shuttle\cargo-shuttle-x86_64-pc-windows-msvc-$LatestRelease\cargo-shuttle.exe" "$CargoHome\bin\cargo-shuttle.exe"
+		Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$TempDir\cargo-shuttle.tar.gz", "$TempDir\cargo-shuttle"
+		Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
+		return
+	}
+	elseif ($Arch -ne "AMD64") {
+		Write-Host "Unsupported Architecture: Binaries are not currently built for $Arch, skipping manual binary download" -ForegroundColor Red
+	}
+	else {
+		Write-Host "Could not find tar.exe, skipping manual binary download (required to extract the release asset)" -ForegroundColor Red
+	}
+
+	if (Get-Command -CommandType Application -ErrorAction SilentlyContinue cargo.exe) {
+		Write-Host "Installing cargo-shuttle using cargo install (from source)"
+		cargo.exe install cargo-shuttle --locked
+		if ($?) {
+			Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
+			return
+		}
+		else {
+			Write-Host "Could not install cargo-shuttle using cargo" -ForegroundColor Red
+			return
+		}
+	}
+	else {
+		if ($Arch -in "AMD64", "x86") {
+			Write-Host "Could not find cargo.exe, Rust may not be installed" -ForegroundColor Red
+			$Confirm = Read-Host -Prompt "Would you like to install Rust via Rustup? [y/N]"
+			if ($Confirm -inotin "y", "yes") {
+				Write-Host "Skipping rustup install, cargo-shuttle not installed"
+				return
+			}
+			$RustupUrl = if ($Arch -eq "AMD64") { "https://win.rustup.rs/x86_64" } else { "https://win.rustup.rs/i686" }
+			Invoke-WebRequest $RustupUrl -OutFile "$TempDir\rustup.exe"
+			& "$TempDir\rustup.exe" toolchain install stable
+			if ($?) {
+				Remove-Item -ErrorAction SilentlyContinue "$TempDir\rustup.exe"
+				Write-Host "Rust installed via Rustup, please re-run this script, you may need reopen your terminal" -ForegroundColor Green
+				return
+			}
+			else {
+				Remove-Item -ErrorAction SilentlyContinue "$TempDir\rustup.exe"
+				Write-Host "Rust install via Rustup failed, please install Rust manually: https://rustup.rs/" -ForegroundColor Red
+				return
+			}
+		}
+		else {
+			Write-Host "Could not find cargo.exe, Rust may not be installed." -ForegroundColor Red
+			Write-Host "Rustup is only provided for x86 and x86_64, not $Arch" -ForegroundColor Red
+			Write-Host "Please install Rust manually, more info at: https://rust-lang.github.io/rustup/installation/other.html" -ForegroundColor Red
+			return
+		}
 	}
 }
+
+$OldErrorAction = $ErrorActionPreference
+$ErrorActionPreference = "Stop"
+Install-Cargo-Shuttle
+$ErrorActionPreference = $OldErrorAction

--- a/install.ps1
+++ b/install.ps1
@@ -41,7 +41,7 @@ if (($Arch -eq "AMD64") -and (Get-Command -CommandType Application -ErrorAction 
 	Invoke-WebRequest $BinaryUrl -OutFile "$TempDir\cargo-shuttle.tar.gz"
 	New-Item -ItemType Directory -Force "$TempDir\cargo-shuttle"
 	tar.exe -xzf "$TempDir\cargo-shuttle.tar.gz" -C "$TempDir\cargo-shuttle"
-	Move-Item "$TempDir\cargo-shuttle\cargo-shuttle-x86_64-pc-windows-msvc-$LatestRelease\cargo-shuttle.exe" "$CargoHome\bin\cargo-shuttle.exe"
+	Move-Item -Force "$TempDir\cargo-shuttle\cargo-shuttle-x86_64-pc-windows-msvc-$LatestRelease\cargo-shuttle.exe" "$CargoHome\bin\cargo-shuttle.exe"
 	Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$TempDir\cargo-shuttle.tar.gz", "$TempDir\cargo-shuttle"
 	Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
 	[Environment]::Exit(0)

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,95 @@
+$ErrorActionPreference = "Stop"
+
+$RepoUrl = "https://github.com/shuttle-hq/shuttle"
+
+Write-Host @"
+     _           _   _   _
+ ___| |__  _   _| |_| |_| | ___
+/ __| '_ \| | | | __| __| |/ _ \
+\__ \ | | | |_| | |_| |_| |  __/
+|___/_| |_|\__,_|\__|\__|_|\___|
+
+https://www.shuttle.rs
+https://github.com/shuttle-hq/shuttle
+
+Please file an issue if you encounter any problems!
+===================================================
+"@
+
+if (Get-Command -CommandType Application -ErrorAction SilentlyContinue cargo-binstall.exe) {
+	Write-Host "Installing cargo-shuttle using cargo binstall"
+	cargo-binstall.exe cargo-shuttle -y
+	if ($?) {
+		Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
+		[Environment]::Exit(0)
+	}
+	else {
+		Write-Host "Could not install from release using cargo binstall, trying manual binary download" -ForegroundColor Red
+	}
+}
+else {
+	Write-Host "cargo binstall not found, trying manual binary download" -ForegroundColor Red
+}
+
+$CargoHome = if ($null -ne $Env:CARGO_HOME) { $Env:CARGO_HOME } else { "$HOME\.cargo" }
+$TempDir = $Env:TEMP
+$Arch = [Environment]::GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", [EnvironmentVariableTarget]::Machine)
+if (($Arch -eq "AMD64") -and (Get-Command -CommandType Application -ErrorAction SilentlyContinue tar.exe)) {
+	(Invoke-WebRequest "$RepoUrl/releases/latest" -Headers @{ "Accept" = "application/json" }).Content -match '"tag_name":"([^"]*)"' | Out-Null
+	$LatestRelease = $Matches.1
+	$BinaryUrl = "$RepoUrl/releases/download/$LatestRelease/cargo-shuttle-$LatestRelease-x86_64-pc-windows-msvc.tar.gz"
+	Invoke-WebRequest $BinaryUrl -OutFile "$TempDir\cargo-shuttle.tar.gz"
+	New-Item -ItemType Directory -Force "$TempDir\cargo-shuttle"
+	tar.exe -xzf "$TempDir\cargo-shuttle.tar.gz" -C "$TempDir\cargo-shuttle"
+	Move-Item "$TempDir\cargo-shuttle\cargo-shuttle-x86_64-pc-windows-msvc-$LatestRelease\cargo-shuttle.exe" "$CargoHome\bin\cargo-shuttle.exe"
+	Remove-Item -Recurse -Force -ErrorAction SilentlyContinue "$TempDir\cargo-shuttle.tar.gz", "$TempDir\cargo-shuttle"
+	Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
+	[Environment]::Exit(0)
+}
+elseif ($Arch -ne "AMD64") {
+	Write-Host "Unsupported Architecture: Binaries are not currently built for $Arch, skipping manual binary download" -ForegroundColor Red
+}
+else {
+	Write-Host "Could not find tar.exe, skipping manual binary download (required to extract the release asset)" -ForegroundColor Red
+}
+
+if (Get-Command -CommandType Application -ErrorAction SilentlyContinue cargo.exe) {
+	cargo.exe install cargo-shuttle --locked
+	if ($?) {
+		Write-Host "Installed cargo-shuttle, try running ``cargo shuttle --help``" -ForegroundColor Green
+		[Environment]::Exit(0)
+	}
+	else {
+		Write-Host "Could not install cargo-shuttle using cargo" -ForegroundColor Red
+		[Environment]::Exit(1)
+	}
+}
+else {
+	if ($Arch -in "AMD64", "x86") {
+		Write-Host "Could not find cargo.exe, Rust may not be installed" -ForegroundColor Red
+		$Confirm = Read-Host -Prompt "Would you like to install Rust via Rustup? [y/N]"
+		if ($Confirm -notin "y", "yes") {
+			Write-Host "Skipping rustup install, cargo-shuttle not installed"
+			[Environment]::Exit(1)
+		}
+		$RustupUrl = if ($Arch -eq "AMD64") { "https://win.rustup.rs/x86_64" } else { "https://win.rustup.rs/i686" }
+		Invoke-WebRequest $RustupUrl -OutFile "$TempDir\rustup.exe"
+		& "$TempDir\rustup.exe" toolchain install stable
+		if ($?) {
+			Remove-Item -ErrorAction SilentlyContinue "$TempDir\rustup.exe"
+			Write-Host "Rust installed via Rustup, please re-run this script, you may need reopen your terminal" -ForegroundColor Green
+			[Environment]::Exit(0)
+		}
+		else {
+			Remove-Item -ErrorAction SilentlyContinue "$TempDir\rustup.exe"
+			Write-Host "Rust install via Rustup failed, please install Rust manually: https://rustup.rs/" -ForegroundColor Red
+			[Environment]::Exit(0)
+		}
+	}
+	else {
+		Write-Host "Could not find cargo.exe, Rust may not be installed." -ForegroundColor Red
+		Write-Host "Rustup is only provided for x86 and x86_64, not $Arch" -ForegroundColor Red
+		Write-Host "Please install Rust manually, more info at: https://rust-lang.github.io/rustup/installation/other.html" -ForegroundColor Red
+		[Environment]::Exit(1)
+	}
+}


### PR DESCRIPTION
## Description of change

Adds Powershell script, following steps as in bash install script, closes #1496.

Install command added to readme will work once shuttle-hq/www#220 is merged.

## How has this been tested? (if applicable)

Tested locally on multiple machines, including commenting out codepaths to check both sides of branches. The section for downloading a binary may need to be updated in the future if CI is updated to produce aarch64 windows binaries.


