### PR TITLE
feat: delete rds subscription item on rds resource deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -837,14 +837,14 @@ workflows:
     jobs:
       - approve-deploy-images-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - approve-build-and-push-images-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/auth/README.md
+++ b/auth/README.md
@@ -38,3 +38,17 @@ cargo run --bin shuttle-auth -- \
     --jwt-signing-private-key <key> \
     --stripe-rds-price-id price_1OIS06FrN7EDaGOjaV0GXD7P
 ```
+
+## Getting a JWT for manual testing
+
+Some endpoints expect a JWT. To get a JWT for a specific user, you can run the following command:
+
+```bash
+curl localhost:8000/auth/key -H "x-shuttle-admin-secret: <admin user api key>" -H "Authorization: Bearer <api key of user to get jwt for>"
+```
+
+A token will be returned in the response, which you can pass in as a bearer token in requests to JWT guarded endpoints, e.g.
+
+```bash
+curl -X POST localhost:8000/users/subscription/items -H "Authorization: Bearer <jwt>" -H "Content-Type: application/json" -d '{"id":"test-database","item":"AwsRds","quantity":1}' -v
+```

--- a/auth/README.md
+++ b/auth/README.md
@@ -50,5 +50,5 @@ curl localhost:8000/auth/key -H "x-shuttle-admin-secret: <admin user api key>" -
 A token will be returned in the response, which you can pass in as a bearer token in requests to JWT guarded endpoints, e.g.
 
 ```bash
