### PR TITLE
feat(shuttle-serenity): make serenity 0.12 default, support poise 0.6, deprecate shuttle-poise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -767,7 +767,7 @@ workflows:
                 - services/shuttle-serenity
               features:
                 - "-F serenity"
-                - "-F serenity-0-12-rustls_backend --no-default-features"
+                - "-F serenity-0-11-rustls_backend --no-default-features"
       - test-workspace-member:
           name: << matrix.crate >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -718,6 +718,7 @@ workflows:
                 - services/shuttle-actix-web
                 - services/shuttle-next
                 - services/shuttle-poem
+                - services/shuttle-poise
                 - services/shuttle-rocket
                 - services/shuttle-salvo
                 - services/shuttle-thruster
@@ -748,17 +749,6 @@ workflows:
               features:
                 - "-F axum"
                 - "-F axum-0-6 --no-default-features"
-      - test-standalone:
-          # Has mutually exclusive features, so we run checks for each feature separately
-          name: "services/shuttle-poise: << matrix.features >>"
-          matrix:
-            alias: test-standalone-services-shuttle-poise
-            parameters:
-              path:
-                - services/shuttle-poise
-              features:
-                - "-F poise"
-                - "-F poise-0-5 --no-default-features"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-serenity: << matrix.features >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -756,7 +756,7 @@ workflows:
                 - services/shuttle-poise
               features:
                 - "-F poise"
-                - "-F poise-0-6 --no-default-features"
+                - "-F poise-0-5 --no-default-features"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-serenity: << matrix.features >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,7 +717,6 @@ workflows:
                 - services/shuttle-actix-web
                 - services/shuttle-next
                 - services/shuttle-poem
-                - services/shuttle-poise
                 - services/shuttle-rocket
                 - services/shuttle-salvo
                 - services/shuttle-thruster
@@ -747,6 +746,17 @@ workflows:
               features:
                 - "-F axum"
                 - "-F axum-0-6 --no-default-features"
+      - test-standalone:
+          # Has mutually exclusive features, so we run checks for each feature separately
+          name: "services/shuttle-poise: << matrix.features >>"
+          matrix:
+            alias: test-standalone-services-shuttle-poise
+            parameters:
+              path:
+                - services/shuttle-poise
+              features:
+                - "-F poise"
+                - "-F poise-0-6 --no-default-features"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-serenity: << matrix.features >>"

--- a/services/shuttle-poise/Cargo.toml
+++ b/services/shuttle-poise/Cargo.toml
@@ -9,9 +9,13 @@ keywords = ["shuttle-service", "poise", "discord-bot", "serenity"]
 [workspace]
 
 [dependencies]
