### PR TITLE
feat(resources): get connection string from db resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,8 +725,11 @@ workflows:
                 - resources/shared-db
               features:
                 - "-F mongodb"
+                - "-F mongodb-client"
                 - "-F postgres"
                 - "-F postgres-rustls"
+                - "-F postgres,sqlx"
+                - "-F postgres-rustls,sqlx"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-axum: << matrix.features >>"

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -14,5 +14,15 @@ shuttle-service = { path = "../../service", version = "0.36.0" }
 sqlx = { version = "0.7.1", optional = true }
 
 [features]
-postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
-postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]
+default = []
+
+# Mongodb
+mongodb = ["dep:mongodb"]
+# Mongodb with a default client
+mongodb-client = ["mongodb"]
+
+# Postgres
+postgres = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
+postgres-rustls = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+# Postgres with an sqlx PgPool
+sqlx = ["dep:sqlx"]

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -4,14 +4,29 @@ use shuttle_service::{
     database, error::CustomError, DbInput, DbOutput, Error, Factory, ResourceBuilder, Type,
 };
 
+// Return different things based on feature choice
+#[cfg(feature = "mongodb-client")]
+type ReturnType = mongodb::Database;
+#[cfg(not(feature = "mongodb-client"))]
+type ReturnType = String;
+
 #[derive(Serialize)]
 pub struct MongoDb {
     config: DbInput,
 }
 
-/// Get a `mongodb::Database` from any factory
+impl MongoDb {
+    /// Use a custom connection string for local runs
+    pub fn local_uri(mut self, local_uri: &str) -> Self {
+        self.config.local_uri = Some(local_uri.to_string());
+
+        self
+    }
+}
+
+/// Get a MongoDB database connection or connection string
 #[async_trait]
-impl ResourceBuilder<mongodb::Database> for MongoDb {
+impl ResourceBuilder<ReturnType> for MongoDb {
     const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::MongoDb));
 
     type Config = DbInput;
@@ -54,38 +69,32 @@ impl ResourceBuilder<mongodb::Database> for MongoDb {
         Ok(info)
     }
 
-    async fn build(build_data: &Self::Output) -> Result<mongodb::Database, Error> {
+    async fn build(build_data: &Self::Output) -> Result<ReturnType, Error> {
         let connection_string = match build_data {
             DbOutput::Local(local_uri) => local_uri.clone(),
             DbOutput::Info(info) => info.connection_string_private(),
         };
 
-        let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
-            .await
-            .map_err(CustomError::new)?;
-        client_options.min_pool_size = Some(1);
-        client_options.max_pool_size = Some(5);
+        #[cfg(feature = "mongodb-client")]
+        return {
+            let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
+                .await
+                .map_err(CustomError::new)?;
+            client_options.min_pool_size = Some(1);
+            client_options.max_pool_size = Some(5);
 
-        let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
+            let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
 
-        // Return a handle to the database defined at the end of the connection string, which is the users provisioned
-        // database
-        let database = client.default_database();
+            // Return a handle to the database defined at the end of the connection string, which is the users provisioned
+            // database
+            let database = client.default_database();
 
-        match database {
-            Some(database) => Ok(database),
-            None => Err(Error::Database(
-                "mongodb connection string missing default database".into(),
-            )),
-        }
-    }
-}
+            database.ok_or_else(|| {
+                Error::Database("mongodb connection string missing default database".into())
+            })
+        };
 
-impl MongoDb {
-    /// Use a custom connection string for local runs
-    pub fn local_uri(mut self, local_uri: &str) -> Self {
-        self.config.local_uri = Some(local_uri.to_string());
-
-        self
+        #[cfg(not(feature = "mongodb-client"))]
+        return Ok(connection_string);
     }
 }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Cargo feature + Return type in macro now determines what is returned from a db resource, adding a plain String option. This can be extended to allow diesel etc

BREAKING: You need to add `sqlx` or `mongodb-client` feature to keep the same behaviour as before.

TODO: Apply the same to aws_rds

TODO: Update examples in a PR

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested locally and adding CI runs for the new features

(CI for c-s run will fail until examples updated)
