### PR TITLE
feat(resources)!: get db connection string from resources, refactor ResourceBuilder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,11 +725,9 @@ workflows:
                 - resources/shared-db
               features:
                 - "-F mongodb"
-                - "-F mongodb-client"
                 - "-F postgres"
                 - "-F postgres-rustls"
                 - "-F postgres,sqlx"
-                - "-F postgres-rustls,sqlx"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-axum: << matrix.features >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -735,8 +735,8 @@ workflows:
               features:
                 - "-F mongodb"
                 - "-F postgres"
-                - "-F postgres-rustls"
                 - "-F postgres,sqlx"
+                - "-F postgres,sqlx-native-tls"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-axum: << matrix.features >>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -725,8 +725,11 @@ workflows:
                 - resources/shared-db
               features:
                 - "-F mongodb"
+                - "-F mongodb-client"
                 - "-F postgres"
                 - "-F postgres-rustls"
+                - "-F postgres,sqlx"
+                - "-F postgres-rustls,sqlx"
       - test-standalone:
           # Has mutually exclusive features, so we run checks for each feature separately
           name: "services/shuttle-axum: << matrix.features >>"

--- a/codegen/src/shuttle_main/mod.rs
+++ b/codegen/src/shuttle_main/mod.rs
@@ -282,7 +282,7 @@ impl ToTokens for Loader {
                         )
                         .await
                         .context(format!("failed to provision {}", stringify!(#fn_inputs_builder)))?
-                        .init()
+                        .into_resource()
                         .await
                         .context(format!("failed to initialize {}", stringify!(#fn_inputs_builder)))?;
                 )*
@@ -426,7 +426,7 @@ mod tests {
                 )
                 .await
                 .context(format!("failed to provision {}", stringify!(shuttle_shared_db::Postgres)))?
-                .init()
+                .into_resource()
                 .await
                 .context(format!("failed to initialize {}", stringify!(shuttle_shared_db::Postgres)))?;
                 let redis: something::Redis = ::shuttle_runtime::__internals::get_resource::<_, _, something::Redis>(
@@ -436,7 +436,7 @@ mod tests {
                 )
                 .await
                 .context(format!("failed to provision {}", stringify!(shuttle_shared_db::Redis)))?
-                .init()
+                .into_resource()
                 .await
                 .context(format!("failed to initialize {}", stringify!(shuttle_shared_db::Redis)))?;
 
@@ -550,7 +550,7 @@ mod tests {
                 )
                 .await
                 .context(format!("failed to provision {}", stringify!(shuttle_shared_db::Postgres)))?
-                .init()
+                .into_resource()
                 .await
                 .context(format!("failed to initialize {}", stringify!(shuttle_shared_db::Postgres)))?;
                 std::mem::drop(__vars);

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -124,11 +124,11 @@ fn get_databases_table(
                 }
             }
             DatabaseResource::Info(info) => {
-                if info.hostname_shuttle == "localhost" && info.hostname_shuttle == "localhost" {
+                if info.hostname_shuttle == "localhost" && info.hostname_public == "localhost" {
                     // If both hostnames are localhost, this must be a local container
                     // from the local provisioner with a default password.
                     // (DatabaseResource::Info is always from a provisioner server)
-                    // It is revealed here since it is the only place the local db url is printed.
+                    // It is revealed since this is the only place to see local db url.
                     info.connection_string_public(true)
                 } else {
                     info.connection_string_public(show_secrets)

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -10,7 +10,7 @@ use crossterm::style::Stylize;
 use crate::{
     resource::{Response, Type},
     secrets::SecretStore,
-    DbOutput,
+    DatabaseResource,
 };
 
 pub fn get_resource_tables(
@@ -106,10 +106,10 @@ fn get_databases_table(
     }
 
     for database in databases {
-        let info = serde_json::from_value::<DbOutput>(database.data.clone())
+        let info = serde_json::from_value::<DatabaseResource>(database.data.clone())
             .expect("resource data to be a valid database");
         let conn_string = match info {
-            DbOutput::Local(url) => {
+            DatabaseResource::ConnectionString(url) => {
                 if let Ok(mut url) = url.parse::<url::Url>() {
                     // if the local_uri can correctly be parsed as a url,
                     // hide the password before producing table,
@@ -123,11 +123,11 @@ fn get_databases_table(
                     url
                 }
             }
-            DbOutput::Info(info) => {
-                if info.address_private == "localhost" && info.address_public == "localhost" {
+            DatabaseResource::Info(info) => {
+                if info.hostname_shuttle == "localhost" && info.hostname_shuttle == "localhost" {
                     // If both hostnames are localhost, this must be a local container
                     // from the local provisioner with a default password.
-                    // (DbOutput::Info is always from a provisioner server)
+                    // (DatabaseResource::Info is always from a provisioner server)
                     // It is revealed here since it is the only place the local db url is printed.
                     info.connection_string_public(true)
                 } else {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -11,14 +11,14 @@ pub mod provisioner {
 
     use shuttle_common::{
         database::{self, AwsRdsEngine, SharedEngine},
-        DatabaseReadyInfo,
+        DatabaseInfo,
     };
 
     pub use super::generated::provisioner::*;
 
-    impl From<DatabaseResponse> for DatabaseReadyInfo {
+    impl From<DatabaseResponse> for DatabaseInfo {
         fn from(response: DatabaseResponse) -> Self {
-            DatabaseReadyInfo::new(
+            DatabaseInfo::new(
                 response.engine,
                 response.username,
                 response.password,

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,11 +1,10 @@
-# Resources
+# Resources / Plugins
 
 ## Managed resources
 
-The list of managed resources for shuttle is always growing.
+The list of managed resources (Shared DB, AWS RDS, Secrets) is always growing.
 If you feel we are missing a resource you would like, then feel to create a feature request for your desired resource.
 
-## Writing your own managed resources
+## Writing your own plugins
 
-Creating your own resources is actually easy.
-You only need to implement the [`ResourceBuilder<T>`](https://docs.rs/shuttle-service/latest/shuttle_service/trait.ResourceBuilder.html) trait for your resource.
+Check out [custom resource examples](https://github.com/shuttle-hq/shuttle-examples/tree/main/custom-resource) or the plugins in this directory for how to implement the `ResourceBuilder` trait.

--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -16,7 +16,7 @@ sqlx = { version = "0.7.1", optional = true }
 [features]
 default = []
 
-# Database and TLS
+# Database
 postgres = ["sqlx?/postgres"]
 mysql = ["sqlx?/mysql"]
 mariadb = ["sqlx?/mysql"]
@@ -24,4 +24,3 @@ mariadb = ["sqlx?/mysql"]
 # Add an sqlx Pool as a resource output type
 sqlx = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-rustls"]
 sqlx-native-tls = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-native-tls"]
-

--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -11,12 +11,18 @@ async-trait = "0.1.56"
 paste = "1.0.7"
 serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.36.0", default-features = false }
-sqlx = "0.7.1"
+sqlx = { version = "0.7.1", optional = true }
 
 [features]
-postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
-postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]
-mysql = ["sqlx/mysql", "sqlx/runtime-tokio-native-tls"]
-mysql-rustls = ["sqlx/mysql", "sqlx/runtime-tokio-rustls"]
-mariadb = ["sqlx/mysql", "sqlx/runtime-tokio-native-tls"]
-mariadb-rustls = ["sqlx/mysql", "sqlx/runtime-tokio-rustls"]
+default = []
+
+# Database and TLS
+postgres = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
+postgres-rustls = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+mysql = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
+mysql-rustls = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+mariadb = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
+mariadb-rustls = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+
+# Add an sqlx Pool as a resource output type
+sqlx = ["dep:sqlx"]

--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -17,12 +17,11 @@ sqlx = { version = "0.7.1", optional = true }
 default = []
 
 # Database and TLS
-postgres = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
-postgres-rustls = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
-mysql = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
-mysql-rustls = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
-mariadb = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
-mariadb-rustls = ["sqlx?/mysql", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+postgres = ["sqlx?/postgres"]
+mysql = ["sqlx?/mysql"]
+mariadb = ["sqlx?/mysql"]
 
 # Add an sqlx Pool as a resource output type
-sqlx = ["dep:sqlx"]
+sqlx = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-rustls"]
+sqlx-native-tls = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-native-tls"]
+

--- a/resources/aws-rds/src/lib.rs
+++ b/resources/aws-rds/src/lib.rs
@@ -32,7 +32,7 @@ macro_rules! aws_engine {
                 );
 
                 type Config = shuttle_service::DbInput;
-                type Output = Wrap;
+                type Output = Wrapper;
 
                 fn config(&self) -> &Self::Config {
                     &self.0
@@ -58,7 +58,7 @@ macro_rules! aws_engine {
                         }
                     };
 
-                    Ok(Wrap(info))
+                    Ok(Wrapper(info))
                 }
             }
         }
@@ -73,10 +73,10 @@ aws_engine!("mariadb", MariaDB);
 
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Wrap(DatabaseResource);
+pub struct Wrapper(DatabaseResource);
 
 #[async_trait]
-impl IntoResource<String> for Wrap {
+impl IntoResource<String> for Wrapper {
     async fn into_resource(self) -> Result<String, Error> {
         Ok(match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
@@ -92,7 +92,7 @@ mod _sqlx {
 
     #[cfg(feature = "postgres")]
     #[async_trait]
-    impl IntoResource<sqlx::PgPool> for Wrap {
+    impl IntoResource<sqlx::PgPool> for Wrapper {
         async fn into_resource(self) -> Result<sqlx::PgPool, Error> {
             let connection_string: String = self.into_resource().await.unwrap();
 
@@ -107,7 +107,7 @@ mod _sqlx {
 
     #[cfg(any(feature = "mysql", feature = "mariadb"))]
     #[async_trait]
-    impl IntoResource<sqlx::MySqlPool> for Wrap {
+    impl IntoResource<sqlx::MySqlPool> for Wrapper {
         async fn into_resource(self) -> Result<sqlx::MySqlPool, Error> {
             let connection_string: String = self.into_resource().await.unwrap();
 

--- a/resources/metadata/src/lib.rs
+++ b/resources/metadata/src/lib.rs
@@ -2,18 +2,13 @@ use async_trait::async_trait;
 use shuttle_service::{error::Error, Factory, ResourceBuilder, Type};
 pub use shuttle_service::{DeploymentMetadata as Metadata, Environment};
 
+#[derive(Default)]
 pub struct ShuttleMetadata;
 
 #[async_trait]
-impl ResourceBuilder<Metadata> for ShuttleMetadata {
-    fn new() -> Self {
-        Self
-    }
-
+impl ResourceBuilder for ShuttleMetadata {
     const TYPE: Type = Type::Metadata;
-
     type Config = ();
-
     type Output = Metadata;
 
     fn config(&self) -> &Self::Config {
@@ -22,9 +17,5 @@ impl ResourceBuilder<Metadata> for ShuttleMetadata {
 
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, Error> {
         Ok(factory.get_metadata())
-    }
-
-    async fn build(build_data: &Self::Output) -> Result<Metadata, Error> {
-        Ok(build_data.clone())
     }
 }

--- a/resources/metadata/src/lib.rs
+++ b/resources/metadata/src/lib.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use shuttle_service::{error::Error, Factory, ResourceBuilder, Type};
+use shuttle_service::{error::Error, resource::Type, Factory, ResourceBuilder};
 pub use shuttle_service::{DeploymentMetadata as Metadata, Environment};
 
 #[derive(Default)]

--- a/resources/persist/src/lib.rs
+++ b/resources/persist/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use async_trait::async_trait;
 use bincode::{deserialize_from, serialize_into, Error as BincodeError};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use shuttle_service::{DeploymentMetadata, Factory, ResourceBuilder, Type};
+use shuttle_service::{resource::Type, DeploymentMetadata, Factory, ResourceBuilder};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/resources/persist/src/lib.rs
+++ b/resources/persist/src/lib.rs
@@ -32,7 +32,7 @@ pub enum PersistError {
     Deserialize(BincodeError),
 }
 
-#[derive(Serialize)]
+#[derive(Default)]
 pub struct Persist;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -123,16 +123,10 @@ impl PersistInstance {
 }
 
 #[async_trait]
-impl ResourceBuilder<PersistInstance> for Persist {
+impl ResourceBuilder for Persist {
     const TYPE: Type = Type::Persist;
-
     type Config = ();
-
     type Output = PersistInstance;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     fn config(&self) -> &Self::Config {
         &()
@@ -154,10 +148,6 @@ impl ResourceBuilder<PersistInstance> for Persist {
                 .join(PathBuf::from(service_name)), // separate persist directories per service
         )
         .map_err(|e| shuttle_service::Error::Custom(e.into()))
-    }
-
-    async fn build(build_data: &Self::Output) -> Result<PersistInstance, shuttle_service::Error> {
-        Ok(build_data.clone())
     }
 }
 

--- a/resources/secrets/Cargo.toml
+++ b/resources/secrets/Cargo.toml
@@ -8,6 +8,4 @@ keywords = ["shuttle-service", "secrets"]
 
 [dependencies]
 async-trait = "0.1.56"
-secrecy = { version = "0.8.0", features = ["serde"] }
-serde = { version = "1.0.148", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.36.0" }

--- a/resources/secrets/src/lib.rs
+++ b/resources/secrets/src/lib.rs
@@ -1,26 +1,17 @@
 #![doc = include_str!("../README.md")]
-
 use async_trait::async_trait;
-use serde::Serialize;
 pub use shuttle_service::SecretStore;
-use shuttle_service::{Error, Factory, ResourceBuilder, Type};
+use shuttle_service::{resource::Type, Error, Factory, ResourceBuilder};
 
-/// A struct that represents service secrets
-#[derive(Serialize)]
+/// Secrets plugin that provides service secrets
+#[derive(Default)]
 pub struct Secrets;
 
-/// Get a store with all the secrets available to a deployment
 #[async_trait]
-impl ResourceBuilder<SecretStore> for Secrets {
+impl ResourceBuilder for Secrets {
     const TYPE: Type = Type::Secrets;
-
     type Config = ();
-
     type Output = SecretStore;
-
-    fn new() -> Self {
-        Self {}
-    }
 
     fn config(&self) -> &Self::Config {
         &()
@@ -30,9 +21,5 @@ impl ResourceBuilder<SecretStore> for Secrets {
         let secrets = factory.get_secrets().await?;
 
         Ok(SecretStore::new(secrets))
-    }
-
-    async fn build(build_data: &Self::Output) -> Result<SecretStore, crate::Error> {
-        Ok(build_data.clone())
     }
 }

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -18,8 +18,6 @@ default = []
 
 # Mongodb
 mongodb = ["dep:mongodb"]
-# Mongodb with a default client
-mongodb-client = ["mongodb"]
 
 # Postgres
 postgres = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -14,5 +14,15 @@ shuttle-service = { path = "../../service", version = "0.36.0" }
 sqlx = { version = "0.7.1", optional = true }
 
 [features]
-postgres = ["sqlx/postgres", "sqlx/runtime-tokio-native-tls"]
-postgres-rustls = ["sqlx/postgres", "sqlx/runtime-tokio-rustls"]
+default = []
+
+# Mongodb
+mongodb = ["dep:mongodb"]
+# Mongodb with a default client
+mongodb-client = ["mongodb"]
+
+# Postgres
+postgres = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
+postgres-rustls = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+# Postgres with an sqlx PgPool
+sqlx = ["dep:sqlx"]

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 mongodb = ["dep:mongodb"]
 
 # Postgres
-postgres = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-native-tls"]
-postgres-rustls = ["sqlx?/postgres", "sqlx?/runtime-tokio", "sqlx?/tls-rustls"]
+postgres = ["sqlx?/postgres"]
 # Postgres with an sqlx PgPool
-sqlx = ["dep:sqlx"]
+sqlx = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-rustls"]
+sqlx-native-tls = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-native-tls"]

--- a/resources/shared-db/README.md
+++ b/resources/shared-db/README.md
@@ -1,31 +1,6 @@
 # Shuttle Shared Databases
 
-This plugin manages databases that are shared with other services on [Shuttle](https://www.shuttle.rs).
+This plugin manages Postgres and MongoDB databases on [Shuttle](https://www.shuttle.rs).
 Your database will be in a cluster shared with other users, but it will not be accessible by other users.
 
-## Usage
-
-Add `shuttle-shared-db` to the dependencies for your service. Every type of shareable database is behind the following feature flag and attribute path (`*-rustls` uses rustls for TLS, the default uses native-tls).
-
-| Engine   | Feature flags                  | Attribute path              |
-|----------|--------------------------------|-----------------------------|
-| Postgres | `postgres` / `postgres-rustls` | shuttle_shared_db::Postgres |
-| MongoDB  | `mongodb`                      | shuttle_shared_db::MongoDb  |
-
-An example using the Rocket framework can be found on [GitHub](https://github.com/shuttle-hq/shuttle-examples/tree/main/rocket/postgres)
-
-### Postgres
-
-This resource has the following options
-
-| Option    | Type | Description                                                                                                    |
-|-----------|------|----------------------------------------------------------------------------------------------------------------|
-| local_uri | &str | Don't spin a local docker instance of Postgres, but rather connect to this URI instead for `cargo shuttle run` |
-
-### MongoDB
-
-This resource has the following options
-
-| Option    | Type | Description                                                                                                   |
-|-----------|------|---------------------------------------------------------------------------------------------------------------|
-| local_uri | &str | Don't spin a local docker instance of MongoDB, but rather connect to this URI instead for `cargo shuttle run` |
+- [Docs](https://docs.shuttle.rs/resources/shuttle-shared-db)

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -4,14 +4,29 @@ use shuttle_service::{
     database, error::CustomError, DbInput, DbOutput, Error, Factory, ResourceBuilder, Type,
 };
 
+// Return different things based on feature choice
+#[cfg(feature = "mongodb-client")]
+type ReturnType = mongodb::Database;
+#[cfg(not(feature = "mongodb-client"))]
+type ReturnType = String;
+
 #[derive(Serialize)]
 pub struct MongoDb {
     config: DbInput,
 }
 
-/// Get a `mongodb::Database` from any factory
+impl MongoDb {
+    /// Use a custom connection string for local runs
+    pub fn local_uri(mut self, local_uri: &str) -> Self {
+        self.config.local_uri = Some(local_uri.to_string());
+
+        self
+    }
+}
+
+/// Get a MongoDB database connection or connection string
 #[async_trait]
-impl ResourceBuilder<mongodb::Database> for MongoDb {
+impl ResourceBuilder<ReturnType> for MongoDb {
     const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::MongoDb));
 
     type Config = DbInput;
@@ -54,38 +69,32 @@ impl ResourceBuilder<mongodb::Database> for MongoDb {
         Ok(info)
     }
 
-    async fn build(build_data: &Self::Output) -> Result<mongodb::Database, Error> {
+    async fn build(build_data: &Self::Output) -> Result<ReturnType, Error> {
         let connection_string = match build_data {
             DbOutput::Local(local_uri) => local_uri.clone(),
             DbOutput::Info(info) => info.connection_string_private(),
         };
 
-        let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
-            .await
-            .map_err(CustomError::new)?;
-        client_options.min_pool_size = Some(1);
-        client_options.max_pool_size = Some(5);
+        #[cfg(feature = "mongodb-client")]
+        return {
+            let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
+                .await
+                .map_err(CustomError::new)?;
+            client_options.min_pool_size = Some(1);
+            client_options.max_pool_size = Some(5);
 
-        let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
+            let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
 
-        // Return a handle to the database defined at the end of the connection string, which is the users provisioned
-        // database
-        let database = client.default_database();
+            // Return a handle to the database defined at the end of the connection string, which is the users provisioned
+            // database
+            let database = client.default_database();
 
-        match database {
-            Some(database) => Ok(database),
-            None => Err(Error::Database(
-                "mongodb connection string missing default database".into(),
-            )),
-        }
-    }
-}
+            database.ok_or_else(|| {
+                Error::Database("mongodb connection string missing default database".into())
+            })
+        };
 
-impl MongoDb {
-    /// Use a custom connection string for local runs
-    pub fn local_uri(mut self, local_uri: &str) -> Self {
-        self.config.local_uri = Some(local_uri.to_string());
-
-        self
+        #[cfg(not(feature = "mongodb-client"))]
+        return Ok(connection_string);
     }
 }

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -5,7 +5,7 @@ use shuttle_service::{
     IntoResource, ResourceBuilder,
 };
 
-/// Shuttle managed MongoDB in a shared cluster.
+/// Shuttle managed MongoDB in a shared cluster
 #[derive(Default)]
 pub struct MongoDb(DbInput);
 
@@ -18,7 +18,6 @@ impl MongoDb {
     }
 }
 
-/// Get a MongoDB database connection or connection string
 #[async_trait]
 impl ResourceBuilder for MongoDb {
     const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::MongoDb));
@@ -60,6 +59,7 @@ impl ResourceBuilder for MongoDb {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Wrap(DatabaseResource);
 
 #[async_trait]

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -64,7 +64,7 @@ pub struct Wrap(DatabaseResource);
 
 #[async_trait]
 impl IntoResource<String> for Wrap {
-    async fn init(self) -> Result<String, Error> {
+    async fn into_resource(self) -> Result<String, Error> {
         Ok(match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
             DatabaseResource::Info(info) => info.connection_string_shuttle(),
@@ -74,7 +74,7 @@ impl IntoResource<String> for Wrap {
 
 #[async_trait]
 impl IntoResource<mongodb::Database> for Wrap {
-    async fn init(self) -> Result<mongodb::Database, Error> {
+    async fn into_resource(self) -> Result<mongodb::Database, Error> {
         let connection_string = match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
             DatabaseResource::Info(info) => info.connection_string_shuttle(),
@@ -88,8 +88,8 @@ impl IntoResource<mongodb::Database> for Wrap {
 
         let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
 
-        // Return a handle to the database defined at the end of the connection string, which is the users provisioned
-        // database
+        // Return a handle to the database defined at the end of the connection string,
+        // which is the users provisioned database
         let database = client.default_database();
 
         database.ok_or_else(|| {

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -1,24 +1,18 @@
 use async_trait::async_trait;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use shuttle_service::{
-    database, error::CustomError, DbInput, DbOutput, Error, Factory, ResourceBuilder, Type,
+    database, error::CustomError, resource::Type, DatabaseResource, DbInput, Error, Factory,
+    IntoResource, ResourceBuilder,
 };
 
-// Return different things based on feature choice
-#[cfg(feature = "mongodb-client")]
-type ReturnType = mongodb::Database;
-#[cfg(not(feature = "mongodb-client"))]
-type ReturnType = String;
-
-#[derive(Serialize)]
-pub struct MongoDb {
-    config: DbInput,
-}
+/// Shuttle managed MongoDB in a shared cluster.
+#[derive(Default)]
+pub struct MongoDb(DbInput);
 
 impl MongoDb {
     /// Use a custom connection string for local runs
     pub fn local_uri(mut self, local_uri: &str) -> Self {
-        self.config.local_uri = Some(local_uri.to_string());
+        self.0.local_uri = Some(local_uri.to_string());
 
         self
     }
@@ -26,36 +20,30 @@ impl MongoDb {
 
 /// Get a MongoDB database connection or connection string
 #[async_trait]
-impl ResourceBuilder<ReturnType> for MongoDb {
+impl ResourceBuilder for MongoDb {
     const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::MongoDb));
 
     type Config = DbInput;
 
-    type Output = DbOutput;
-
-    fn new() -> Self {
-        Self {
-            config: Default::default(),
-        }
-    }
+    type Output = Wrap;
 
     fn config(&self) -> &Self::Config {
-        &self.config
+        &self.0
     }
 
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, Error> {
         let info = match factory.get_metadata().env {
-            shuttle_service::Environment::Deployment => DbOutput::Info(
+            shuttle_service::Environment::Deployment => DatabaseResource::Info(
                 factory
                     .get_db_connection(database::Type::Shared(database::SharedEngine::MongoDb))
                     .await
                     .map_err(CustomError::new)?,
             ),
             shuttle_service::Environment::Local => {
-                if let Some(local_uri) = self.config.local_uri {
-                    DbOutput::Local(local_uri)
+                if let Some(local_uri) = self.0.local_uri {
+                    DatabaseResource::ConnectionString(local_uri)
                 } else {
-                    DbOutput::Info(
+                    DatabaseResource::Info(
                         factory
                             .get_db_connection(database::Type::Shared(
                                 database::SharedEngine::MongoDb,
@@ -66,35 +54,46 @@ impl ResourceBuilder<ReturnType> for MongoDb {
                 }
             }
         };
-        Ok(info)
+
+        Ok(Wrap(info))
     }
+}
 
-    async fn build(build_data: &Self::Output) -> Result<ReturnType, Error> {
-        let connection_string = match build_data {
-            DbOutput::Local(local_uri) => local_uri.clone(),
-            DbOutput::Info(info) => info.connection_string_private(),
+#[derive(Serialize, Deserialize)]
+pub struct Wrap(DatabaseResource);
+
+#[async_trait]
+impl IntoResource<String> for Wrap {
+    async fn init(self) -> Result<String, Error> {
+        Ok(match self.0 {
+            DatabaseResource::ConnectionString(s) => s.clone(),
+            DatabaseResource::Info(info) => info.connection_string_shuttle(),
+        })
+    }
+}
+
+#[async_trait]
+impl IntoResource<mongodb::Database> for Wrap {
+    async fn init(self) -> Result<mongodb::Database, Error> {
+        let connection_string = match self.0 {
+            DatabaseResource::ConnectionString(s) => s.clone(),
+            DatabaseResource::Info(info) => info.connection_string_shuttle(),
         };
 
-        #[cfg(feature = "mongodb-client")]
-        return {
-            let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
-                .await
-                .map_err(CustomError::new)?;
-            client_options.min_pool_size = Some(1);
-            client_options.max_pool_size = Some(5);
+        let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
+            .await
+            .map_err(CustomError::new)?;
+        client_options.min_pool_size = Some(1);
+        client_options.max_pool_size = Some(5);
 
-            let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
+        let client = mongodb::Client::with_options(client_options).map_err(CustomError::new)?;
 
-            // Return a handle to the database defined at the end of the connection string, which is the users provisioned
-            // database
-            let database = client.default_database();
+        // Return a handle to the database defined at the end of the connection string, which is the users provisioned
+        // database
+        let database = client.default_database();
 
-            database.ok_or_else(|| {
-                Error::Database("mongodb connection string missing default database".into())
-            })
-        };
-
-        #[cfg(not(feature = "mongodb-client"))]
-        return Ok(connection_string);
+        database.ok_or_else(|| {
+            Error::Database("mongodb connection string missing default database".into())
+        })
     }
 }

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -75,10 +75,7 @@ impl IntoResource<String> for Wrap {
 #[async_trait]
 impl IntoResource<mongodb::Database> for Wrap {
     async fn into_resource(self) -> Result<mongodb::Database, Error> {
-        let connection_string = match self.0 {
-            DatabaseResource::ConnectionString(s) => s.clone(),
-            DatabaseResource::Info(info) => info.connection_string_shuttle(),
-        };
+        let connection_string: String = self.into_resource().await.unwrap();
 
         let mut client_options = mongodb::options::ClientOptions::parse(connection_string)
             .await

--- a/resources/shared-db/src/mongo.rs
+++ b/resources/shared-db/src/mongo.rs
@@ -24,7 +24,7 @@ impl ResourceBuilder for MongoDb {
 
     type Config = DbInput;
 
-    type Output = Wrap;
+    type Output = Wrapper;
 
     fn config(&self) -> &Self::Config {
         &self.0
@@ -54,16 +54,16 @@ impl ResourceBuilder for MongoDb {
             }
         };
 
-        Ok(Wrap(info))
+        Ok(Wrapper(info))
     }
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Wrap(DatabaseResource);
+pub struct Wrapper(DatabaseResource);
 
 #[async_trait]
-impl IntoResource<String> for Wrap {
+impl IntoResource<String> for Wrapper {
     async fn into_resource(self) -> Result<String, Error> {
         Ok(match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
@@ -73,7 +73,7 @@ impl IntoResource<String> for Wrap {
 }
 
 #[async_trait]
-impl IntoResource<mongodb::Database> for Wrap {
+impl IntoResource<mongodb::Database> for Wrapper {
     async fn into_resource(self) -> Result<mongodb::Database, Error> {
         let connection_string: String = self.into_resource().await.unwrap();
 

--- a/resources/shared-db/src/postgres.rs
+++ b/resources/shared-db/src/postgres.rs
@@ -62,7 +62,7 @@ pub struct Wrap(DatabaseResource);
 
 #[async_trait]
 impl IntoResource<String> for Wrap {
-    async fn init(self) -> Result<String, Error> {
+    async fn into_resource(self) -> Result<String, Error> {
         Ok(match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
             DatabaseResource::Info(info) => info.connection_string_shuttle(),
@@ -73,7 +73,7 @@ impl IntoResource<String> for Wrap {
 #[cfg(feature = "sqlx")]
 #[async_trait]
 impl IntoResource<sqlx::PgPool> for Wrap {
-    async fn init(self) -> Result<sqlx::PgPool, Error> {
+    async fn into_resource(self) -> Result<sqlx::PgPool, Error> {
         let connection_string = match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
             DatabaseResource::Info(info) => info.connection_string_shuttle(),

--- a/resources/shared-db/src/postgres.rs
+++ b/resources/shared-db/src/postgres.rs
@@ -5,7 +5,7 @@ use shuttle_service::{
     ResourceBuilder,
 };
 
-/// Shuttle managed Postgres DB in a shared cluster.
+/// Shuttle managed Postgres DB in a shared cluster
 #[derive(Default)]
 pub struct Postgres(DbInput);
 
@@ -18,7 +18,6 @@ impl Postgres {
     }
 }
 
-/// Get a Postgres Database as an `sqlx::PgPool` or connection string
 #[async_trait]
 impl ResourceBuilder for Postgres {
     const TYPE: Type = Type::Database(database::Type::Shared(database::SharedEngine::Postgres));
@@ -58,6 +57,7 @@ impl ResourceBuilder for Postgres {
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct Wrap(DatabaseResource);
 
 #[async_trait]

--- a/resources/shared-db/src/postgres.rs
+++ b/resources/shared-db/src/postgres.rs
@@ -24,7 +24,7 @@ impl ResourceBuilder for Postgres {
 
     type Config = DbInput;
 
-    type Output = Wrap;
+    type Output = Wrapper;
 
     fn config(&self) -> &Self::Config {
         &self.0
@@ -52,16 +52,16 @@ impl ResourceBuilder for Postgres {
             }
         };
 
-        Ok(Wrap(info))
+        Ok(Wrapper(info))
     }
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Wrap(DatabaseResource);
+pub struct Wrapper(DatabaseResource);
 
 #[async_trait]
-impl IntoResource<String> for Wrap {
+impl IntoResource<String> for Wrapper {
     async fn into_resource(self) -> Result<String, Error> {
         Ok(match self.0 {
             DatabaseResource::ConnectionString(s) => s.clone(),
@@ -72,7 +72,7 @@ impl IntoResource<String> for Wrap {
 
 #[cfg(feature = "sqlx")]
 #[async_trait]
-impl IntoResource<sqlx::PgPool> for Wrap {
+impl IntoResource<sqlx::PgPool> for Wrapper {
     async fn into_resource(self) -> Result<sqlx::PgPool, Error> {
         let connection_string: String = self.into_resource().await.unwrap();
 

--- a/resources/shared-db/src/postgres.rs
+++ b/resources/shared-db/src/postgres.rs
@@ -74,10 +74,7 @@ impl IntoResource<String> for Wrap {
 #[async_trait]
 impl IntoResource<sqlx::PgPool> for Wrap {
     async fn into_resource(self) -> Result<sqlx::PgPool, Error> {
-        let connection_string = match self.0 {
-            DatabaseResource::ConnectionString(s) => s.clone(),
-            DatabaseResource::Info(info) => info.connection_string_shuttle(),
-        };
+        let connection_string: String = self.into_resource().await.unwrap();
 
         Ok(sqlx::postgres::PgPoolOptions::new()
             .min_connections(1)

--- a/resources/shared-db/src/postgres.rs
+++ b/resources/shared-db/src/postgres.rs
@@ -5,7 +5,7 @@ use shuttle_service::{
     ResourceBuilder,
 };
 
-/// Handles the state of a Shuttle managed Postgres DB and sets up a Postgres driver.
+/// Shuttle managed Postgres DB in a shared cluster.
 #[derive(Default)]
 pub struct Postgres(DbInput);
 

--- a/resources/turso/src/lib.rs
+++ b/resources/turso/src/lib.rs
@@ -7,7 +7,7 @@ use shuttle_service::{
 };
 use url::Url;
 
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Default)]
 pub struct Turso {
     addr: String,
     token: String,
@@ -72,13 +72,8 @@ impl Turso {
 #[async_trait]
 impl ResourceBuilder<Client> for Turso {
     const TYPE: Type = Type::Turso;
-
     type Config = Self;
     type Output = TursoOutput;
-
-    fn new() -> Self {
-        Self::default()
-    }
 
     fn config(&self) -> &Self::Config {
         self
@@ -126,14 +121,16 @@ impl ResourceBuilder<Client> for Turso {
             }
         }
     }
+}
 
-    async fn build(config: &Self::Output) -> Result<Client, shuttle_service::Error> {
-        let client = Client::from_config(Config {
-            url: config.conn_url.clone(),
-            auth_token: config.token.clone(),
+#[async_trait]
+impl IntoResource<Client> for TursoOutput {
+    async fn into_resource(self) -> Result<String, Error> {
+        Ok(Client::from_config(Config {
+            url: self.conn_url.clone(),
+            auth_token: self.token.clone(),
         })
-        .await?;
-        Ok(client)
+        .await?)
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -205,7 +205,7 @@
 
 // Public API
 pub use shuttle_codegen::main;
-pub use shuttle_service::{CustomError, Error, Factory, ResourceBuilder, Service};
+pub use shuttle_service::{CustomError, Error, Factory, IntoResource, ResourceBuilder, Service};
 
 // Useful re-exports
 pub use async_trait::async_trait;

--- a/runtime/src/provisioner_factory.rs
+++ b/runtime/src/provisioner_factory.rs
@@ -6,7 +6,7 @@ use shuttle_common::{
     constants::STORAGE_DIRNAME,
     database,
     secrets::Secret,
-    DatabaseReadyInfo,
+    DatabaseInfo,
 };
 use shuttle_proto::provisioner::{provisioner_client::ProvisionerClient, DatabaseRequest};
 use shuttle_service::{DeploymentMetadata, Environment, Factory};
@@ -44,7 +44,7 @@ impl Factory for ProvisionerFactory {
     async fn get_db_connection(
         &mut self,
         db_type: database::Type,
-    ) -> Result<DatabaseReadyInfo, shuttle_service::Error> {
+    ) -> Result<DatabaseInfo, shuttle_service::Error> {
         let mut request = Request::new(DatabaseRequest {
             project_name: self.service_name.to_string(),
             db_type: Some(db_type.into()),
@@ -61,7 +61,7 @@ impl Factory for ProvisionerFactory {
             .map_err(shuttle_service::error::CustomError::new)?
             .into_inner();
 
-        let info: DatabaseReadyInfo = response.into();
+        let info: DatabaseInfo = response.into();
 
         Ok(info)
     }

--- a/runtime/src/resource_tracker.rs
+++ b/runtime/src/resource_tracker.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use serde::{de::DeserializeOwned, Serialize};
 use serde_json::Value;
 use shuttle_common::resource::{self, Type};
-use shuttle_service::ResourceBuilder;
+use shuttle_service::{IntoResource, ResourceBuilder};
 
 use crate::__internals::ProvisionerFactory;
 
@@ -63,67 +63,60 @@ macro_rules! log {
 /// Helper function to get a resource from a builder.
 ///
 /// This function is called by the loader (see codegen) to create each type of needed resource.
-pub async fn get_resource<B, T, O>(
+pub async fn get_resource<B, O, T>(
     builder: B,
     factory: &mut ProvisionerFactory,
     resource_tracker: &mut ResourceTracker,
 ) -> Result<T, shuttle_service::Error>
 where
-    B: ResourceBuilder<T, Output = O>,
-    O: Serialize + DeserializeOwned,
+    B: ResourceBuilder<Output = O>,
+    O: Serialize + DeserializeOwned + IntoResource<Output = T>,
 {
     log!("Getting resource");
 
     let config = serde_json::to_value(builder.config())
         .context("failed to turn builder config into a value")?;
 
-    log!(format!("Using config: {}", config));
+    log!(format!("Using config: {}", config)); // TODO: This can contain secrets
 
-    let output = if let Some(output) = resource_tracker.get_cached_output(B::TYPE, &config) {
-        log!("Found past output from config");
-
-        match serde_json::from_value(output) {
-            Ok(output) => output,
-            Err(err) => {
-                log!(format!(
-                    "failed to get output from past value ({err}). Will build a new output instead"
-                ));
-
-                log!("Provisioning. This can take a while...");
-
-                let output = builder
-                    .output(factory)
-                    .await
-                    .context("failed to provision resource again")?;
-
-                log!("Done provisioning");
-
-                output
+    let output = resource_tracker.get_cached_output(B::TYPE, &config)
+        .and_then(|output| {
+            log!("Found past output for this config");
+            match serde_json::from_value(output) {
+                Ok(output) => Some(output),
+                Err(err) => {
+                    log!(format!(
+                        "Failed to get output from past config ({err}). Will build a new output instead."
+                    ));
+                    None
+                }
             }
+        })
+        ;
+    let output = match output {
+        Some(output) => output,
+        None => {
+            log!("Provisioning. This can take a while...");
+
+            let output = builder
+                .output(factory)
+                .await
+                .context("failed to provision resource")?;
+
+            log!("Done provisioning");
+
+            output
         }
-    } else {
-        log!("Past output for config does not exist");
-
-        log!("Provisioning. This can take a while...");
-
-        let output = builder
-            .output(factory)
-            .await
-            .context("failed to provision resource")?;
-
-        log!("Done provisioning");
-
-        output
     };
 
+    let output_value =
+        serde_json::to_value(&output).context("failed to turn builder output into a JSON value")?;
+
     log!("Connecting resource");
-    let resource = B::build(&output).await?;
+    let resource: T = output.init().await?;
     log!("Resource connected");
 
-    let output =
-        serde_json::to_value(&output).context("failed to turn builder output into a value")?;
-
-    resource_tracker.record_resource(B::TYPE, config, output);
+    resource_tracker.record_resource(B::TYPE, config, output_value);
 
     Ok(resource)
 }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Service traits and macros to deploy on the shuttle platform (https://www.shuttle.rs/)"
+description = "The core traits for running services on Shuttle (https://www.shuttle.rs/)"
 homepage = "https://www.shuttle.rs"
 
 [lib]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -50,14 +50,11 @@ pub trait ResourceBuilder {
     const TYPE: resource::Type;
 
     /// The input config to this resource.
-    type Config: Serialize;
+    type Config: Default + Serialize;
 
     /// The output from requesting this resource.
     /// A cached copy of this will be used if the same [`Self::Config`] is found for this [`Self::TYPE`].
     type Output: Serialize + DeserializeOwned;
-
-    /// Create a new instance of this resource builder
-    fn new() -> Self; // consider dropping this and use .default() in codegen?
 
     /// Get the internal config state of the builder
     ///
@@ -74,11 +71,11 @@ pub trait ResourceBuilder {
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, crate::Error>;
 }
 
+/// Implement this on an ResourceBuilder::Output type to turn the
+/// base resource into the end type exposed to the shuttle main function.
 #[async_trait]
-pub trait IntoResource {
-    type Output;
-
-    async fn init(self) -> Result<Self::Output, crate::Error>;
+pub trait IntoResource<R>: Serialize + DeserializeOwned {
+    async fn init(self) -> Result<R, crate::Error>;
 }
 
 // #[async_trait]

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -76,7 +76,7 @@ pub trait ResourceBuilder: Default {
     /// can at times even take minutes. That is why the output of this method is cached and calling this method can be
     /// skipped as explained in [`ResourceBuilder::config`].
     ///
-    /// The output from this function is passed to [`IntoResource::init`].
+    /// The output from this function is passed to [`IntoResource::into_resource`].
     async fn output(self, factory: &mut dyn Factory) -> Result<Self::Output, crate::Error>;
 }
 

--- a/services/shuttle-poem/Cargo.toml
+++ b/services/shuttle-poem/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-poem"
-version = "0.37.0"
+version = "0.36.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Service implementation to run a poem webserver on shuttle"


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Supersedes #1515

Main function arg's type declaration determine which type is returned from a resource, allowing DB plugins to return the connection string.

BREAKING: Postgres projects with the sqlx connector need to add a feature flag to keep the same behaviour. Also breaking changes in the public API of shuttle-service.

TODO:
- [x] Approval of pattern
- [x] Update rest of plugins with this ResourceBuilder
- [x] Update examples https://github.com/shuttle-hq/shuttle-examples/pull/127
- [x] Docs

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

All examples build with the PR above