-poise = { version = "0.5.2" }
+poise = { version = "0.5.2", optional = true }
+poise-0-6 = { package = "poise", version = "0.6.1", optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
 shuttle-secrets = { path = "../../resources/secrets" }
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
+
+[features]
+default = ["poise"]

--- a/services/shuttle-poise/Cargo.toml
+++ b/services/shuttle-poise/Cargo.toml
@@ -9,13 +9,5 @@ keywords = ["shuttle-service", "poise", "discord-bot", "serenity"]
 [workspace]
 
 [dependencies]
-poise = { version = "0.6.1", optional = true }
-poise-0-5 = { package = "poise", version = "0.5.7", optional = true }
-shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
-
-[dev-dependencies]
-shuttle-secrets = { path = "../../resources/secrets" }
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
-
-[features]
-default = ["poise"]
+poise = "0.5.2"
+shuttle-runtime = { path = "../../runtime", version = "<=0.40.0", default-features = false }

--- a/services/shuttle-poise/Cargo.toml
+++ b/services/shuttle-poise/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["shuttle-service", "poise", "discord-bot", "serenity"]
 [workspace]
 
 [dependencies]
-poise = { version = "0.5.2", optional = true }
-poise-0-6 = { package = "poise", version = "0.6.1", optional = true }
+poise = { version = "0.6.1", optional = true }
+poise-0-5 = { package = "poise", version = "0.5.7", optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]

--- a/services/shuttle-poise/README.md
+++ b/services/shuttle-poise/README.md
@@ -1,56 +1,5 @@
-## Shuttle service integration for the Poise discord bot framework.
+## Shuttle service integration for the Poise Discord bot framework
 
-Poise 0.6 is used by default.
+**This plugin is deprecated.**
 
-Poise 0.5 is supported by using these feature flags:
-
-```toml,ignore
-poise = { version = "0.5.7", features = ["..."] }
-shuttle-poise = { version = "0.36.0", default-features = false, features = ["poise-0-5"] }
-```
-
-### Example
-
-```rust,ignore
-use poise::serenity_prelude as serenity;
-use shuttle_secrets::SecretStore;
-use shuttle_poise::ShuttlePoise;
-
-struct Data {} // User data, which is stored and accessible in all command invocations
-type Error = Box<dyn std::error::Error + Send + Sync>;
-type Context<'a> = poise::Context<'a, Data, Error>;
-
-/// Responds with "world!"
-#[poise::command(slash_command)]
-async fn hello(ctx: Context<'_>) -> Result<(), Error> {
-    ctx.say("world!").await?;
-    Ok(())
-}
-
-#[shuttle_runtime::main]
-async fn poise(#[shuttle_secrets::Secrets] secret_store: SecretStore) -> ShuttlePoise<Data, Error> {
-    // Get the discord token set in `Secrets.toml`
-    let discord_token = secret_store
-        .get("DISCORD_TOKEN")
-        .expect("'DISCORD_TOKEN' was not found");
-
-    let framework = poise::Framework::builder()
-        .options(poise::FrameworkOptions {
-            commands: vec![hello()],
-            ..Default::default()
-        })
-        .token(discord_token)
-        .intents(serenity::GatewayIntents::non_privileged())
-        .setup(|ctx, _ready, framework| {
-            Box::pin(async move {
-                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-                Ok(Data {})
-            })
-        })
-        .build()
-        .await
-        .map_err(shuttle_runtime::CustomError::new)?;
-
-    Ok(framework.into())
-}
-```
+Poise >=0.6 can now be used together with [shuttle-serenity](https://docs.rs/shuttle-serenity/latest/shuttle_serenity/).

--- a/services/shuttle-poise/README.md
+++ b/services/shuttle-poise/README.md
@@ -8,7 +8,7 @@ shuttle-poise = { version = "0.36.0", default-features = false, features = ["poi
 
 ### Example
 
-```rust,no_run
+```rust,ignore
 use poise::serenity_prelude as serenity;
 use shuttle_secrets::SecretStore;
 use shuttle_poise::ShuttlePoise;

--- a/services/shuttle-poise/README.md
+++ b/services/shuttle-poise/README.md
@@ -1,5 +1,11 @@
 ## Shuttle service integration for the Poise discord bot framework.
 
+Poise 0.6 is now supported by using these feature flags:
+```toml,ignore
+poise = { version = "0.6.1", features = ["..."] }
+shuttle-poise = { version = "0.36.0", default-features = false, features = ["poise-0-6"] }
+```
+
 ### Example
 
 ```rust,no_run

--- a/services/shuttle-poise/README.md
+++ b/services/shuttle-poise/README.md
@@ -1,9 +1,12 @@
 ## Shuttle service integration for the Poise discord bot framework.
 
-Poise 0.6 is now supported by using these feature flags:
+Poise 0.6 is used by default.
+
+Poise 0.5 is supported by using these feature flags:
+
 ```toml,ignore
-poise = { version = "0.6.1", features = ["..."] }
-shuttle-poise = { version = "0.36.0", default-features = false, features = ["poise-0-6"] }
+poise = { version = "0.5.7", features = ["..."] }
+shuttle-poise = { version = "0.36.0", default-features = false, features = ["poise-0-5"] }
 ```
 
 ### Example

--- a/services/shuttle-poise/src/lib.rs
+++ b/services/shuttle-poise/src/lib.rs
@@ -1,20 +1,20 @@
 #![doc = include_str!("../README.md")]
-#[cfg(feature = "poise-0-6")]
-use poise_0_6::serenity_prelude as serenity;
-use std::net::SocketAddr;
 #[cfg(feature = "poise")]
+use poise::serenity_prelude as serenity;
+use std::net::SocketAddr;
+#[cfg(feature = "poise-0-5")]
 use std::sync::Arc;
 
 /// A wrapper type for [poise::Framework] so we can implement [shuttle_runtime::Service] for it.
 #[cfg(feature = "poise")]
-pub struct PoiseService<T, E>(pub Arc<poise::Framework<T, E>>);
-/// A wrapper type for [poise::Framework] so we can implement [shuttle_runtime::Service] for it.
-#[cfg(feature = "poise-0-6")]
 pub struct PoiseService<T, E> {
-    pub framework: poise_0_6::Framework<T, E>,
+    pub framework: poise::Framework<T, E>,
     pub token: String,
     pub intents: serenity::GatewayIntents,
 }
+/// A wrapper type for [poise::Framework] so we can implement [shuttle_runtime::Service] for it.
+#[cfg(feature = "poise-0-5")]
+pub struct PoiseService<T, E>(pub Arc<poise_0_5::Framework<T, E>>);
 
 #[shuttle_runtime::async_trait]
 impl<T, E> shuttle_runtime::Service for PoiseService<T, E>
@@ -24,16 +24,16 @@ where
 {
     async fn bind(mut self, _addr: SocketAddr) -> Result<(), shuttle_runtime::Error> {
         #[cfg(feature = "poise")]
-        self.0
-            .start_autosharded()
-            .await
-            .map_err(shuttle_runtime::CustomError::new)?;
-
-        #[cfg(feature = "poise-0-6")]
         serenity::ClientBuilder::new(self.token, self.intents)
             .framework(self.framework)
             .await
             .map_err(shuttle_runtime::CustomError::new)?
+            .start_autosharded()
+            .await
+            .map_err(shuttle_runtime::CustomError::new)?;
+
+        #[cfg(feature = "poise-0-5")]
+        self.0
             .start_autosharded()
             .await
             .map_err(shuttle_runtime::CustomError::new)?;
@@ -43,24 +43,22 @@ where
 }
 
 #[cfg(feature = "poise")]
-impl<T, E> From<Arc<poise::Framework<T, E>>> for PoiseService<T, E> {
-    fn from(framework: Arc<poise::Framework<T, E>>) -> Self {
-        Self(framework)
-    }
-}
-
-#[cfg(feature = "poise-0-6")]
-impl<T, E> From<(poise_0_6::Framework<T, E>, String, serenity::GatewayIntents)>
-    for PoiseService<T, E>
-{
+impl<T, E> From<(poise::Framework<T, E>, String, serenity::GatewayIntents)> for PoiseService<T, E> {
     fn from(
-        (framework, token, intents): (poise_0_6::Framework<T, E>, String, serenity::GatewayIntents),
+        (framework, token, intents): (poise::Framework<T, E>, String, serenity::GatewayIntents),
     ) -> Self {
         Self {
             framework,
             token,
             intents,
         }
+    }
+}
+
+#[cfg(feature = "poise-0-5")]
+impl<T, E> From<Arc<poise_0_5::Framework<T, E>>> for PoiseService<T, E> {
+    fn from(framework: Arc<poise_0_5::Framework<T, E>>) -> Self {
+        Self(framework)
     }
 }
 

--- a/services/shuttle-poise/src/lib.rs
+++ b/services/shuttle-poise/src/lib.rs
@@ -1,20 +1,10 @@
 #![doc = include_str!("../README.md")]
-#[cfg(feature = "poise")]
-use poise::serenity_prelude as serenity;
 use std::net::SocketAddr;
-#[cfg(feature = "poise-0-5")]
 use std::sync::Arc;
 
 /// A wrapper type for [poise::Framework] so we can implement [shuttle_runtime::Service] for it.
-#[cfg(feature = "poise")]
-pub struct PoiseService<T, E> {
-    pub framework: poise::Framework<T, E>,
-    pub token: String,
-    pub intents: serenity::GatewayIntents,
-}
-/// A wrapper type for [poise::Framework] so we can implement [shuttle_runtime::Service] for it.
-#[cfg(feature = "poise-0-5")]
-pub struct PoiseService<T, E>(pub Arc<poise_0_5::Framework<T, E>>);
+#[deprecated = "shuttle-poise for poise 0.5 is deprecated. To use poise 0.6 and Shuttle, check https://docs.rs/shuttle-serenity/latest/shuttle_serenity/"]
+pub struct PoiseService<T, E>(pub Arc<poise::Framework<T, E>>);
 
 #[shuttle_runtime::async_trait]
 impl<T, E> shuttle_runtime::Service for PoiseService<T, E>
@@ -23,16 +13,6 @@ where
     E: Send + Sync + 'static,
 {
     async fn bind(mut self, _addr: SocketAddr) -> Result<(), shuttle_runtime::Error> {
-        #[cfg(feature = "poise")]
-        serenity::ClientBuilder::new(self.token, self.intents)
-            .framework(self.framework)
-            .await
-            .map_err(shuttle_runtime::CustomError::new)?
-            .start_autosharded()
-            .await
-            .map_err(shuttle_runtime::CustomError::new)?;
-
-        #[cfg(feature = "poise-0-5")]
         self.0
             .start_autosharded()
             .await
@@ -42,22 +22,8 @@ where
     }
 }
 
-#[cfg(feature = "poise")]
-impl<T, E> From<(poise::Framework<T, E>, String, serenity::GatewayIntents)> for PoiseService<T, E> {
-    fn from(
-        (framework, token, intents): (poise::Framework<T, E>, String, serenity::GatewayIntents),
-    ) -> Self {
-        Self {
-            framework,
-            token,
-            intents,
-        }
-    }
-}
-
-#[cfg(feature = "poise-0-5")]
-impl<T, E> From<Arc<poise_0_5::Framework<T, E>>> for PoiseService<T, E> {
-    fn from(framework: Arc<poise_0_5::Framework<T, E>>) -> Self {
+impl<T, E> From<Arc<poise::Framework<T, E>>> for PoiseService<T, E> {
+    fn from(framework: Arc<poise::Framework<T, E>>) -> Self {
         Self(framework)
     }
 }

--- a/services/shuttle-serenity/Cargo.toml
+++ b/services/shuttle-serenity/Cargo.toml
@@ -9,8 +9,8 @@ keywords = ["shuttle-service", "serenity"]
 [workspace]
 
 [dependencies]
-serenity = { version = "0.11.5", default-features = false, features = ["client", "gateway", "model"], optional = true }
-serenity-0-12 = { package = "serenity", version = "0.12", default-features = false, features = ["client", "gateway", "model"], optional = true }
+serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "model"], optional = true }
+serenity-0-11 = { package = "serenity", version = "0.11.7", default-features = false, features = ["client", "gateway", "model"], optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.36.0", default-features = false }
 
 [dev-dependencies]
@@ -24,5 +24,5 @@ default = ["rustls_backend"]
 
 rustls_backend = ["serenity/rustls_backend"]
 native_tls_backend = ["serenity/native_tls_backend"]
-serenity-0-12-rustls_backend = ["serenity-0-12/rustls_backend"]
-serenity-0-12-native_tls_backend = ["serenity-0-12/native_tls_backend"]
+serenity-0-11-rustls_backend = ["serenity-0-11/rustls_backend"]
+serenity-0-11-native_tls_backend = ["serenity-0-11/native_tls_backend"]

--- a/services/shuttle-serenity/README.md
+++ b/services/shuttle-serenity/README.md
@@ -1,9 +1,12 @@
 ## Shuttle service integration for the Serenity discord bot framework.
 
-Serenity 0.12 is now supported by using these feature flags (native TLS also available):
+Serenity 0.12 is used by default.
+
+Serenity 0.11 is supported by using these feature flags (native TLS also available):
+
 ```toml,ignore
-serenity = { version = "0.12.0", features = ["..."] }
-shuttle-serenity = { version = "0.36.0", default-features = false, features = ["serenity-0-12-rustls_backend"] }
+serenity = { version = "0.11.7", features = ["..."] }
+shuttle-serenity = { version = "0.36.0", default-features = false, features = ["serenity-0-11-rustls_backend"] }
 ```
 
 ### Example

--- a/services/shuttle-serenity/README.md
+++ b/services/shuttle-serenity/README.md
@@ -1,6 +1,6 @@
-## Shuttle service integration for the Serenity discord bot framework.
+## Shuttle service integration for the Serenity Discord bot framework
 
-Serenity 0.12 is used by default.
+Serenity 0.12 is used by default. Poise 0.6 is also supported.
 
 Serenity 0.11 is supported by using these feature flags (native TLS also available):
 

--- a/services/shuttle-serenity/src/lib.rs
+++ b/services/shuttle-serenity/src/lib.rs
@@ -4,8 +4,8 @@ use std::net::SocketAddr;
 
 #[cfg(feature = "serenity")]
 use serenity::Client;
-#[cfg(feature = "serenity-0-12")]
-use serenity_0_12::Client;
+#[cfg(feature = "serenity-0-11")]
+use serenity_0_11::Client;
 
 /// A wrapper type for [serenity::Client] so we can implement [shuttle_runtime::Service] for it.
 pub struct SerenityService(pub Client);


### PR DESCRIPTION
## Description of change

- Adds `poise` and `poise-0-6` feature flags, with `poise` enabled by default
- Note similar to `shuttle-serenity` added to readme

## How has this been tested? (if applicable)

- `cargo clippy`
- `cargo clippy --no-default-features -F poise-0-6`
