### PR TITLE
chore: v0.36.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: Version
       description: What version of `cargo-shuttle` are you running (`cargo shuttle --version`)?
-      placeholder: "v0.35.1"
+      placeholder: "v0.36.0"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 
 **For proper release notes with more details such as upgrading guidelines, check out the [releases page](https://github.com/shuttle-hq/shuttle/releases).**
 
+## [0.36.0](https://github.com/shuttle-hq/shuttle/compare/v0.35.1..v0.36.0) - 2024-01-08
+
+### Features
+
+- *(installer)* Add windows installer script ([#1503](https://github.com/shuttle-hq/shuttle/issues/1503)) - ([52ca24a](https://github.com/shuttle-hq/shuttle/commit/52ca24a63279b3879db14886134c1964e7e3e715))
+- *(service)* Emit trace with shuttle dependencies ([#1498](https://github.com/shuttle-hq/shuttle/issues/1498)) - ([90dfb72](https://github.com/shuttle-hq/shuttle/commit/90dfb72d3ac6b6dfdf3e5572f13c9beebabe6da5))
+- Track project deployments ([#1508](https://github.com/shuttle-hq/shuttle/issues/1508)) - ([82f815b](https://github.com/shuttle-hq/shuttle/commit/82f815b64e41b06c2770c276c1fed7f623619055))
+- `--no-git` to `cargo shuttle init` ([#1501](https://github.com/shuttle-hq/shuttle/issues/1501)) - ([05c5e53](https://github.com/shuttle-hq/shuttle/commit/05c5e5322a5825ecce55d746936f332fb7c0e287))
+- Add subscription items endpoint and call it when provisioning rds ([#1478](https://github.com/shuttle-hq/shuttle/issues/1478)) - ([657815d](https://github.com/shuttle-hq/shuttle/commit/657815d07ba169cc90094b6121b3c6dc9d7d1e36))
+
+### Bug Fixes
+
+- *(deployer)* Return empty list when when no service is found ([#1495](https://github.com/shuttle-hq/shuttle/issues/1495)) - ([386c9cd](https://github.com/shuttle-hq/shuttle/commit/386c9cd4cfb9738848a56191e4490419f65138ee))
+- *(gateway)* Dynamically pick docker stats source ([#1476](https://github.com/shuttle-hq/shuttle/issues/1476)) - ([402e3f0](https://github.com/shuttle-hq/shuttle/commit/402e3f0ba527b891360e621e68688537d9ab4ec8))
+- *(provisioner)* Only delete new rds on failed subscription update ([#1488](https://github.com/shuttle-hq/shuttle/issues/1488)) - ([f81b5ef](https://github.com/shuttle-hq/shuttle/commit/f81b5efbbf167c674ae5afc9179715f6bd4af9bd))
+- Tracing fixes, use consistent key names for project and service names ([#1500](https://github.com/shuttle-hq/shuttle/issues/1500)) - ([1568b1c](https://github.com/shuttle-hq/shuttle/commit/1568b1cf795686e4423ce3109d4aeeb406e9257e))
+
+### Documentation
+
+- Update README.md ([#1505](https://github.com/shuttle-hq/shuttle/issues/1505)) - ([7cce28b](https://github.com/shuttle-hq/shuttle/commit/7cce28b0e3543ae6f09ed3141739ce7c8a253f74))
+
+### Miscellaneous Tasks
+
+- *(shuttle-axum)* Use axum 0.7 by default ([#1507](https://github.com/shuttle-hq/shuttle/issues/1507)) - ([1325b12](https://github.com/shuttle-hq/shuttle/commit/1325b1208cb57592acb8626a29f69b29717c2e8d))
+- *(shuttle-salvo)* Bump salvo version ([#1486](https://github.com/shuttle-hq/shuttle/issues/1486)) - ([eb7362c](https://github.com/shuttle-hq/shuttle/commit/eb7362cf49879fad204a85a6483e3f255b96c306))
+- Bump examples - ([9ac5982](https://github.com/shuttle-hq/shuttle/commit/9ac59820697e3f22eda70c39b0297bd7bb2e9c72))
+- V0.36.0 - ([afeea5b](https://github.com/shuttle-hq/shuttle/commit/afeea5b2dae5bd35f9ed89d8377f4bd9fe6c849f))
+- Rust 1.75 ([#1506](https://github.com/shuttle-hq/shuttle/issues/1506)) - ([74fb4fb](https://github.com/shuttle-hq/shuttle/commit/74fb4fba8a2815ea3ee223607efe92cf9ccb5cea))
+- Guard the `/auth/key` endpoint ([#1487](https://github.com/shuttle-hq/shuttle/issues/1487)) - ([e8bb1a0](https://github.com/shuttle-hq/shuttle/commit/e8bb1a0b4fed9a1b1bc1f94f6071dd12783541b8))
+- Bump zerocopy ([#1489](https://github.com/shuttle-hq/shuttle/issues/1489)) - ([ab6ab8e](https://github.com/shuttle-hq/shuttle/commit/ab6ab8e195d230d7dc8993abfbcb21e64213774a))
+- Upgrade proto-gen to 0.2.0 ([#1482](https://github.com/shuttle-hq/shuttle/issues/1482)) - ([2ee5934](https://github.com/shuttle-hq/shuttle/commit/2ee59348a3124cef2e317f6bc54182f10a4d7dea))
+
+### Revert
+
+- Initial implementation of rds billing ([#1510](https://github.com/shuttle-hq/shuttle/issues/1510)) - ([3adff9e](https://github.com/shuttle-hq/shuttle/commit/3adff9e1edf4f8200425837e2271cc46cabc20c8))
+
+### Miscellaneous
+
+- Missing gateway key when trying to get jwt ([#1499](https://github.com/shuttle-hq/shuttle/issues/1499)) - ([68c8255](https://github.com/shuttle-hq/shuttle/commit/68c82555501e011b49920875a645e9f112ebe82d))
+
 ## [0.35.1](https://github.com/shuttle-hq/shuttle/compare/v0.35.0..v0.35.1) - 2023-12-13
 
 ### Features
@@ -28,13 +68,8 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 
 ### Miscellaneous Tasks
 
-- V0.35.1 - ([30cf22a](https://github.com/shuttle-hq/shuttle/commit/30cf22a750828ccaaecd2f10f0a1abdfd5368dd9))
+- V0.35.1 ([#1480](https://github.com/shuttle-hq/shuttle/issues/1480)) - ([fa0fce6](https://github.com/shuttle-hq/shuttle/commit/fa0fce6eb44218551ef71e7fe3a2fa67b03009f1))
 - Store state in postgres instance ([#1420](https://github.com/shuttle-hq/shuttle/issues/1420)) - ([da538ac](https://github.com/shuttle-hq/shuttle/commit/da538ac3f3647f6b8889bd7bff037c6f35fa6f5d))
-
-### Miscellaneous
-
-- Change back to main commit - ([17a9116](https://github.com/shuttle-hq/shuttle/commit/17a91166ffe770cf59434ae909a31bbda013f339))
-- Fix comment - ([88bcea8](https://github.com/shuttle-hq/shuttle/commit/88bcea8a393821d483f22b5c6abb05450c73825c))
 
 ## [0.35.0](https://github.com/shuttle-hq/shuttle/compare/v0.34.1..v0.35.0) - 2023-12-07
 
@@ -396,7 +431,6 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 - *(deployer)* Connect deployer to builder service ([#1248](https://github.com/shuttle-hq/shuttle/issues/1248)) - ([97077ae](https://github.com/shuttle-hq/shuttle/commit/97077ae67727e90b8ebc6144d457a1445d6fd961))
 - Execute projects from within workspace and other resources changes ([#1050](https://github.com/shuttle-hq/shuttle/issues/1050)) - ([9d28100](https://github.com/shuttle-hq/shuttle/commit/9d28100081ff71e906b8f8bbbb4ac6e8ec905a3e))
 - Builder service ([#1244](https://github.com/shuttle-hq/shuttle/issues/1244)) - ([361e00e](https://github.com/shuttle-hq/shuttle/commit/361e00ec41c2bcce3a2fc87d910d4524cf60646c))
-- Outdated log parse warning ([#1243](https://github.com/shuttle-hq/shuttle/issues/1243)) - ([a77ecb1](https://github.com/shuttle-hq/shuttle/commit/a77ecb1732e8ae8813428050583216ac0ea65db0))
 
 ### Bug Fixes
 
@@ -409,14 +443,13 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 
 - *(shuttle-shared-db)* Bump local postgres version from 11 to 14 ([#1073](https://github.com/shuttle-hq/shuttle/issues/1073)) - ([0d64923](https://github.com/shuttle-hq/shuttle/commit/0d64923f7598ce65e603589b0cedbd08fc8a6101))
 - V0.27.0 ([#1261](https://github.com/shuttle-hq/shuttle/issues/1261)) - ([2af0076](https://github.com/shuttle-hq/shuttle/commit/2af0076623fa5bb5fd98524642c5afc8b98eab66))
-- Bump examples ([#1246](https://github.com/shuttle-hq/shuttle/issues/1246)) - ([c7c0ceb](https://github.com/shuttle-hq/shuttle/commit/c7c0ceb59be91b986169bf624f2e99ed806c7345))
 
 ### Miscellaneous
 
 - Project entering a state loop ([#1260](https://github.com/shuttle-hq/shuttle/issues/1260)) - ([6b73157](https://github.com/shuttle-hq/shuttle/commit/6b731577593a4de5ad0a6c90d32ae0efedb6eafd))
 - Fix Cargo.lock - ([9889b59](https://github.com/shuttle-hq/shuttle/commit/9889b59bdbf73df20f6cc552d4cff591e6c791f1))
 
-## [0.26.0](https://github.com/shuttle-hq/shuttle/compare/v0.25.1..v0.26.0) - 2023-09-14
+## [0.26.0](https://github.com/shuttle-hq/shuttle/compare/v0.25.1..v0.26.0) - 2023-09-18
 
 ### Features
 
@@ -433,6 +466,7 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 - *(runtime)* Write next runtime logs to stdout ([#1187](https://github.com/shuttle-hq/shuttle/issues/1187)) - ([0f269d6](https://github.com/shuttle-hq/shuttle/commit/0f269d67ab2c1c27575f317c0f5bbb464582adb9))
 - *(services)* Enable auto-sharding in shuttle-poise ([#1217](https://github.com/shuttle-hq/shuttle/issues/1217)) - ([32d63eb](https://github.com/shuttle-hq/shuttle/commit/32d63ebdc44ffe23e6077d3609733777b6e6d554))
 - *(shuttle-next)* Enable tracing by default ([#1219](https://github.com/shuttle-hq/shuttle/issues/1219)) - ([ef47eae](https://github.com/shuttle-hq/shuttle/commit/ef47eaeea61836d8c3a60d765509084829872b4e))
+- Outdated log parse warning ([#1243](https://github.com/shuttle-hq/shuttle/issues/1243)) - ([a77ecb1](https://github.com/shuttle-hq/shuttle/commit/a77ecb1732e8ae8813428050583216ac0ea65db0))
 - Match local logs with deployer logs ([#1216](https://github.com/shuttle-hq/shuttle/issues/1216)) - ([1d13115](https://github.com/shuttle-hq/shuttle/commit/1d131150976a77973a81e480f1bcb936ede07759))
 - Logs batching ([#1188](https://github.com/shuttle-hq/shuttle/issues/1188)) - ([64520fb](https://github.com/shuttle-hq/shuttle/commit/64520fb14d87a2c5dfc3194ce857a989181d90b3))
 
@@ -470,6 +504,7 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 - *(gateway)* Stop setting `RUST_LOG` in deployers ([#1197](https://github.com/shuttle-hq/shuttle/issues/1197)) - ([bd5c9ff](https://github.com/shuttle-hq/shuttle/commit/bd5c9ff5a1159b374515d624e4ced25c5cc2eda5))
 - *(makefile)* Remove unused commands ([#1196](https://github.com/shuttle-hq/shuttle/issues/1196)) - ([a9ffc8f](https://github.com/shuttle-hq/shuttle/commit/a9ffc8f7be326d62a41831c1af8b159a645d0551))
 - *(services)* Disable default features for shuttle-runtime ([#1205](https://github.com/shuttle-hq/shuttle/issues/1205)) - ([b158bca](https://github.com/shuttle-hq/shuttle/commit/b158bca50c9cc57c3d77eef09ec6254e2c4adb90))
+- Bump examples ([#1246](https://github.com/shuttle-hq/shuttle/issues/1246)) - ([c7c0ceb](https://github.com/shuttle-hq/shuttle/commit/c7c0ceb59be91b986169bf624f2e99ed806c7345))
 - V0.26.0 ([#1239](https://github.com/shuttle-hq/shuttle/issues/1239)) - ([94f7966](https://github.com/shuttle-hq/shuttle/commit/94f79662bd0f99b9cc229a62ce78b5ad725f38e8))
 - Uncomment build & deploy branch filters ([#1238](https://github.com/shuttle-hq/shuttle/issues/1238)) - ([7703d85](https://github.com/shuttle-hq/shuttle/commit/7703d85685462b08ba2d0fb7927fa98cb0501455))
 - Logger postgres uri ([#1228](https://github.com/shuttle-hq/shuttle/issues/1228)) - ([4fb7629](https://github.com/shuttle-hq/shuttle/commit/4fb762961eb63d817e7312f87b12fe6060f8f867))
@@ -589,9 +624,8 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 
 - Sync resource-recorder with persistence ([#1101](https://github.com/shuttle-hq/shuttle/issues/1101)) - ([c055cae](https://github.com/shuttle-hq/shuttle/commit/c055cae5d3d3780a352abc15f570040d4e0e2547))
 - Add warning for api url arg ([#1128](https://github.com/shuttle-hq/shuttle/issues/1128)) - ([2f5ec20](https://github.com/shuttle-hq/shuttle/commit/2f5ec208012a206a6e68cec693eb8ba10ebe97f4))
-- Copy the certificate ([#1123](https://github.com/shuttle-hq/shuttle/issues/1123)) - ([0a78f36](https://github.com/shuttle-hq/shuttle/commit/0a78f369931a459b46c234d5f7af7950c400efaa))
 
-## [0.22.0](https://github.com/shuttle-hq/shuttle/compare/v0.21.0..v0.22.0) - 2023-07-31
+## [0.22.0](https://github.com/shuttle-hq/shuttle/compare/v0.21.0..v0.22.0) - 2023-08-02
 
 ### Features
 
@@ -616,6 +650,7 @@ See [conventional commits](https://www.conventionalcommits.org/) for commit guid
 
 ### Miscellaneous
 
+- Copy the certificate ([#1123](https://github.com/shuttle-hq/shuttle/issues/1123)) - ([0a78f36](https://github.com/shuttle-hq/shuttle/commit/0a78f369931a459b46c234d5f7af7950c400efaa))
 - Chore/v0.22.0 ([#1119](https://github.com/shuttle-hq/shuttle/issues/1119)) - ([bc38d36](https://github.com/shuttle-hq/shuttle/commit/bc38d3644c4bf841b3e74355cf9e534565a416c2))
 - Chore/bump sqlx ([#1118](https://github.com/shuttle-hq/shuttle/issues/1118)) - ([9d12b68](https://github.com/shuttle-hq/shuttle/commit/9d12b689e23c78a7b243941fa9fee3fcb1f31551))
 - Fixed runtime logs receiving ([#1108](https://github.com/shuttle-hq/shuttle/issues/1108)) - ([1a400be](https://github.com/shuttle-hq/shuttle/commit/1a400be6017213180fc40beb11454a983e4caa90))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-shuttle"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-admin"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-auth"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-stripe",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-builder"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "clap",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-codegen"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "pretty_assertions",
  "proc-macro-error",
@@ -5872,7 +5872,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common-tests"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "cargo-shuttle",
  "hyper",
@@ -5942,7 +5942,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-deployer"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5994,7 +5994,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-gateway"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-posthog",
@@ -6059,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-logger"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6084,11 +6084,11 @@ dependencies = [
 
 [[package]]
 name = "shuttle-orchestrator"
-version = "0.35.1"
+version = "0.36.0"
 
 [[package]]
 name = "shuttle-proto"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-provisioner"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "aws-config",
  "aws-sdk-rds",
@@ -6129,7 +6129,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-resource-recorder"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-runtime"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6186,7 +6186,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-service"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,19 +26,19 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/shuttle-hq/shuttle"
 
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspacedependencies-table
 [workspace.dependencies]
-shuttle-codegen = { path = "codegen", version = "0.35.1" }
-shuttle-common = { path = "common", version = "0.35.1" }
-shuttle-common-tests = { path = "common-tests", version = "0.35.1" }
-shuttle-orchestrator = { path = "orchestrator", version = "0.35.1" }
-shuttle-proto = { path = "proto", version = "0.35.1" }
-shuttle-service = { path = "service", version = "0.35.1" }
+shuttle-codegen = { path = "codegen", version = "0.36.0" }
+shuttle-common = { path = "common", version = "0.36.0" }
+shuttle-common-tests = { path = "common-tests", version = "0.36.0" }
+shuttle-orchestrator = { path = "orchestrator", version = "0.36.0" }
+shuttle-proto = { path = "proto", version = "0.36.0" }
+shuttle-service = { path = "service", version = "0.36.0" }
 
 anyhow = "1.0.66"
 async-trait = "0.1.58"

--- a/admin/Cargo.toml
+++ b/admin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-admin"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 
 [dependencies]

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-auth"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-builder"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-shuttle"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/cargo-shuttle/README.md
+++ b/cargo-shuttle/README.md
@@ -142,8 +142,8 @@ This should generate the following dependency in `Cargo.toml`:
 
 ```toml
 rocket = "0.5.0"
-shuttle-rocket = "0.35.1"
-shuttle-runtime = "0.35.1"
+shuttle-rocket = "0.36.0"
+shuttle-runtime = "0.36.0"
 tokio = "1.26.0"
 ```
 

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-codegen"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-common"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-deployer"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 description = "Service with instances created per project for handling the compilation, loading, and execution of Shuttle services"

--- a/deployer/tests/deploy_layer/bind-panic/Cargo.toml
+++ b/deployer/tests/deploy_layer/bind-panic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-shuttle-runtime = "0.35.1"
+shuttle-runtime = "0.36.0"
 tokio = "1.22"

--- a/deployer/tests/deploy_layer/main-panic/Cargo.toml
+++ b/deployer/tests/deploy_layer/main-panic/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-shuttle-runtime = "0.35.1"
+shuttle-runtime = "0.36.0"
 tokio = "1.22"

--- a/deployer/tests/deploy_layer/self-stop/Cargo.toml
+++ b/deployer/tests/deploy_layer/self-stop/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-shuttle-runtime = "0.35.1"
+shuttle-runtime = "0.36.0"
 tokio = "1.22"

--- a/deployer/tests/deploy_layer/sleep-async/Cargo.toml
+++ b/deployer/tests/deploy_layer/sleep-async/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-shuttle-runtime = "0.35.1"
+shuttle-runtime = "0.36.0"
 tokio = { version = "1.0", features = ["time"]}

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-gateway"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/logger/Cargo.toml
+++ b/logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-logger"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/provisioner/Cargo.toml
+++ b/provisioner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-provisioner"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 description = "Service responsible for provisioning and managing resources for services"

--- a/resource-recorder/Cargo.toml
+++ b/resource-recorder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-resource-recorder"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-aws-rds"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to provision AWS RDS resources"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "rds"]
 async-trait = "0.1.56"
 paste = "1.0.7"
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.35.1", default-features = false }
+shuttle-service = { path = "../../service", version = "0.36.0", default-features = false }
 sqlx = "0.7.1"
 
 [features]

--- a/resources/metadata/Cargo.toml
+++ b/resources/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-metadata"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to get Shuttle service information"
@@ -8,4 +8,4 @@ keywords = ["shuttle-service", "metadata"]
 
 [dependencies]
 async-trait = "0.1.56"
-shuttle-service = { path = "../../service", version = "0.35.1" }
+shuttle-service = { path = "../../service", version = "0.36.0" }

--- a/resources/persist/Cargo.toml
+++ b/resources/persist/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-persist"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin for persist objects"
@@ -10,5 +10,5 @@ keywords = ["shuttle-service", "persistence"]
 async-trait = "0.1.56"
 bincode = "1.2.1"
 serde = { version = "1.0.0", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.35.1" }
+shuttle-service = { path = "../../service", version = "0.36.0" }
 thiserror = "1.0.32"

--- a/resources/secrets/Cargo.toml
+++ b/resources/secrets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-secrets"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to for managing secrets on shuttle"
@@ -10,4 +10,4 @@ keywords = ["shuttle-service", "secrets"]
 async-trait = "0.1.56"
 secrecy = { version = "0.8.0", features = ["serde"] }
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.35.1" }
+shuttle-service = { path = "../../service", version = "0.36.0" }

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-shared-db"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin for managing shared databases on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "database"]
 async-trait = "0.1.56"
 mongodb = { version = "2.3.0", optional = true }
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.35.1" }
+shuttle-service = { path = "../../service", version = "0.36.0" }
 sqlx = { version = "0.7.1", optional = true }
 
 [features]

--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-turso"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Plugin to obtain a client connected to a Turso database"
@@ -11,7 +11,7 @@ async-trait = "0.1.56"
 dunce = "1.0.4"
 libsql-client = "0.31.0" # Stays on 0.31 until https://github.com/libsql/libsql-client-rs/issues/52
 serde = { version = "1.0.148", features = ["derive"] }
-shuttle-service = { path = "../../service", version = "0.35.1", default-features = false }
+shuttle-service = { path = "../../service", version = "0.36.0", default-features = false }
 url = { version = "2.3.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-runtime"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 description = "Runtime to start and manage any service that runs on shuttle"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -28,8 +28,8 @@
 //!
 //! ```toml
 //! axum = "0.7.3"
-//! shuttle-axum = "0.35.1"
-//! shuttle-runtime = "0.35.1"
+//! shuttle-axum = "0.36.0"
+//! shuttle-runtime = "0.36.0"
 //! tokio = "1.28.2"
 //! ```
 //!
@@ -112,7 +112,7 @@
 //! `runtime-tokio-native-tls` and `postgres` features inside `Cargo.toml`:
 //!
 //! ```toml
-//! shuttle-shared-db = { version = "0.35.1", features = ["postgres"] }
+//! shuttle-shared-db = { version = "0.36.0", features = ["postgres"] }
 //! sqlx = "0.7.1"
 //! ```
 //!

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-service"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/services/shuttle-actix-web/Cargo.toml
+++ b/services/shuttle-actix-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-actix-web"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run an actix webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "actix"]
 
 [dependencies]
 actix-web = { version = "4.3.1" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 num_cpus = "1.15.0"
 
 [dev-dependencies]

--- a/services/shuttle-axum/Cargo.toml
+++ b/services/shuttle-axum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-axum"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run an axum webserver on shuttle"
@@ -11,7 +11,7 @@ keywords = ["shuttle-service", "axum"]
 [dependencies]
 axum = { version = "0.7.3", optional = true }
 axum-0-6 = { package = "axum", version = "0.6.13", optional = true }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-axum/README.md
+++ b/services/shuttle-axum/README.md
@@ -6,7 +6,7 @@ Axum 0.6 is supported by using these feature flags:
 
 ```toml,ignore
 axum = "0.6.0"
-shuttle-axum = { version = "0.35.1", default-features = false, features = ["axum-0-6"] }
+shuttle-axum = { version = "0.36.0", default-features = false, features = ["axum-0-6"] }
 ```
 
 ### Example

--- a/services/shuttle-next/Cargo.toml
+++ b/services/shuttle-next/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-next"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Macros and aliases to deploy wasm on the shuttle platform (https://www.shuttle.rs/)"
@@ -18,6 +18,6 @@ futures-executor = "0.3.21"
 http = "0.2.7"
 rmp-serde = "1.1.1"
 tower-service = "0.3.1"
-shuttle-common = { path = "../../common", version = "0.35.1", features = ["wasm"] }
-shuttle-codegen = { path = "../../codegen", version = "0.35.1", features = ["next"] }
+shuttle-common = { path = "../../common", version = "0.36.0", features = ["wasm"] }
+shuttle-codegen = { path = "../../codegen", version = "0.36.0", features = ["next"] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "registry"] }

--- a/services/shuttle-poem/Cargo.toml
+++ b/services/shuttle-poem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-poem"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a poem webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "poem"]
 
 [dependencies]
 poem = { version = "1.3.55" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-poise/Cargo.toml
+++ b/services/shuttle-poise/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-poise"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a poise discord bot on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "poise", "discord-bot", "serenity"]
 
 [dependencies]
 poise = { version = "0.5.2" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 shuttle-secrets = { path = "../../resources/secrets" }

--- a/services/shuttle-rocket/Cargo.toml
+++ b/services/shuttle-rocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-rocket"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a rocket webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "rocket"]
 
 [dependencies]
 rocket = { version = "0.5.0" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-salvo/Cargo.toml
+++ b/services/shuttle-salvo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-salvo"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a salvo webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "salvo"]
 
 [dependencies]
 salvo = { version = "0.63.0" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-serenity/Cargo.toml
+++ b/services/shuttle-serenity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-serenity"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a serenity server on shuttle"
@@ -11,7 +11,7 @@ keywords = ["shuttle-service", "serenity"]
 [dependencies]
 serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "model"], optional = true }
 serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model"], optional = true }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.69"

--- a/services/shuttle-serenity/README.md
+++ b/services/shuttle-serenity/README.md
@@ -3,7 +3,7 @@
 Serenity 0.12 is now supported by using these feature flags (native TLS also available):
 ```toml,ignore
 serenity = { version = "0.12.0", features = ["..."] }
-shuttle-serenity = { version = "0.35.1", default-features = false, features = ["serenity-0-12-rustls_backend"] }
+shuttle-serenity = { version = "0.36.0", default-features = false, features = ["serenity-0-12-rustls_backend"] }
 ```
 
 ### Example

--- a/services/shuttle-thruster/Cargo.toml
+++ b/services/shuttle-thruster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-thruster"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a thruster webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "thruster"]
 
 [dependencies]
 thruster = { version = "1.3.0" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 thruster = { version = "1.3.0", features = ["hyper_server"] }

--- a/services/shuttle-tide/Cargo.toml
+++ b/services/shuttle-tide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-tide"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a tide webserver on shuttle"
@@ -13,7 +13,7 @@ keywords = ["shuttle-service", "tide"]
 # https://github.com/http-rs/tide/issues/791
 async-std = { version = "1.12.0", features = ["tokio1"] }
 tide = { version = "0.16.0" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-tower/Cargo.toml
+++ b/services/shuttle-tower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-tower"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a tower webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "tower"]
 
 [dependencies]
 hyper = { version = "0.14.23", features = ["server", "tcp", "http1"] }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 tower = { version = "0.4.13", features = ["make"] }
 
 [dev-dependencies]

--- a/services/shuttle-warp/Cargo.toml
+++ b/services/shuttle-warp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-warp"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a warp webserver on shuttle"
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "warp"]
 
 [dependencies]
 warp = { version = "0.3.3" }
-shuttle-runtime = { path = "../../runtime", version = "0.35.1", default-features = false }
+shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Bump versions, examples and update changelog for the v0.36.0 release.