-curl -X POST localhost:8000/users/subscription/items -H "Authorization: Bearer <jwt>" -H "Content-Type: application/json" -d '{"id":"test-database","item":"AwsRds","quantity":1}' -v
+curl -X POST localhost:8000/users/subscription/items -H "Authorization: Bearer <jwt>" -H "Content-Type: application/json" -d '{"metadata_id":"test-database","item":"AwsRds","quantity":1}' -v
 ```

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -107,8 +107,6 @@ pub(crate) async fn delete_subscription_items(
         return Err(Error::MissingSubscriptionId);
     };
 
-    // TODO: do we need to check account tier here, like we do when adding items?
-
     span::Span::current().record("account.subscription_id", subscription_id.as_str());
 
     user_manager

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -99,8 +99,6 @@ pub(crate) async fn delete_subscription_items(
     State(user_manager): State<UserManagerState>,
     Path(metadata_id): Path<String>,
 ) -> Result<(), Error> {
-    // Fetching the user will also sync their subscription. This means we can verify that the
-    // caller still has the required tier after the sync.
     let user = user_manager.get_user(AccountName::from(claim.sub)).await?;
 
     let Some(ref subscription_id) = user.subscription_id else {

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -120,10 +120,10 @@ pub(crate) async fn delete_subscription_items(
             message: "successfully deleted subscription item".to_string(),
         })),
         // If the subscription item is missing, we still return 200, since the rds instance could
-        // have been provisioned before we implemented billing. If the subscription is canceled,
+        // have been provisioned before we implemented billing. If the subscription is cancelled,
         // we return 200 since we don't need to remove any items. A cancelled Stripe subscription
         // cannot be restarted.
-        Err(error @ Error::MissingSubscriptionItem(_) | error @ Error::CanceledSubscription) => {
+        Err(error @ Error::MissingSubscriptionItem(_) | error @ Error::CancelledSubscription) => {
             Ok(Json(SubscriptionResponse {
                 success: false,
                 message: error.to_string(),

--- a/auth/src/error.rs
+++ b/auth/src/error.rs
@@ -27,10 +27,12 @@ pub enum Error {
     IncompleteCheckoutSession,
     #[error("Interacting with stripe resulted in error: {0}.")]
     Stripe(#[from] StripeError),
-    // NOTE: this string is matched in the provisioner when requesting subscription item deletion.
-    // If this is changed here it needs to be changed there as well.
     #[error("Missing subscription ID.")]
     MissingSubscriptionId,
+    #[error("found more than one subscription items with the same metadata id: {0}")]
+    DuplicateSubscriptionItems(String),
+    #[error("found no subscription item with the given metadata id: {0}")]
+    MissingSubscriptionItem(String),
 }
 
 impl Serialize for Error {
@@ -53,7 +55,6 @@ impl IntoResponse for Error {
             Error::Unauthorized | Error::KeyMissing => StatusCode::UNAUTHORIZED,
             Error::Database(_) | Error::UserNotFound => StatusCode::NOT_FOUND,
             Error::MissingCheckoutSession
-            // NOTE: the provisioner expects a MissingSubscriptionId to return 400.
             | Error::MissingSubscriptionId
             | Error::IncompleteCheckoutSession => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/auth/src/error.rs
+++ b/auth/src/error.rs
@@ -29,12 +29,12 @@ pub enum Error {
     Stripe(#[from] StripeError),
     #[error("Missing subscription ID.")]
     MissingSubscriptionId,
-    #[error("found more than one subscription items with the same metadata id: {0}")]
+    #[error("Found more than one subscription items with the same metadata id: {0}")]
     DuplicateSubscriptionItems(String),
-    #[error("found no subscription item with the given metadata id: {0}")]
+    #[error("Found no subscription item with the given metadata id: {0}")]
     MissingSubscriptionItem(String),
-    #[error("stripe subscription is canceled")]
-    CanceledSubscription,
+    #[error("Stripe subscription is already cancelled")]
+    CancelledSubscription,
 }
 
 impl Serialize for Error {

--- a/auth/src/error.rs
+++ b/auth/src/error.rs
@@ -27,7 +27,9 @@ pub enum Error {
     IncompleteCheckoutSession,
     #[error("Interacting with stripe resulted in error: {0}.")]
     Stripe(#[from] StripeError),
-    #[error("Missing subscription ID from the checkout session.")]
+    // NOTE: this string is matched in the provisioner when requesting subscription item deletion.
+    // If this is changed here it needs to be changed there as well.
+    #[error("Missing subscription ID.")]
     MissingSubscriptionId,
 }
 
@@ -51,6 +53,7 @@ impl IntoResponse for Error {
             Error::Unauthorized | Error::KeyMissing => StatusCode::UNAUTHORIZED,
             Error::Database(_) | Error::UserNotFound => StatusCode::NOT_FOUND,
             Error::MissingCheckoutSession
+            // NOTE: the provisioner expects a MissingSubscriptionId to return 400.
             | Error::MissingSubscriptionId
             | Error::IncompleteCheckoutSession => StatusCode::BAD_REQUEST,
             _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/auth/src/error.rs
+++ b/auth/src/error.rs
@@ -33,6 +33,8 @@ pub enum Error {
     DuplicateSubscriptionItems(String),
     #[error("found no subscription item with the given metadata id: {0}")]
     MissingSubscriptionItem(String),
+    #[error("stripe subscription is canceled")]
+    CanceledSubscription,
 }
 
 impl Serialize for Error {

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -15,6 +15,7 @@ use tracing::info;
 use crate::api::serve;
 pub use api::{ApiBuilder, RouterState};
 pub use args::{Args, Commands, InitArgs};
+pub use error::Error;
 pub use subscription::NewSubscriptionItemExtractor;
 
 pub const COOKIE_EXPIRATION: Duration = Duration::from_secs(60 * 60 * 24); // One day

--- a/auth/src/subscription.rs
+++ b/auth/src/subscription.rs
@@ -25,7 +25,7 @@ where
         // Extract the NewSubscriptionItem, the struct that other services should use when calling
         // the endpoint to add subscription items.
         let NewSubscriptionItem {
-            id,
+            metadata_id,
             quantity,
             r#type,
         } = axum::Json::from_request(req, state)
@@ -40,7 +40,7 @@ where
             SubscriptionItemType::AwsRds => state.rds_price_id,
         };
 
-        let metadata = stripe::Metadata::from([("id".to_string(), id)]);
+        let metadata = stripe::Metadata::from([("id".to_string(), metadata_id)]);
 
         let update_subscription_items = stripe::UpdateSubscriptionItems {
             price: Some(price_id),

--- a/auth/src/subscription.rs
+++ b/auth/src/subscription.rs
@@ -24,7 +24,7 @@ where
     async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
         // Extract the NewSubscriptionItem, the struct that other services should use when calling
         // the endpoint to add subscription items.
-        let NewSubscriptionItem { quantity, item } = axum::Json::from_request(req, state)
+        let NewSubscriptionItem { id, quantity, item } = axum::Json::from_request(req, state)
             .await
             .map_err(IntoResponse::into_response)?
             .0;
@@ -36,9 +36,12 @@ where
             SubscriptionItem::AwsRds => state.rds_price_id,
         };
 
+        let metadata = stripe::Metadata::from([("id".to_string(), id)]);
+
         let update_subscription_items = stripe::UpdateSubscriptionItems {
             price: Some(price_id),
             quantity: Some(quantity),
+            metadata: Some(metadata),
             ..Default::default()
         };
 

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Formatter, io::ErrorKind, str::FromStr};
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use axum::{
     extract::{FromRef, FromRequestParts},
@@ -200,16 +201,12 @@ impl UserManagement for UserManager {
 
         if items_to_delete.len() > 1 {
             error!("found more than one subscription item with given metadata id");
-            return Err(Error::Internal(anyhow::anyhow!(
-                "failed to delete subscription item"
-            )));
+            return Err(anyhow!("failed to delete subscription item").into());
         }
 
         let Some(subscription_item_id) = items_to_delete.first() else {
             error!("subscription item with given metadata it was not found");
-            return Err(Error::Internal(anyhow::anyhow!(
-                "failed to delete subscription item"
-            )));
+            return Err(anyhow!("failed to delete subscription item").into());
         };
 
         stripe::SubscriptionItem::delete(&self.stripe_client, subscription_item_id).await?;

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -188,8 +188,8 @@ impl UserManagement for UserManager {
             stripe::Subscription::retrieve(&self.stripe_client, subscription_id, &[]).await?;
 
         if subscription.status == SubscriptionStatus::Canceled {
-            info!("tried to delete subscription item for a canceled subscription");
-            return Err(Error::CanceledSubscription);
+            info!("tried to delete subscription item for a cancelled subscription");
+            return Err(Error::CancelledSubscription);
         }
 
         // First we filter out any items that do not have the expected metadata ID, then we map

--- a/auth/tests/api/stripe/active_subscription_with_rds.rs
+++ b/auth/tests/api/stripe/active_subscription_with_rds.rs
@@ -1,0 +1,210 @@
+pub(crate) const MOCKED_ACTIVE_SUBSCRIPTION_WITH_RDS: &str = r#"{
+    "id": "sub_1Nw8xOD8t1tt0S3DtwAuOVp6",
+    "object": "subscription",
+    "application": null,
+    "application_fee_percent": null,
+    "automatic_tax": {
+      "enabled": false
+    },
+    "billing_cycle_anchor": 1696102566,
+    "billing_thresholds": null,
+    "cancel_at": null,
+    "cancel_at_period_end": false,
+    "canceled_at": null,
+    "cancellation_details": {
+      "comment": null,
+      "feedback": null,
+      "reason": null
+    },
+    "collection_method": "charge_automatically",
+    "created": 1696102566,
+    "currency": "ron",
+    "current_period_end": 1698694566,
+    "current_period_start": 1696102566,
+    "customer": "cus_OjcBtb9CGkRN0Q",
+    "days_until_due": null,
+    "default_payment_method": "pm_1Nw8xND8t1tt0S3DdoPw8WzZ",
+    "default_source": null,
+    "default_tax_rates": [],
+    "description": null,
+    "discount": null,
+    "ended_at": null,
+    "items": {
+      "object": "list",
+      "data": [
+        {
+          "id": "si_OjcB0PrsQ861FB",
+          "object": "subscription_item",
+          "billing_thresholds": null,
+          "created": 1696102567,
+          "metadata": {},
+          "plan": {
+            "id": "price_1NvdmxD8t1tt0S3DBi2jTI92",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 10000,
+            "amount_decimal": "10000",
+            "billing_scheme": "per_unit",
+            "created": 1695982755,
+            "currency": "ron",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {},
+            "nickname": null,
+            "product": "prod_Oj5yfmphYbZ8RE",
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "price": {
+            "id": "price_1NvdmxD8t1tt0S3DBi2jTI92",
+            "object": "price",
+            "active": true,
+            "billing_scheme": "per_unit",
+            "created": 1695982755,
+            "currency": "ron",
+            "custom_unit_amount": null,
+            "livemode": false,
+            "lookup_key": null,
+            "metadata": {},
+            "nickname": null,
+            "product": "prod_Oj5yfmphYbZ8RE",
+            "recurring": {
+              "aggregate_usage": null,
+              "interval": "month",
+              "interval_count": 1,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "tax_behavior": "unspecified",
+            "tiers_mode": null,
+            "transform_quantity": null,
+            "type": "recurring",
+            "unit_amount": 10000,
+            "unit_amount_decimal": "10000"
+          },
+          "quantity": 1,
+          "subscription": "sub_1Nw8xOD8t1tt0S3DtwAuOVp6",
+          "tax_rates": []
+        },
+        {
+            "id": "si_PIi5CjfGcXmRKe",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1704196916,
+            "metadata": {
+              "id": "database-test-db"
+            },
+            "plan": {
+              "id": "price_1OIS06FrN7EDaGOjaV0GXD7P",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 2000,
+              "amount_decimal": "2000",
+              "billing_scheme": "per_unit",
+              "created": 1701418986,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+              },
+              "nickname": null,
+              "product": "prod_P6O33MsTZ6yRCI",
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1OIS06FrN7EDaGOjaV0GXD7P",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1701418986,
+              "currency": "usd",
+              "custom_unit_amount": null,
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {
+              },
+              "nickname": null,
+              "product": "prod_P6O33MsTZ6yRCI",
+              "recurring": {
+                "aggregate_usage": null,
+                "interval": "month",
+                "interval_count": 1,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tax_behavior": "inclusive",
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 2000,
+              "unit_amount_decimal": "2000"
+            },
+            "quantity": 1,
+            "subscription": "sub_1Nw8xOD8t1tt0S3DtwAuOVp6",
+            "tax_rates": [
+            ]
+          }
+      ],
+      "has_more": false,
+      "total_count": 2,
+      "url": "/v1/subscription_items?subscription=sub_1Nw8xOD8t1tt0S3DtwAuOVp6"
+    },
+    "latest_invoice": "in_1Nw8xOD8t1tt0S3DU4YDQ8ok",
+    "livemode": false,
+    "metadata": {},
+    "next_pending_invoice_item_invoice": null,
+    "on_behalf_of": null,
+    "pause_collection": null,
+    "payment_settings": {
+      "payment_method_options": null,
+      "payment_method_types": null,
+      "save_default_payment_method": "off"
+    },
+    "pending_invoice_item_interval": null,
+    "pending_setup_intent": null,
+    "pending_update": null,
+    "plan": {
+      "id": "price_1NvdmxD8t1tt0S3DBi2jTI92",
+      "object": "plan",
+      "active": true,
+      "aggregate_usage": null,
+      "amount": 10000,
+      "amount_decimal": "10000",
+      "billing_scheme": "per_unit",
+      "created": 1695982755,
+      "currency": "ron",
+      "interval": "month",
+      "interval_count": 1,
+      "livemode": false,
+      "metadata": {},
+      "nickname": null,
+      "product": "prod_Oj5yfmphYbZ8RE",
+      "tiers_mode": null,
+      "transform_usage": null,
+      "trial_period_days": null,
+      "usage_type": "licensed"
+    },
+    "quantity": 1,
+    "schedule": null,
+    "start_date": 1696102566,
+    "status": "active",
+    "test_clock": null,
+    "transfer_data": null,
+    "trial_end": null,
+    "trial_settings": {
+      "end_behavior": {
+        "missing_payment_method": "create_invoice"
+      }
+    },
+    "trial_start": null
+  }
+"#;

--- a/auth/tests/api/stripe/mod.rs
+++ b/auth/tests/api/stripe/mod.rs
@@ -1,5 +1,16 @@
+mod active_subscription;
+mod active_subscription_with_rds;
+mod cancelledpro_checkout_session;
+mod cancelledpro_subscription_active;
+mod cancelledpro_subscription_cancelled;
+mod completed_checkout_session;
+mod incomplete_checkout_session;
+mod overdue_payment_checkout_session;
+mod past_due_subscription;
+
 use self::{
     active_subscription::MOCKED_ACTIVE_SUBSCRIPTION,
+    active_subscription_with_rds::MOCKED_ACTIVE_SUBSCRIPTION_WITH_RDS,
     cancelledpro_checkout_session::MOCKED_CANCELLEDPRO_CHECKOUT_SESSION,
     cancelledpro_subscription_active::MOCKED_CANCELLEDPRO_SUBSCRIPTION_ACTIVE,
     cancelledpro_subscription_cancelled::MOCKED_CANCELLEDPRO_SUBSCRIPTION_CANCELLED,
@@ -9,20 +20,12 @@ use self::{
     past_due_subscription::MOCKED_PAST_DUE_SUBSCRIPTION,
 };
 
-mod active_subscription;
-mod cancelledpro_checkout_session;
-mod cancelledpro_subscription_active;
-mod cancelledpro_subscription_cancelled;
-mod completed_checkout_session;
-mod incomplete_checkout_session;
-mod overdue_payment_checkout_session;
-mod past_due_subscription;
-
 pub(crate) const MOCKED_SUBSCRIPTIONS: &[&str] = &[
     MOCKED_ACTIVE_SUBSCRIPTION,
     MOCKED_PAST_DUE_SUBSCRIPTION,
     MOCKED_CANCELLEDPRO_SUBSCRIPTION_ACTIVE,
     MOCKED_CANCELLEDPRO_SUBSCRIPTION_CANCELLED,
+    MOCKED_ACTIVE_SUBSCRIPTION_WITH_RDS,
 ];
 
 pub(crate) const MOCKED_CHECKOUT_SESSIONS: &[&str] = &[

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -458,10 +458,11 @@ mod needs_docker {
         let response: SubscriptionResponse = serde_json::from_slice(&body).unwrap();
 
         assert!(!response.success);
-        assert_eq!(
-            response.message,
-            format!("found no subscription item with the given metadata id: non-existent-id")
-        );
+
+        // The returned message will be created from the expected error.
+        let err = shuttle_auth::Error::MissingSubscriptionItem("non-existent-id".to_string());
+
+        assert_eq!(response.message, err.to_string());
 
         // The expected successful response from stripe.
         let json_response = serde_json::json!({

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -9,7 +9,7 @@ mod needs_docker {
     use serde_json::{self, Value};
     use shuttle_common::backends::subscription::NewSubscriptionItem;
     use wiremock::{
-        matchers::{bearer_token, body_partial_json, body_string_contains, method, path},
+        matchers::{bearer_token, body_string_contains, method, path},
         Mock, ResponseTemplate,
     };
 

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -9,7 +9,7 @@ mod needs_docker {
     use serde_json::{self, Value};
     use shuttle_common::backends::subscription::NewSubscriptionItem;
     use wiremock::{
-        matchers::{bearer_token, body_string_contains, method, path},
+        matchers::{bearer_token, body_partial_json, body_string_contains, method, path},
         Mock, ResponseTemplate,
     };
 
@@ -311,7 +311,6 @@ mod needs_docker {
         Mock::given(method("POST"))
             .and(bearer_token(STRIPE_TEST_KEY))
             .and(path("/v1/subscriptions/sub_1Nw8xOD8t1tt0S3DtwAuOVp6"))
-            // TODO: change these to body_partial_json?
             .and(body_string_contains(STRIPE_TEST_RDS_PRICE_ID))
             .and(body_string_contains("quantity"))
             .and(body_string_contains("metadata"))
@@ -335,7 +334,7 @@ mod needs_docker {
         let metadata_id = "database-test-db";
 
         // --- First, we need to add a subscription item to the test users subscription. ---
-        // TODO: deduplicate this?
+
         let subscription_item = serde_json::to_string(&NewSubscriptionItem::new(
             metadata_id,
             shuttle_common::backends::subscription::SubscriptionItemType::AwsRds,
@@ -391,7 +390,6 @@ mod needs_docker {
                 Mock::given(method("POST"))
                     .and(bearer_token(STRIPE_TEST_KEY))
                     .and(path("/v1/subscriptions/sub_1Nw8xOD8t1tt0S3DtwAuOVp6"))
-                    // TODO: change these to body_partial_json?
                     .and(body_string_contains(STRIPE_TEST_RDS_PRICE_ID))
                     .and(body_string_contains("quantity"))
                     .and(body_string_contains("metadata"))
@@ -414,8 +412,7 @@ mod needs_docker {
         // fetching the subscription from stripe.
         //
         // Our deletion handler logic will then fetch the subscription again, so we can see if it has
-        // an item of the type we want to delete, as well as with the metadata ID of the item we
-        // want to delete.
+        // an item with the metadata ID of the item we want to delete.
         //
         // We return a mocked subscription that has the RDS item we added earlier in the test, with
         // the same ID. We will get the subscription item id from the subscription, and use it in

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -245,6 +245,7 @@ mod needs_docker {
         let app = app().await;
 
         let subscription_item = serde_json::to_string(&NewSubscriptionItem::new(
+            "database-test-db",
             shuttle_common::backends::subscription::SubscriptionItem::AwsRds,
             1,
         ))
@@ -324,13 +325,15 @@ mod needs_docker {
         // We just return a mocked active subscription without the RDS items, our logic doesn't check
         // the subscription after updating, if it receives a 200 and a correctly formed subscription
         // response we know that the update succeeded.
-        // We also want to ensure it's called with the correct price_id, the one the auth serviec was
-        // started with, as well as the quantity field.
+        // We also want to ensure it's called with the correct price_id for this item, the one the
+        // auth service was started with, that it has the quantity field and the metadata id.
         Mock::given(method("POST"))
             .and(bearer_token(STRIPE_TEST_KEY))
             .and(path("/v1/subscriptions/sub_1Nw8xOD8t1tt0S3DtwAuOVp6"))
             .and(body_string_contains(STRIPE_TEST_RDS_PRICE_ID))
             .and(body_string_contains("quantity"))
+            .and(body_string_contains("metadata"))
+            .and(body_string_contains("database-test-db"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .set_body_json(serde_json::from_str::<Value>(MOCKED_SUBSCRIPTIONS[0]).unwrap()),

--- a/common/src/backends/auth.rs
+++ b/common/src/backends/auth.rs
@@ -452,7 +452,7 @@ impl<B> VerifyClaim for tonic::Request<B> {
             Ok(())
         } else {
             Err(tonic::Status::permission_denied(format!(
-                "don't have permission to: {}",
+                "this account does not have permission to: {}",
                 required_scope
                     .get_documentation()
                     .unwrap_or("perform this operation")
@@ -470,7 +470,7 @@ impl<B> VerifyClaim for tonic::Request<B> {
             Ok(claim.clone())
         } else {
             Err(tonic::Status::permission_denied(
-                "don't have permission to provision rds instances",
+                "this account does not have permission to provision rds instances",
             ))
         }
     }

--- a/common/src/backends/subscription.rs
+++ b/common/src/backends/subscription.rs
@@ -3,13 +3,19 @@ use serde::{Deserialize, Serialize};
 /// Used when sending requests to the Auth service to add a new item to a user's subscription.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NewSubscriptionItem {
+    // A unique id to tie the subscription item to a resource, e.g. a database name or resource ulid.
+    pub id: String,
     pub item: SubscriptionItem,
     pub quantity: u64,
 }
 
 impl NewSubscriptionItem {
-    pub fn new(item: SubscriptionItem, quantity: u64) -> NewSubscriptionItem {
-        NewSubscriptionItem { item, quantity }
+    pub fn new(id: impl ToString, item: SubscriptionItem, quantity: u64) -> NewSubscriptionItem {
+        NewSubscriptionItem {
+            id: id.to_string(),
+            item,
+            quantity,
+        }
     }
 }
 

--- a/common/src/backends/subscription.rs
+++ b/common/src/backends/subscription.rs
@@ -3,20 +3,20 @@ use serde::{Deserialize, Serialize};
 /// Used when sending requests to the Auth service to add a new item to a user's subscription.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NewSubscriptionItem {
-    // A unique id to tie the subscription item to a resource, e.g. a database name or resource ulid.
-    pub id: String,
+    /// A unique id to tie the subscription item to a resource, e.g. a database name or resource ulid.
+    pub metadata_id: String,
     pub r#type: SubscriptionItemType,
     pub quantity: u64,
 }
 
 impl NewSubscriptionItem {
     pub fn new(
-        id: impl ToString,
+        metadata_id: impl ToString,
         item: SubscriptionItemType,
         quantity: u64,
     ) -> NewSubscriptionItem {
         NewSubscriptionItem {
-            id: id.to_string(),
+            metadata_id: metadata_id.to_string(),
             r#type: item,
             quantity,
         }

--- a/common/src/backends/subscription.rs
+++ b/common/src/backends/subscription.rs
@@ -3,7 +3,8 @@ use serde::{Deserialize, Serialize};
 /// Used when sending requests to the Auth service to add a new item to a user's subscription.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NewSubscriptionItem {
-    /// A unique id to tie the subscription item to a resource, e.g. a database name or resource ulid.
+    /// A unique id to tie the subscription item to a resource, e.g. a database name or resource ulid,
+    /// that will be inserted into the metadata of the new Stripe subscription item.
     pub metadata_id: String,
     pub r#type: SubscriptionItemType,
     pub quantity: u64,

--- a/common/src/backends/subscription.rs
+++ b/common/src/backends/subscription.rs
@@ -5,21 +5,25 @@ use serde::{Deserialize, Serialize};
 pub struct NewSubscriptionItem {
     // A unique id to tie the subscription item to a resource, e.g. a database name or resource ulid.
     pub id: String,
-    pub item: SubscriptionItem,
+    pub r#type: SubscriptionItemType,
     pub quantity: u64,
 }
 
 impl NewSubscriptionItem {
-    pub fn new(id: impl ToString, item: SubscriptionItem, quantity: u64) -> NewSubscriptionItem {
+    pub fn new(
+        id: impl ToString,
+        item: SubscriptionItemType,
+        quantity: u64,
+    ) -> NewSubscriptionItem {
         NewSubscriptionItem {
             id: id.to_string(),
-            item,
+            r#type: item,
             quantity,
         }
     }
 }
 
 #[derive(Deserialize, Debug, Serialize)]
-pub enum SubscriptionItem {
+pub enum SubscriptionItemType {
     AwsRds,
 }

--- a/common/src/backends/subscription.rs
+++ b/common/src/backends/subscription.rs
@@ -28,3 +28,9 @@ impl NewSubscriptionItem {
 pub enum SubscriptionItemType {
     AwsRds,
 }
+
+#[derive(Deserialize, Debug, Serialize)]
+pub struct SubscriptionResponse {
+    pub success: bool,
+    pub message: String,
+}

--- a/provisioner/src/error.rs
+++ b/provisioner/src/error.rs
@@ -39,6 +39,8 @@ pub enum Error {
 pub enum AuthClientError {
     #[error["token sent to auth service was expired, retry the request"]]
     ExpiredJwt,
+    #[error["claim subject does not have a subscription"]]
+    MissingSubscription,
     #[error["failed to request subscription update from auth service: {0}"]]
     Internal(String),
 }

--- a/provisioner/src/lib.rs
+++ b/provisioner/src/lib.rs
@@ -12,7 +12,7 @@ pub use error::Error;
 use mongodb::{bson::doc, options::ClientOptions};
 use rand::Rng;
 use shuttle_common::backends::auth::VerifyClaim;
-use shuttle_common::backends::subscription::{NewSubscriptionItem, SubscriptionItem};
+use shuttle_common::backends::subscription::{NewSubscriptionItem, SubscriptionItemType};
 use shuttle_common::claims::{AccountTier, Scope};
 use shuttle_common::models::project::ProjectName;
 pub use shuttle_proto::provisioner::provisioner_server::ProvisionerServer;
@@ -539,7 +539,7 @@ impl Provisioner for MyProvisioner {
                             claim.token().expect("claim should have a token"),
                             NewSubscriptionItem::new(
                                 &database_response.database_name,
-                                SubscriptionItem::AwsRds,
+                                SubscriptionItemType::AwsRds,
                                 1,
                             ),
                         )

--- a/provisioner/src/lib.rs
+++ b/provisioner/src/lib.rs
@@ -537,7 +537,11 @@ impl Provisioner for MyProvisioner {
                         .add_subscription_items(
                             // The token should be set on the claim in the JWT auth layer.
                             claim.token().expect("claim should have a token"),
-                            NewSubscriptionItem::new(SubscriptionItem::AwsRds, 1),
+                            NewSubscriptionItem::new(
+                                &database_response.database_name,
+                                SubscriptionItem::AwsRds,
+                                1,
+                            ),
                         )
                         .await
                     {

--- a/provisioner/tests/provisioner.rs
+++ b/provisioner/tests/provisioner.rs
@@ -4,7 +4,7 @@ use helpers::{exec_mongosh, exec_psql, DbType, DockerInstance};
 use once_cell::sync::Lazy;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE};
 use serde_json::Value;
-use shuttle_common::backends::subscription::{NewSubscriptionItem, SubscriptionItem};
+use shuttle_common::backends::subscription::{NewSubscriptionItem, SubscriptionItemType};
 use shuttle_proto::provisioner::shared;
 use shuttle_provisioner::MyProvisioner;
 use tonic::transport::Uri;
@@ -39,7 +39,7 @@ async fn correctly_calls_auth_service_to_add_rds_subscription_item() {
     .unwrap();
 
     let subscription_item =
-        || NewSubscriptionItem::new("database-test-db", SubscriptionItem::AwsRds, 1);
+        || NewSubscriptionItem::new("database-test-db", SubscriptionItemType::AwsRds, 1);
 
     // Respond with a 200 for a correctly formed request.
     wiremock::Mock::given(method("POST"))

--- a/provisioner/tests/provisioner.rs
+++ b/provisioner/tests/provisioner.rs
@@ -38,7 +38,8 @@ async fn correctly_calls_auth_service_to_add_rds_subscription_item() {
     .await
     .unwrap();
 
-    let subscription_item = || NewSubscriptionItem::new(SubscriptionItem::AwsRds, 1);
+    let subscription_item =
+        || NewSubscriptionItem::new("database-test-db", SubscriptionItem::AwsRds, 1);
 
     // Respond with a 200 for a correctly formed request.
     wiremock::Mock::given(method("POST"))


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- [x] Refactor the add_subscription_item flow to add a unique id to the metadata of the subscription item, so we can know which item to delete. 
- [x] Add a new endpoint to auth to delete an item from a users subscription.
- [x] Call the new endpoint when deleting an RDS database.
- [x] Code cleanups and refactoring.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

I have added a new mocked integration test to the auth service, a new mocked test to the provisioner, and I have tested the full flow on staging, for basic users, pro users and lapsed pro users with RDS.
