### PR TITLE
[WIP] deployer: move deployer(s) state in gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5840,6 +5840,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ttl_cache",
+ "ulid",
  "url",
  "uuid",
  "wiremock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5963,6 +5963,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-context",
+ "thiserror",
  "tokio",
  "tonic 0.10.2",
  "tower",

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -212,7 +212,7 @@ Make sure an admin user is inserted into auth and that the key is used by cargo-
 We're now ready to start a local run of the deployer:
 
 ```bash
-OTLP_ADDRESS=http://127.0.0.1:4317 cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --resource-recorder http://localhost:8007 --builder-uri http://localhost:8009 --logger-uri http://localhost:8010 --proxy-fqdn local.rs --admin-secret dh9z58jttoes3qvt --local --project-id "01H7WHDK23XYGSESCBG6XWJ1V0" --project <name>
+OTLP_ADDRESS=http://127.0.0.1:4317 cargo run -p shuttle-deployer -- --provisioner-address http://localhost:3000 --auth-uri http://localhost:8008 --resource-recorder http://localhost:8007 --builder-uri http://localhost:8009 --logger-uri http://localhost:8010 --proxy-fqdn local.rs --admin-secret dh9z58jttoes3qvt --local_auth_layer --project-id "01H7WHDK23XYGSESCBG6XWJ1V0" --project <name>
 ```
 
 The `<name>` needs to match the name of the project that will be deployed to this deployer.

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -37,7 +37,7 @@ rustrict = { version = "=0.7.12", optional = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true }
-sqlx = { workspace = true, optional = true }
+sqlx = { workspace = true, features = ["sqlite", "uuid", "chrono"], optional = true }
 strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
@@ -49,7 +49,7 @@ tracing-core = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ttl_cache = { workspace = true, optional = true }
-ulid = { workspace = true }
+ulid = { workspace = true, optional = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 zeroize = { workspace = true }
@@ -92,7 +92,7 @@ claims = [
 ]
 display = ["chrono/clock", "comfy-table", "crossterm"]
 models = ["async-trait", "http", "reqwest", "service", "thiserror"]
-persist = ["sqlx", "rand"]
+persist = ["sqlx/sqlite", "sqlx/uuid", "sqlx/chrono", "rand", "uuid", "ulid", "models"]
 service = ["chrono/serde", "display", "tracing", "tracing-subscriber", "uuid"]
 test-utils = ["wiremock"]
 tracing = ["dep:tracing"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -49,6 +49,7 @@ tracing-core = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ttl_cache = { workspace = true, optional = true }
+ulid = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 zeroize = { workspace = true }

--- a/common/src/backends/client/gateway.rs
+++ b/common/src/backends/client/gateway.rs
@@ -5,6 +5,21 @@ use tracing::instrument;
 use crate::models;
 
 use super::{Error, ServicesApiClient};
+#[cfg(feature = "persist")]
+use crate::persistence::{
+    deployment::{
+        ActiveDeploymentsGetter, AddressGetter, Deployment, DeploymentRunnable, DeploymentUpdater,
+    },
+    service::Service,
+    state::DeploymentState,
+    DeployerPersistenceApi,
+};
+#[cfg(feature = "persist")]
+use std::net::SocketAddr;
+#[cfg(feature = "persist")]
+use ulid::Ulid;
+#[cfg(feature = "persist")]
+use uuid::Uuid;
 
 /// Wrapper struct to make API calls to gateway easier
 #[derive(Clone)]
@@ -52,6 +67,113 @@ pub trait ProjectsDal {
             .collect();
 
         Ok(ids)
+    }
+}
+
+#[cfg(feature = "persist")]
+#[async_trait::async_trait]
+impl DeploymentUpdater for Client {
+    type Err = Error;
+
+    async fn set_address(&self, _id: &Uuid, _address: &SocketAddr) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn set_is_next(&self, _id: &Uuid, _is_next: bool) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn set_state(&self, _state: DeploymentState) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn update_deployment(&self, _state: DeploymentState) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+#[cfg(feature = "persist")]
+#[async_trait::async_trait]
+impl ActiveDeploymentsGetter for Client {
+    type Err = Error;
+
+    async fn get_active_deployments(
+        &self,
+        _service_id: &ulid::Ulid,
+    ) -> std::result::Result<Vec<Uuid>, Error> {
+        todo!()
+    }
+}
+
+#[cfg(feature = "persist")]
+#[async_trait::async_trait]
+impl AddressGetter for Client {
+    type Err = Error;
+
+    async fn get_address_for_service(
+        &self,
+        _service_name: &str,
+    ) -> std::result::Result<Option<std::net::SocketAddr>, Error> {
+        todo!()
+    }
+}
+
+#[cfg(feature = "persist")]
+#[async_trait::async_trait]
+impl DeployerPersistenceApi for Client {
+    type MasterErr = Error;
+
+    async fn insert_deployment(
+        &self,
+        _deployment: impl Into<&Deployment> + Send,
+    ) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn get_deployment(&self, _id: &Uuid) -> Result<Option<Deployment>, Error> {
+        todo!()
+    }
+
+    async fn get_deployments(
+        &self,
+        _service_id: &Ulid,
+        _offset: u32,
+        _limit: u32,
+    ) -> Result<Vec<Deployment>, Error> {
+        todo!()
+    }
+
+    async fn get_active_deployment(&self, _service_id: &Ulid) -> Result<Option<Deployment>, Error> {
+        todo!()
+    }
+
+    async fn cleanup_invalid_states(&self) -> Result<(), Error> {
+        todo!()
+    }
+
+    async fn get_service_by_name(&self, _name: &str) -> Result<Option<Service>, Error> {
+        todo!()
+    }
+
+    async fn get_or_create_service(&self, _name: &str) -> Result<Service, Error> {
+        todo!()
+    }
+
+    async fn delete_service(&self, _id: &Ulid) -> Result<(), Error> {
+        todo!()
+    }
+    async fn get_all_services(&self) -> Result<Vec<Service>, Error> {
+        todo!()
+    }
+
+    async fn get_all_runnable_deployments(&self) -> Result<Vec<DeploymentRunnable>, Error> {
+        todo!()
+    }
+    async fn get_runnable_deployment(
+        &self,
+        _id: &Uuid,
+    ) -> Result<Option<DeploymentRunnable>, Error> {
+        todo!()
     }
 }
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -21,6 +21,8 @@ pub mod secrets;
 pub use secrets::{Secret, SecretStore};
 #[cfg(feature = "claims")]
 pub mod limits;
+#[cfg(feature = "persist")]
+pub mod persistence;
 #[cfg(feature = "tracing")]
 pub mod tracing;
 #[cfg(feature = "wasm")]

--- a/common/src/persistence/deployment.rs
+++ b/common/src/persistence/deployment.rs
@@ -54,9 +54,9 @@ impl FromRow<'_, SqliteRow> for Deployment {
     }
 }
 
-impl From<Deployment> for shuttle_common::models::deployment::Response {
+impl From<Deployment> for super::super::models::deployment::Response {
     fn from(deployment: Deployment) -> Self {
-        shuttle_common::models::deployment::Response {
+        super::super::models::deployment::Response {
             id: deployment.id,
             service_id: deployment.service_id.to_string(),
             state: deployment.state.into(),

--- a/common/src/persistence/mod.rs
+++ b/common/src/persistence/mod.rs
@@ -1,3 +1,69 @@
+use thiserror::Error;
+use ulid::Ulid;
+use uuid::Uuid;
+
+use self::deployment::{
+    ActiveDeploymentsGetter, AddressGetter, Deployment, DeploymentRunnable, DeploymentUpdater,
+};
+use self::service::Service;
+
 pub mod deployment;
 pub mod service;
 pub mod state;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Hyper error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("Failed to convert {from} to {to}")]
+    Convert {
+        from: String,
+        to: String,
+        message: String,
+    },
+}
+
+#[async_trait::async_trait]
+pub trait DeployerPersistenceApi:
+    DeploymentUpdater + ActiveDeploymentsGetter + AddressGetter
+{
+    type MasterErr: std::error::Error + Send;
+
+    async fn insert_deployment(
+        &self,
+        deployment: impl Into<&Deployment> + Send,
+    ) -> Result<(), Self::MasterErr>;
+
+    async fn get_deployment(&self, id: &Uuid) -> Result<Option<Deployment>, Self::MasterErr>;
+
+    async fn get_deployments(
+        &self,
+        service_id: &Ulid,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<Deployment>, Self::MasterErr>;
+
+    async fn get_active_deployment(
+        &self,
+        service_id: &Ulid,
+    ) -> Result<Option<Deployment>, Self::MasterErr>;
+
+    async fn cleanup_invalid_states(&self) -> Result<(), Self::MasterErr>;
+
+    async fn get_service_by_name(&self, name: &str) -> Result<Option<Service>, Self::MasterErr>;
+
+    async fn get_or_create_service(&self, name: &str) -> Result<Service, Self::MasterErr>;
+
+    async fn delete_service(&self, id: &Ulid) -> Result<(), Self::MasterErr>;
+
+    async fn get_all_services(&self) -> Result<Vec<Service>, Self::MasterErr>;
+
+    async fn get_all_runnable_deployments(
+        &self,
+    ) -> Result<Vec<DeploymentRunnable>, Self::MasterErr>;
+
+    async fn get_runnable_deployment(
+        &self,
+        id: &Uuid,
+    ) -> Result<Option<DeploymentRunnable>, Self::MasterErr>;
+}

--- a/common/src/persistence/mod.rs
+++ b/common/src/persistence/mod.rs
@@ -1,0 +1,3 @@
+pub mod deployment;
+pub mod service;
+pub mod state;

--- a/common/src/persistence/service.rs
+++ b/common/src/persistence/service.rs
@@ -1,4 +1,4 @@
-use shuttle_common::models::service;
+use super::super::models::service;
 use sqlx::{sqlite::SqliteRow, FromRow, Row};
 use ulid::Ulid;
 

--- a/common/src/persistence/state.rs
+++ b/common/src/persistence/state.rs
@@ -45,7 +45,7 @@ impl Default for State {
     }
 }
 
-impl From<State> for shuttle_common::deployment::State {
+impl From<State> for super::super::deployment::State {
     fn from(state: State) -> Self {
         match state {
             State::Queued => Self::Queued,
@@ -61,18 +61,18 @@ impl From<State> for shuttle_common::deployment::State {
     }
 }
 
-impl From<shuttle_common::deployment::State> for State {
-    fn from(state: shuttle_common::deployment::State) -> Self {
+impl From<super::super::deployment::State> for State {
+    fn from(state: super::super::deployment::State) -> Self {
         match state {
-            shuttle_common::deployment::State::Queued => Self::Queued,
-            shuttle_common::deployment::State::Building => Self::Building,
-            shuttle_common::deployment::State::Built => Self::Built,
-            shuttle_common::deployment::State::Loading => Self::Loading,
-            shuttle_common::deployment::State::Running => Self::Running,
-            shuttle_common::deployment::State::Completed => Self::Completed,
-            shuttle_common::deployment::State::Stopped => Self::Stopped,
-            shuttle_common::deployment::State::Crashed => Self::Crashed,
-            shuttle_common::deployment::State::Unknown => Self::Unknown,
+            super::super::deployment::State::Queued => Self::Queued,
+            super::super::deployment::State::Building => Self::Building,
+            super::super::deployment::State::Built => Self::Built,
+            super::super::deployment::State::Loading => Self::Loading,
+            super::super::deployment::State::Running => Self::Running,
+            super::super::deployment::State::Completed => Self::Completed,
+            super::super::deployment::State::Stopped => Self::Stopped,
+            super::super::deployment::State::Crashed => Self::Crashed,
+            super::super::deployment::State::Unknown => Self::Unknown,
         }
     }
 }
@@ -89,7 +89,7 @@ pub trait StateRecorder: Clone + Send + Sync + 'static {
 mod tests {
     use std::str::FromStr;
 
-    use crate::persistence::State;
+    use super::State;
 
     #[test]
     fn test_state_deser() {

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Service with instances created per project for handling the compilation, loading, and execution of Shuttle services"
 
 [dependencies]
-shuttle-common = { workspace = true, features = ["backend", "models"] }
+shuttle-common = { workspace = true, features = ["backend", "models", "persist" ] }
 shuttle-proto = { workspace = true, features = ["resource-recorder"] }
 shuttle-service = { workspace = true, features = ["builder", "runner"] }
 

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -11,7 +11,7 @@ use tonic::transport::Endpoint;
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
 pub struct Args {
-    /// Uri to the `.sqlite` file used to store state
+    /// Uri to the deployer state
     #[clap(long, default_value = "./deployer.sqlite")]
     pub state: String,
 
@@ -69,5 +69,9 @@ pub struct Args {
 
     /// Add an auth layer to deployer for local development
     #[arg(long)]
-    pub local: bool,
+    pub local_auth_layer: bool,
+
+    /// Flag that determines whether this deployer uses remote persistence
+    #[arg(long)]
+    pub is_remote_persistence: bool,
 }

--- a/deployer/src/deployment/gateway_client.rs
+++ b/deployer/src/deployment/gateway_client.rs
@@ -1,7 +1,10 @@
 use axum::headers::{authorization::Bearer, Authorization};
 use hyper::Method;
 use shuttle_common::{
-    backends::client::{gateway, Error},
+    backends::client::{
+        gateway::{self},
+        Error,
+    },
     models::{self},
 };
 use uuid::Uuid;

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -5,7 +5,10 @@ use std::{
 
 use shuttle_common::{
     log::LogRecorder,
-    persistence::{deployment::DeploymentUpdater, state::State},
+    persistence::{
+        deployment::{ActiveDeploymentsGetter, DeploymentUpdater},
+        state::State,
+    },
 };
 use shuttle_proto::{builder::builder_client::BuilderClient, logger::logger_client::LoggerClient};
 use tokio::{
@@ -24,7 +27,7 @@ pub mod state_change_layer;
 use self::gateway_client::BuildQueueClient;
 use crate::{persistence::resource::ResourceManager, RuntimeManager};
 pub use queue::Queued;
-pub use run::{ActiveDeploymentsGetter, Built};
+pub use run::Built;
 
 const QUEUE_BUFFER_SIZE: usize = 100;
 const RUN_BUFFER_SIZE: usize = 100;

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -3,7 +3,10 @@ use std::{
     sync::Arc,
 };
 
-use shuttle_common::log::LogRecorder;
+use shuttle_common::{
+    log::LogRecorder,
+    persistence::{deployment::DeploymentUpdater, state::State},
+};
 use shuttle_proto::{builder::builder_client::BuilderClient, logger::logger_client::LoggerClient};
 use tokio::{
     sync::{mpsc, Mutex},
@@ -19,10 +22,7 @@ mod run;
 pub mod state_change_layer;
 
 use self::gateway_client::BuildQueueClient;
-use crate::{
-    persistence::{resource::ResourceManager, DeploymentUpdater, State},
-    RuntimeManager,
-};
+use crate::{persistence::resource::ResourceManager, RuntimeManager};
 pub use queue::Queued;
 pub use run::{ActiveDeploymentsGetter, Built};
 

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use flate2::read::GzDecoder;
 use opentelemetry::global;
+use shuttle_common::persistence::deployment::DeploymentUpdater;
 use shuttle_common::{
     claims::Claim,
     constants::{EXECUTABLE_DIRNAME, STORAGE_DIRNAME},
@@ -33,7 +34,6 @@ use uuid::Uuid;
 use super::gateway_client::BuildQueueClient;
 use super::{Built, QueueReceiver, RunSender, State};
 use crate::error::{Error, Result, TestError};
-use crate::persistence::DeploymentUpdater;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn task(

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -5,7 +5,6 @@ use std::{
     sync::Arc,
 };
 
-use async_trait::async_trait;
 use opentelemetry::global;
 use portpicker::pick_unused_port;
 use shuttle_common::{
@@ -15,7 +14,7 @@ use shuttle_common::{
         DEPLOYER_END_MSG_COMPLETED, DEPLOYER_END_MSG_CRASHED, DEPLOYER_END_MSG_STARTUP_ERR,
         DEPLOYER_END_MSG_STOPPED, DEPLOYER_RUNTIME_START_RESPONSE,
     },
-    persistence::deployment::DeploymentUpdater,
+    persistence::deployment::{ActiveDeploymentsGetter, DeploymentUpdater},
     resource, SecretStore,
 };
 use shuttle_proto::{
@@ -205,16 +204,6 @@ fn start_crashed_cleanup(_id: &Uuid, error: impl std::error::Error + 'static) {
         error = &error as &dyn std::error::Error,
         "{}", DEPLOYER_END_MSG_STARTUP_ERR
     );
-}
-
-#[async_trait]
-pub trait ActiveDeploymentsGetter: Clone + Send + Sync + 'static {
-    type Err: std::error::Error + Send;
-
-    async fn get_active_deployments(
-        &self,
-        service_id: &Ulid,
-    ) -> std::result::Result<Vec<Uuid>, Self::Err>;
 }
 
 #[derive(Clone, Debug)]

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -15,6 +15,7 @@ use shuttle_common::{
         DEPLOYER_END_MSG_COMPLETED, DEPLOYER_END_MSG_CRASHED, DEPLOYER_END_MSG_STARTUP_ERR,
         DEPLOYER_END_MSG_STOPPED, DEPLOYER_RUNTIME_START_RESPONSE,
     },
+    persistence::deployment::DeploymentUpdater,
     resource, SecretStore,
 };
 use shuttle_proto::{
@@ -37,7 +38,7 @@ use uuid::Uuid;
 use super::{RunReceiver, State};
 use crate::{
     error::{Error, Result},
-    persistence::{resource::ResourceManager, DeploymentUpdater},
+    persistence::resource::ResourceManager,
     RuntimeManager,
 };
 

--- a/deployer/src/deployment/state_change_layer.rs
+++ b/deployer/src/deployment/state_change_layer.rs
@@ -392,6 +392,14 @@ mod tests {
         async fn set_is_next(&self, _id: &Uuid, _is_next: bool) -> Result<(), Self::Err> {
             Ok(())
         }
+
+        async fn set_state(&self, _state: DeploymentState) -> Result<(), Self::Err> {
+            Ok(())
+        }
+
+        async fn update_deployment(&self, _state: DeploymentState) -> Result<(), Self::Err> {
+            Ok(())
+        }
     }
 
     #[derive(Clone)]

--- a/deployer/src/deployment/state_change_layer.rs
+++ b/deployer/src/deployment/state_change_layer.rs
@@ -25,10 +25,9 @@ use uuid::Uuid;
 
 use shuttle_common::{
     log::{Backend, ColoredLevel, LogRecorder},
+    persistence::state::{DeploymentState, State, StateRecorder},
     LogItem,
 };
-
-use crate::persistence::{DeploymentState, State, StateRecorder};
 
 /// Tracing subscriber layer which keeps track of a deployment's state.
 /// Logs a special line when entering a span tagged with deployment id and state.
@@ -135,18 +134,19 @@ mod tests {
         time::Duration,
     };
 
-    use crate::{
-        persistence::{
-            resource::ResourceManager, DeploymentState, DeploymentUpdater, StateRecorder,
-        },
-        RuntimeManager,
-    };
+    use crate::{persistence::resource::ResourceManager, RuntimeManager};
     use async_trait::async_trait;
     use axum::body::Bytes;
     use ctor::ctor;
     use flate2::{write::GzEncoder, Compression};
     use portpicker::pick_unused_port;
-    use shuttle_common::claims::Claim;
+    use shuttle_common::{
+        claims::Claim,
+        persistence::{
+            deployment::DeploymentUpdater,
+            state::{DeploymentState, State, StateRecorder},
+        },
+    };
     use shuttle_common_tests::{
         builder::get_mocked_builder_client, logger::get_mocked_logger_client,
     };
@@ -170,12 +170,8 @@ mod tests {
     use ulid::Ulid;
     use uuid::Uuid;
 
-    use crate::{
-        deployment::{
-            gateway_client::BuildQueueClient, ActiveDeploymentsGetter, Built, DeploymentManager,
-            Queued,
-        },
-        persistence::State,
+    use crate::deployment::{
+        gateway_client::BuildQueueClient, ActiveDeploymentsGetter, Built, DeploymentManager, Queued,
     };
 
     use super::{LogItem, StateChangeLayer};

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -34,7 +34,7 @@ use shuttle_common::{
         error::axum::CustomErrorPath,
         project::ProjectName,
     },
-    persistence::{deployment::Deployment, state::State},
+    persistence::{deployment::Deployment, state::State, DeployerPersistenceApi},
     request_span, LogItem,
 };
 use shuttle_proto::logger::LogsRequest;

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -34,11 +34,12 @@ use shuttle_common::{
         error::axum::CustomErrorPath,
         project::ProjectName,
     },
+    persistence::{deployment::Deployment, state::State},
     request_span, LogItem,
 };
 use shuttle_proto::logger::LogsRequest;
 
-use crate::persistence::{Deployment, Persistence, State};
+use crate::persistence::Persistence;
 use crate::{
     deployment::{Built, DeploymentManager, Queued},
     persistence::resource::ResourceManager,

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -6,9 +6,11 @@ use hyper::{
     service::{make_service_fn, service_fn},
 };
 pub use persistence::Persistence;
-use proxy::AddressGetter;
 pub use runtime_manager::RuntimeManager;
-use shuttle_common::log::LogRecorder;
+use shuttle_common::{
+    log::LogRecorder,
+    persistence::{deployment::AddressGetter, DeployerPersistenceApi},
+};
 use shuttle_proto::{builder::builder_client::BuilderClient, logger::logger_client::LoggerClient};
 use tokio::sync::Mutex;
 use tracing::{error, info};
@@ -87,8 +89,8 @@ pub async fn start(
         args.auth_uri,
     );
 
-    if args.local {
-        // If the --local flag is passed, setup an auth layer in deployer
+    if args.local_auth_layer {
+        // If the --local_auth_layer flag is passed, setup an auth layer in deployer
         builder = builder.with_local_admin_layer()
     } else {
         builder = builder.with_admin_secret_layer(args.admin_secret)

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -27,6 +27,7 @@ async fn main() {
 
     let (persistence, _) = Persistence::new(
         &args.state,
+        args.is_remote_persistence,
         args.resource_recorder.clone(),
         &args.provisioner_address,
         Ulid::from_string(args.project_id.as_str())

--- a/deployer/src/persistence/error.rs
+++ b/deployer/src/persistence/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
     ParseError(String),
     #[error("Provisioner request failed: {0}")]
     Provisioner(tonic::Status),
+    #[error("SQLite persistence error: {0}")]
+    LocalPersistence(#[from] shuttle_common::persistence::Error),
+    #[error("Remote persistence error: {0}")]
+    RemotePersistence(#[from] shuttle_common::backends::client::Error),
+    #[error("Persistence mode error: {0}")]
+    Mode(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -5,12 +5,15 @@ use std::str::FromStr;
 use chrono::Utc;
 use error::{Error, Result};
 use hyper::Uri;
+use shuttle_common::backends::client::gateway::Client as GatewayClient;
+use shuttle_common::persistence::deployment::AddressGetter;
 use shuttle_common::{
     claims::{Claim, ClaimLayer, InjectPropagationLayer},
     persistence::{
-        deployment::{Deployment, DeploymentRunnable, DeploymentUpdater},
+        deployment::{ActiveDeploymentsGetter, Deployment, DeploymentRunnable, DeploymentUpdater},
         service::Service,
         state::{DeploymentState, State, StateRecorder},
+        DeployerPersistenceApi,
     },
     resource::Type,
 };
@@ -21,10 +24,10 @@ use shuttle_proto::{
         ResultResponse, ServiceResourcesRequest,
     },
 };
+use sqlx::QueryBuilder;
 use sqlx::{
     migrate::{MigrateDatabase, Migrator},
     sqlite::{Sqlite, SqliteConnectOptions, SqliteJournalMode, SqlitePool},
-    QueryBuilder,
 };
 use tokio::task::JoinHandle;
 use tonic::{transport::Endpoint, Request};
@@ -40,14 +43,369 @@ mod user;
 pub use self::error::Error as PersistenceError;
 use self::resource::{Resource, ResourceManager};
 pub use self::user::User;
-use crate::deployment::ActiveDeploymentsGetter;
-use crate::proxy::AddressGetter;
 
 pub static MIGRATIONS: Migrator = sqlx::migrate!("./migrations");
 
 #[derive(Clone)]
+pub enum Mode {
+    Local(SqlitePool),
+    Remote(GatewayClient),
+}
+
+#[async_trait::async_trait]
+impl DeploymentUpdater for Mode {
+    type Err = Error;
+
+    /// Set the address for a deployment
+    async fn set_address(&self, id: &Uuid, address: &SocketAddr) -> Result<()> {
+        match self {
+            Mode::Local(pool) => sqlx::query("UPDATE deployments SET address = ? WHERE id = ?")
+                .bind(address.to_string())
+                .bind(id)
+                .execute(pool)
+                .await
+                .map(|_| ())
+                .map_err(Self::Err::from),
+            Mode::Remote(client) => client.set_address(id, address).await.map_err(Error::from),
+        }
+    }
+
+    /// Set if a deployment is build on shuttle-next
+    async fn set_is_next(&self, id: &Uuid, is_next: bool) -> Result<()> {
+        match self {
+            Mode::Local(pool) => sqlx::query("UPDATE deployments SET is_next = ? WHERE id = ?")
+                .bind(is_next)
+                .bind(id)
+                .execute(pool)
+                .await
+                .map(|_| ())
+                .map_err(Self::Err::from),
+            Mode::Remote(client) => client.set_is_next(id, is_next).await.map_err(Error::from),
+        }
+    }
+
+    /// Update the state
+    async fn set_state(&self, state: DeploymentState) -> Result<()> {
+        match self {
+            Mode::Local(pool) => {
+                sqlx::query("UPDATE deployments SET state = ?, last_update = ? WHERE id = ?")
+                    .bind(state.state)
+                    .bind(Utc::now())
+                    .bind(state.id)
+                    .execute(pool)
+                    .await
+                    .map(|_| ())
+                    .map_err(Self::Err::from)
+            }
+            Mode::Remote(client) => client.set_state(state).await.map_err(Error::from),
+        }
+    }
+
+    async fn update_deployment(&self, state: DeploymentState) -> Result<()> {
+        match self {
+            Mode::Local(pool) => {
+                sqlx::query("UPDATE deployments SET state = ?, last_update = ? WHERE id = ?")
+                    .bind(state.state)
+                    .bind(Utc::now())
+                    .bind(state.id)
+                    .execute(pool)
+                    .await
+                    .map(|_| ())
+                    .map_err(Self::Err::from)
+            }
+            Mode::Remote(client) => client.update_deployment(state).await.map_err(Error::from),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl AddressGetter for Mode {
+    type Err = Error;
+
+    async fn get_address_for_service(
+        &self,
+        service_name: &str,
+    ) -> Result<Option<std::net::SocketAddr>> {
+        match self {
+            Mode::Local(pool) => {
+                let address_str = sqlx::query_as::<_, (String,)>(
+                    r#"SELECT d.address
+                FROM deployments AS d
+                JOIN services AS s ON d.service_id = s.id
+                WHERE s.name = ? AND d.state = ?
+                ORDER BY d.last_update
+                DESC"#,
+                )
+                .bind(service_name)
+                .bind(State::Running)
+                .fetch_optional(pool)
+                .await
+                .map_err(Self::Err::from)?;
+
+                if let Some((address_str,)) = address_str {
+                    SocketAddr::from_str(&address_str).map(Some).map_err(|err| {
+                        Error::ParseError(format!(
+                            "couldn't parse socket address from persistence: {err}"
+                        ))
+                    })
+                } else {
+                    Ok(None)
+                }
+            }
+            Mode::Remote(client) => client
+                .get_address_for_service(service_name)
+                .await
+                .map_err(Error::from),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ActiveDeploymentsGetter for Mode {
+    type Err = Error;
+
+    async fn get_active_deployments(&self, service_id: &Ulid) -> Result<Vec<Uuid>> {
+        match self {
+            Mode::Local(pool) => {
+                let ids: Vec<_> = sqlx::query_as::<_, Deployment>(
+                    "SELECT * FROM deployments WHERE service_id = ? AND state = ?",
+                )
+                .bind(service_id.to_string())
+                .bind(State::Running)
+                .fetch_all(pool)
+                .await
+                .map_err(Self::Err::from)?
+                .into_iter()
+                .map(|deployment| deployment.id)
+                .collect();
+
+                Ok(ids)
+            }
+            Mode::Remote(client) => client
+                .get_active_deployments(service_id)
+                .await
+                .map_err(Error::from),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl DeployerPersistenceApi for Mode {
+    type MasterErr = Error;
+
+    async fn insert_deployment(&self, deployment: impl Into<&Deployment> + Send) -> Result<()> {
+        match self {
+            Mode::Local(pool) => {
+                let deployment: &Deployment = deployment.into();
+
+                sqlx::query("INSERT INTO deployments VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+                    .bind(deployment.id)
+                    .bind(deployment.service_id.to_string())
+                    .bind(deployment.state)
+                    .bind(deployment.last_update)
+                    .bind(deployment.address.map(|socket| socket.to_string()))
+                    .bind(deployment.is_next)
+                    .bind(deployment.git_commit_id.as_ref())
+                    .bind(deployment.git_commit_msg.as_ref())
+                    .bind(deployment.git_branch.as_ref())
+                    .bind(deployment.git_dirty)
+                    .execute(pool)
+                    .await
+                    .map(|_| ())
+                    .map_err(Error::from)
+            }
+            Mode::Remote(client) => client
+                .insert_deployment(deployment)
+                .await
+                .map_err(Error::from),
+        }
+    }
+
+    async fn get_deployment(&self, id: &Uuid) -> Result<Option<Deployment>> {
+        match self {
+            Mode::Local(pool) => sqlx::query_as("SELECT * FROM deployments WHERE id = ?")
+                .bind(id)
+                .fetch_optional(pool)
+                .await
+                .map_err(Error::from),
+            Mode::Remote(client) => client.get_deployment(id).await.map_err(Error::from),
+        }
+    }
+
+    async fn get_deployments(
+        &self,
+        service_id: &Ulid,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<Deployment>> {
+        match self {
+            Mode::Local(pool) => {
+                let mut query = QueryBuilder::new("SELECT * FROM deployments WHERE service_id = ");
+
+                query
+                    .push_bind(service_id.to_string())
+                    .push(" ORDER BY last_update DESC LIMIT ")
+                    .push_bind(limit);
+
+                if offset > 0 {
+                    query.push(" OFFSET ").push_bind(offset);
+                }
+
+                query
+                    .build_query_as()
+                    .fetch_all(pool)
+                    .await
+                    .map_err(Error::from)
+            }
+            Mode::Remote(client) => client
+                .get_deployments(service_id, offset, limit)
+                .await
+                .map_err(Error::from),
+        }
+    }
+
+    async fn get_active_deployment(&self, service_id: &Ulid) -> Result<Option<Deployment>> {
+        match self {
+            Mode::Local(pool) => {
+                sqlx::query_as("SELECT * FROM deployments WHERE service_id = ? AND state = ?")
+                    .bind(service_id.to_string())
+                    .bind(State::Running)
+                    .fetch_optional(pool)
+                    .await
+                    .map_err(Error::from)
+            }
+            Mode::Remote(client) => client
+                .get_active_deployment(service_id)
+                .await
+                .map_err(Error::from),
+        }
+    }
+
+    async fn cleanup_invalid_states(&self) -> Result<()> {
+        match self {
+            Mode::Local(pool) => {
+                sqlx::query("UPDATE deployments SET state = ? WHERE state IN(?, ?, ?, ?)")
+                    .bind(State::Stopped)
+                    .bind(State::Queued)
+                    .bind(State::Built)
+                    .bind(State::Building)
+                    .bind(State::Loading)
+                    .execute(pool)
+                    .await?;
+
+                Ok(())
+            }
+            Mode::Remote(client) => client.cleanup_invalid_states().await.map_err(Error::from),
+        }
+    }
+
+    async fn get_service_by_name(&self, name: &str) -> Result<Option<Service>> {
+        match self {
+            Mode::Local(pool) => sqlx::query_as("SELECT * FROM services WHERE name = ?")
+                .bind(name)
+                .fetch_optional(pool)
+                .await
+                .map_err(Error::from),
+            Mode::Remote(client) => client.get_service_by_name(name).await.map_err(Error::from),
+        }
+    }
+
+    async fn get_or_create_service(&self, name: &str) -> Result<Service> {
+        match self {
+            Mode::Local(pool) => {
+                if let Some(service) = self.get_service_by_name(name).await? {
+                    Ok(service)
+                } else {
+                    let service = Service {
+                        id: Ulid::new(),
+                        name: name.to_string(),
+                    };
+
+                    sqlx::query("INSERT INTO services (id, name) VALUES (?, ?)")
+                        .bind(service.id.to_string())
+                        .bind(&service.name)
+                        .execute(pool)
+                        .await?;
+
+                    Ok(service)
+                }
+            }
+            Mode::Remote(client) => client
+                .get_or_create_service(name)
+                .await
+                .map_err(Error::from),
+        }
+    }
+
+    async fn delete_service(&self, id: &Ulid) -> Result<()> {
+        match self {
+            Mode::Local(pool) => sqlx::query("DELETE FROM services WHERE id = ?")
+                .bind(id.to_string())
+                .execute(pool)
+                .await
+                .map(|_| ())
+                .map_err(Error::from),
+            Mode::Remote(client) => client.delete_service(id).await.map_err(Error::from),
+        }
+    }
+
+    async fn get_all_services(&self) -> Result<Vec<Service>> {
+        match self {
+            Mode::Local(pool) => sqlx::query_as("SELECT * FROM services")
+                .fetch_all(pool)
+                .await
+                .map_err(Error::from),
+            Mode::Remote(client) => client.get_all_services().await.map_err(Error::from),
+        }
+    }
+
+    async fn get_all_runnable_deployments(&self) -> Result<Vec<DeploymentRunnable>> {
+        match self {
+            Mode::Local(pool) => sqlx::query_as(
+                r#"SELECT d.id, service_id, s.name AS service_name, d.is_next
+                FROM deployments AS d
+                JOIN services AS s ON s.id = d.service_id
+                WHERE state = ?
+                ORDER BY last_update DESC"#,
+            )
+            .bind(State::Running)
+            .fetch_all(pool)
+            .await
+            .map_err(Error::from),
+            Mode::Remote(client) => client
+                .get_all_runnable_deployments()
+                .await
+                .map_err(Error::from),
+        }
+    }
+
+    async fn get_runnable_deployment(&self, id: &Uuid) -> Result<Option<DeploymentRunnable>> {
+        match self {
+            Mode::Local(pool) => sqlx::query_as(
+                r#"SELECT d.id, service_id, s.name AS service_name, d.is_next
+                FROM deployments AS d
+                JOIN services AS s ON s.id = d.service_id
+                WHERE state IN (?, ?, ?)
+                AND d.id = ?"#,
+            )
+            .bind(State::Running)
+            .bind(State::Stopped)
+            .bind(State::Completed)
+            .bind(id)
+            .fetch_optional(pool)
+            .await
+            .map_err(Error::from),
+            Mode::Remote(client) => client
+                .get_runnable_deployment(id)
+                .await
+                .map_err(Error::from),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct Persistence {
-    pool: SqlitePool,
+    mode: Mode,
     state_send: tokio::sync::mpsc::UnboundedSender<DeploymentState>,
     resource_recorder_client: Option<resource_recorder::Client>,
     provisioner_client: Option<
@@ -66,40 +424,24 @@ impl Persistence {
     /// pool - new connections should be made by cloning [`Persistence`] rather
     /// than repeatedly calling [`Persistence::new`].
     pub async fn new(
-        path: &str,
+        state_connection_uri: &str,
+        is_remote_persistence: bool,
         resource_recorder_uri: Uri,
         provisioner_address: &Uri,
         project_id: Ulid,
     ) -> (Self, JoinHandle<()>) {
-        if !Path::new(path).exists() {
-            Sqlite::create_database(path).await.unwrap();
+        if is_remote_persistence {
+            return Self::configure_remote(
+                state_connection_uri,
+                resource_recorder_uri,
+                provisioner_address.to_string(),
+                project_id,
+            )
+            .await;
         }
 
-        info!(
-            "state db: {}",
-            std::fs::canonicalize(path).unwrap().to_string_lossy()
-        );
-
-        // We have found in the past that setting synchronous to anything other than the default (full) breaks the
-        // broadcast channel in deployer. The broken symptoms are that the ws socket connections won't get any logs
-        // from the broadcast channel and would then close. When users did deploys, this would make it seem like the
-        // deploy is done (while it is still building for most of the time) and the status of the previous deployment
-        // would be returned to the user.
-        //
-        // If you want to activate a faster synchronous mode, then also do proper testing to confirm this bug is no
-        // longer present.
-        let sqlite_options = SqliteConnectOptions::from_str(path)
-            .unwrap()
-            .journal_mode(SqliteJournalMode::Wal)
-            // Set the ulid0 extension for converting UUIDs to ULID's in migrations.
-            // This uses the ulid0.so file in the crate root, with the
-            // LD_LIBRARY_PATH env set in build.rs.
-            .extension("ulid0");
-
-        let pool = SqlitePool::connect_with(sqlite_options).await.unwrap();
-
-        Self::configure(
-            pool,
+        Self::configure_local(
+            state_connection_uri,
             resource_recorder_uri,
             provisioner_address.to_string(),
             project_id,
@@ -119,9 +461,11 @@ impl Persistence {
         )
         .await
         .unwrap();
-        let (state_send, handle) = Self::from_pool(pool.clone()).await;
+        MIGRATIONS.run(&pool).await.unwrap();
+        let mode = Mode::Local(pool);
+        let (state_send, handle) = Self::state_updater_hook(mode.clone()).await;
         let persistence = Self {
-            pool,
+            mode,
             state_send,
             resource_recorder_client: None,
             provisioner_client: None,
@@ -131,12 +475,89 @@ impl Persistence {
         (persistence, handle)
     }
 
-    async fn configure(
-        pool: SqlitePool,
+    async fn configure_local(
+        state_connection_uri: &str,
         resource_recorder_uri: Uri,
         provisioner_address: String,
         project_id: Ulid,
     ) -> (Self, JoinHandle<()>) {
+        if !Path::new(state_connection_uri).exists() {
+            Sqlite::create_database(state_connection_uri).await.unwrap();
+        }
+
+        info!(
+            "state db: {}",
+            std::fs::canonicalize(state_connection_uri)
+                .unwrap()
+                .to_string_lossy()
+        );
+
+        // We have found in the past that setting synchronous to anything other than the default (full) breaks the
+        // broadcast channel in deployer. The broken symptoms are that the ws socket connections won't get any logs
+        // from the broadcast channel and would then close. When users did deploys, this would make it seem like the
+        // deploy is done (while it is still building for most of the time) and the status of the previous deployment
+        // would be returned to the user.
+        //
+        // If you want to activate a faster synchronous mode, then also do proper testing to confirm this bug is no
+        // longer present.
+        let sqlite_options = SqliteConnectOptions::from_str(state_connection_uri)
+            .unwrap()
+            .journal_mode(SqliteJournalMode::Wal)
+            // Set the ulid0 extension for converting UUIDs to ULID's in migrations.
+            // This uses the ulid0.so file in the crate root, with the
+            // LD_LIBRARY_PATH env set in build.rs.
+            .extension("ulid0");
+
+        let pool = SqlitePool::connect_with(sqlite_options)
+            .await
+            .expect("to be able to connect to sqlite with the options");
+
+        MIGRATIONS.run(&pool).await.unwrap();
+        let channel = Endpoint::from_shared(provisioner_address)
+            .expect("to have a valid string endpoint for the provisioner")
+            .connect()
+            .await
+            .expect("failed to connect to provisioner");
+
+        let provisioner_service = ServiceBuilder::new()
+            .layer(ClaimLayer)
+            .layer(InjectPropagationLayer)
+            .service(channel);
+
+        let resource_recorder_client = resource_recorder::get_client(resource_recorder_uri).await;
+        let provisioner_client = ProvisionerClient::new(provisioner_service);
+        let mode = Mode::Local(pool);
+        let (state_send, handle) = Self::state_updater_hook(mode.clone()).await;
+
+        let persistence = Self {
+            mode,
+            state_send,
+            resource_recorder_client: Some(resource_recorder_client),
+            provisioner_client: Some(provisioner_client),
+            project_id,
+        };
+
+        (persistence, handle)
+    }
+
+    async fn configure_remote(
+        state_connection_uri: &str,
+        resource_recorder_uri: Uri,
+        provisioner_address: String,
+        project_id: Ulid,
+    ) -> (Self, JoinHandle<()>) {
+        let gateway_deployer_api_uri =
+            Uri::from_str(state_connection_uri).expect("to have a valid gateway deployer API uri");
+
+        // The private and public APIs are the same, but in a next iteration, once all deployers use
+        // the remote persistence, we can set a valid public API that can be used to handle current
+        // deployer APIs that don't depend on the user space that the deployer manages, and as a result
+        // can live outside the deployer, centrally.
+        let gateway_client = shuttle_common::backends::client::gateway::Client::new(
+            gateway_deployer_api_uri.clone(),
+            gateway_deployer_api_uri,
+        );
+
         let channel = Endpoint::from_shared(provisioner_address)
             .expect("to have a valid string endpoint for the provisioner")
             .connect()
@@ -151,10 +572,10 @@ impl Persistence {
         let resource_recorder_client = resource_recorder::get_client(resource_recorder_uri).await;
         let provisioner_client = ProvisionerClient::new(provisioner_service);
 
-        let (state_send, handle) = Self::from_pool(pool.clone()).await;
+        let (state_send, handle) = Self::state_updater_hook(gateway_client.clone()).await;
 
         let persistence = Self {
-            pool,
+            mode: Mode::Remote(gateway_client),
             state_send,
             resource_recorder_client: Some(resource_recorder_client),
             provisioner_client: Some(provisioner_client),
@@ -164,14 +585,12 @@ impl Persistence {
         (persistence, handle)
     }
 
-    async fn from_pool(
-        pool: SqlitePool,
+    async fn state_updater_hook(
+        client: impl DeploymentUpdater,
     ) -> (
         tokio::sync::mpsc::UnboundedSender<DeploymentState>,
         JoinHandle<()>,
     ) {
-        MIGRATIONS.run(&pool).await.unwrap();
-
         // Unbounded channel so that sync code (tracing layer) can send to async listener (here)
         let (state_send, mut state_recv) =
             tokio::sync::mpsc::unbounded_channel::<DeploymentState>();
@@ -179,14 +598,12 @@ impl Persistence {
         let handle = tokio::spawn(async move {
             while let Some(state) = state_recv.recv().await {
                 trace!(?state, "persistence received state change");
-                update_deployment(&pool, state)
-                    .await
-                    .unwrap_or_else(|error| {
-                        error!(
-                            error = &error as &dyn std::error::Error,
-                            "failed to update deployment state"
-                        )
-                    });
+                client.set_state(state).await.unwrap_or_else(|error| {
+                    error!(
+                        error = &error as &dyn std::error::Error,
+                        "failed to update deployment state"
+                    )
+                });
             }
         });
 
@@ -197,181 +614,18 @@ impl Persistence {
         self.project_id
     }
 
-    pub async fn insert_deployment(&self, deployment: impl Into<&Deployment>) -> Result<()> {
-        let deployment: &Deployment = deployment.into();
-
-        sqlx::query("INSERT INTO deployments VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
-            .bind(deployment.id)
-            .bind(deployment.service_id.to_string())
-            .bind(deployment.state)
-            .bind(deployment.last_update)
-            .bind(deployment.address.map(|socket| socket.to_string()))
-            .bind(deployment.is_next)
-            .bind(deployment.git_commit_id.as_ref())
-            .bind(deployment.git_commit_msg.as_ref())
-            .bind(deployment.git_branch.as_ref())
-            .bind(deployment.git_dirty)
-            .execute(&self.pool)
-            .await
-            .map(|_| ())
-            .map_err(PersistenceError::from)
-    }
-
     pub async fn get_deployment(&self, id: &Uuid) -> Result<Option<Deployment>> {
-        get_deployment(&self.pool, id).await
-    }
-
-    pub async fn get_deployments(
-        &self,
-        service_id: &Ulid,
-        offset: u32,
-        limit: u32,
-    ) -> Result<Vec<Deployment>> {
-        let mut query = QueryBuilder::new("SELECT * FROM deployments WHERE service_id = ");
-
-        query
-            .push_bind(service_id.to_string())
-            .push(" ORDER BY last_update DESC LIMIT ")
-            .push_bind(limit);
-
-        if offset > 0 {
-            query.push(" OFFSET ").push_bind(offset);
-        }
-
-        query
-            .build_query_as()
-            .fetch_all(&self.pool)
-            .await
-            .map_err(Error::from)
-    }
-
-    pub async fn get_active_deployment(&self, service_id: &Ulid) -> Result<Option<Deployment>> {
-        sqlx::query_as("SELECT * FROM deployments WHERE service_id = ? AND state = ?")
-            .bind(service_id.to_string())
-            .bind(State::Running)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(Error::from)
-    }
-
-    // Clean up all invalid states inside persistence
-    pub async fn cleanup_invalid_states(&self) -> Result<()> {
-        sqlx::query("UPDATE deployments SET state = ? WHERE state IN(?, ?, ?, ?)")
-            .bind(State::Stopped)
-            .bind(State::Queued)
-            .bind(State::Built)
-            .bind(State::Building)
-            .bind(State::Loading)
-            .execute(&self.pool)
-            .await?;
-
-        Ok(())
-    }
-
-    pub async fn get_or_create_service(&self, name: &str) -> Result<Service> {
-        if let Some(service) = self.get_service_by_name(name).await? {
-            Ok(service)
-        } else {
-            let service = Service {
-                id: Ulid::new(),
-                name: name.to_string(),
-            };
-
-            sqlx::query("INSERT INTO services (id, name) VALUES (?, ?)")
-                .bind(service.id.to_string())
-                .bind(&service.name)
-                .execute(&self.pool)
-                .await?;
-
-            Ok(service)
-        }
-    }
-
-    pub async fn get_service_by_name(&self, name: &str) -> Result<Option<Service>> {
-        sqlx::query_as("SELECT * FROM services WHERE name = ?")
-            .bind(name)
-            .fetch_optional(&self.pool)
-            .await
-            .map_err(Error::from)
-    }
-
-    pub async fn delete_service(&self, id: &Ulid) -> Result<()> {
-        sqlx::query("DELETE FROM services WHERE id = ?")
-            .bind(id.to_string())
-            .execute(&self.pool)
-            .await
-            .map(|_| ())
-            .map_err(Error::from)
-    }
-
-    pub async fn get_all_services(&self) -> Result<Vec<Service>> {
-        sqlx::query_as("SELECT * FROM services")
-            .fetch_all(&self.pool)
-            .await
-            .map_err(Error::from)
-    }
-
-    pub async fn get_all_runnable_deployments(&self) -> Result<Vec<DeploymentRunnable>> {
-        sqlx::query_as(
-            r#"SELECT d.id, service_id, s.name AS service_name, d.is_next
-                FROM deployments AS d
-                JOIN services AS s ON s.id = d.service_id
-                WHERE state = ?
-                ORDER BY last_update DESC"#,
-        )
-        .bind(State::Running)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(Error::from)
-    }
-
-    /// Gets a deployment if it is runnable
-    pub async fn get_runnable_deployment(&self, id: &Uuid) -> Result<Option<DeploymentRunnable>> {
-        sqlx::query_as(
-            r#"SELECT d.id, service_id, s.name AS service_name, d.is_next
-                FROM deployments AS d
-                JOIN services AS s ON s.id = d.service_id
-                WHERE state IN (?, ?, ?)
-                AND d.id = ?"#,
-        )
-        .bind(State::Running)
-        .bind(State::Stopped)
-        .bind(State::Completed)
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(Error::from)
+        self.mode.get_deployment(id).await
     }
 
     pub async fn stop_running_deployment(&self, deployable: DeploymentRunnable) -> Result<()> {
-        update_deployment(
-            &self.pool,
-            DeploymentState {
+        self.mode
+            .update_deployment(DeploymentState {
                 id: deployable.id,
                 state: State::Stopped,
-            },
-        )
-        .await
+            })
+            .await
     }
-}
-
-async fn update_deployment(pool: &SqlitePool, state: DeploymentState) -> Result<()> {
-    sqlx::query("UPDATE deployments SET state = ?, last_update = ? WHERE id = ?")
-        .bind(state.state)
-        .bind(Utc::now())
-        .bind(state.id)
-        .execute(pool)
-        .await
-        .map(|_| ())
-        .map_err(Error::from)
-}
-
-async fn get_deployment(pool: &SqlitePool, id: &Uuid) -> Result<Option<Deployment>> {
-    sqlx::query_as("SELECT * FROM deployments WHERE id = ?")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .map_err(Error::from)
 }
 
 #[async_trait::async_trait]
@@ -423,71 +677,78 @@ impl ResourceManager for Persistence {
             .map_err(PersistenceError::ResourceRecorder)
             .map(|res| res.into_inner())?;
 
-        // If the resources list is empty
-        if res.resources.is_empty() {
-            info!("Got no resources from resource-recorder");
-            // Check if there are cached resources on the local persistence.
-            let resources: std::result::Result<Vec<Resource>, sqlx::Error> =
-                sqlx::query_as("SELECT * FROM resources WHERE service_id = ?")
-                    .bind(service_id.to_string())
-                    .fetch_all(&self.pool)
-                    .await;
-
-            info!(?resources, "Local resources");
-            // If there are cached resources
-            if let Ok(inner) = resources {
-                // Return early if the local persistence is empty.
-                if inner.is_empty() {
-                    return Ok(res);
-                }
-
-                // Insert local resources in the resource-recorder.
-                let local_resources = inner
-                    .into_iter()
-                    .map(|res| record_request::Resource {
-                        r#type: res.r#type.to_string(),
-                        config: res.config.to_string().into_bytes(),
-                        data: res.data.to_string().into_bytes(),
-                    })
-                    .collect();
-
-                self.insert_resources(local_resources, service_id, claim.clone())
-                    .await?;
-
-                let mut service_resources_req = tonic::Request::new(ServiceResourcesRequest {
-                    service_id: service_id.to_string(),
-                });
-
-                service_resources_req.extensions_mut().insert(claim);
-
-                info!("Getting resources from resource-recorder again");
-                let res = self
-                    .resource_recorder_client
-                    .as_mut()
-                    .expect("to have the resource recorder set up")
-                    .get_service_resources(service_resources_req)
-                    .await
-                    .map_err(PersistenceError::ResourceRecorder)
-                    .map(|res| res.into_inner())?;
-
+        // If the resources list is empty and we're using the persistence in local mode
+        let mode = self.mode.clone();
+        match mode {
+            Mode::Remote(_) => Ok(res),
+            Mode::Local(pool) => {
                 if res.resources.is_empty() {
-                    // Something went wrong since it was empty before the upload, and is still empty now.
-                    return Err(Error::ResourceRecorderSync);
+                    info!("Got no resources from resource-recorder");
+                    // Check if there are cached resources on the local persistence.
+                    let resources: std::result::Result<Vec<Resource>, sqlx::Error> =
+                        sqlx::query_as("SELECT * FROM resources WHERE service_id = ?")
+                            .bind(service_id.to_string())
+                            .fetch_all(&pool)
+                            .await;
+
+                    info!(?resources, "Local resources");
+                    // If there are cached resources
+                    if let Ok(inner) = resources {
+                        // Return early if the local persistence is empty.
+                        if inner.is_empty() {
+                            return Ok(res);
+                        }
+
+                        // Insert local resources in the resource-recorder.
+                        let local_resources = inner
+                            .into_iter()
+                            .map(|res| record_request::Resource {
+                                r#type: res.r#type.to_string(),
+                                config: res.config.to_string().into_bytes(),
+                                data: res.data.to_string().into_bytes(),
+                            })
+                            .collect();
+
+                        self.insert_resources(local_resources, service_id, claim.clone())
+                            .await?;
+
+                        let mut service_resources_req =
+                            tonic::Request::new(ServiceResourcesRequest {
+                                service_id: service_id.to_string(),
+                            });
+
+                        service_resources_req.extensions_mut().insert(claim);
+
+                        info!("Getting resources from resource-recorder again");
+                        let res = self
+                            .resource_recorder_client
+                            .as_mut()
+                            .expect("to have the resource recorder set up")
+                            .get_service_resources(service_resources_req)
+                            .await
+                            .map_err(PersistenceError::ResourceRecorder)
+                            .map(|res| res.into_inner())?;
+
+                        if res.resources.is_empty() {
+                            // Something went wrong since it was empty before the upload, and is still empty now.
+                            return Err(Error::ResourceRecorderSync);
+                        }
+
+                        info!("Deleting local resources");
+                        // Now that we know that the resources are in resource-recorder,
+                        // we can safely delete them from here to prevent de-sync issues and to not hinder project deletion
+                        sqlx::query("DELETE FROM resources WHERE service_id = ?")
+                            .bind(service_id.to_string())
+                            .execute(&pool)
+                            .await?;
+
+                        return Ok(res);
+                    }
                 }
 
-                info!("Deleting local resources");
-                // Now that we know that the resources are in resource-recorder,
-                // we can safely delete them from here to prevent de-sync issues and to not hinder project deletion
-                sqlx::query("DELETE FROM resources WHERE service_id = ?")
-                    .bind(service_id.to_string())
-                    .execute(&self.pool)
-                    .await?;
-
-                return Ok(res);
+                Ok(res)
             }
         }
-
-        Ok(res)
     }
 
     async fn get_resource(
@@ -558,37 +819,14 @@ impl ResourceManager for Persistence {
 
 #[async_trait::async_trait]
 impl AddressGetter for Persistence {
+    type Err = Error;
+
     #[instrument(skip_all, fields(shuttle.service.name = service_name, shuttle.project.name = service_name))]
     async fn get_address_for_service(
         &self,
         service_name: &str,
-    ) -> crate::handlers::Result<Option<std::net::SocketAddr>> {
-        let address_str = sqlx::query_as::<_, (String,)>(
-            r#"SELECT d.address
-                FROM deployments AS d
-                JOIN services AS s ON d.service_id = s.id
-                WHERE s.name = ? AND d.state = ?
-                ORDER BY d.last_update
-                DESC"#,
-        )
-        .bind(service_name)
-        .bind(State::Running)
-        .fetch_optional(&self.pool)
-        .await
-        .map_err(Error::from)
-        .map_err(crate::handlers::Error::Persistence)?;
-
-        if let Some((address_str,)) = address_str {
-            SocketAddr::from_str(&address_str).map(Some).map_err(|err| {
-                crate::handlers::Error::Convert {
-                    from: "String".to_string(),
-                    to: "SocketAddr".to_string(),
-                    message: err.to_string(),
-                }
-            })
-        } else {
-            Ok(None)
-        }
+    ) -> Result<Option<std::net::SocketAddr>> {
+        self.mode.get_address_for_service(service_name).await
     }
 }
 
@@ -597,23 +835,73 @@ impl DeploymentUpdater for Persistence {
     type Err = Error;
 
     async fn set_address(&self, id: &Uuid, address: &SocketAddr) -> Result<()> {
-        sqlx::query("UPDATE deployments SET address = ? WHERE id = ?")
-            .bind(address.to_string())
-            .bind(id)
-            .execute(&self.pool)
-            .await
-            .map(|_| ())
-            .map_err(Error::from)
+        self.mode.set_address(id, address).await
     }
 
     async fn set_is_next(&self, id: &Uuid, is_next: bool) -> Result<()> {
-        sqlx::query("UPDATE deployments SET is_next = ? WHERE id = ?")
-            .bind(is_next)
-            .bind(id)
-            .execute(&self.pool)
-            .await
-            .map(|_| ())
-            .map_err(Error::from)
+        self.mode.set_is_next(id, is_next).await
+    }
+
+    async fn set_state(&self, state: DeploymentState) -> Result<()> {
+        self.mode.set_state(state).await
+    }
+
+    async fn update_deployment(&self, state: DeploymentState) -> Result<()> {
+        self.mode.update_deployment(state).await
+    }
+}
+
+#[async_trait::async_trait]
+impl DeployerPersistenceApi for Persistence {
+    type MasterErr = Error;
+
+    async fn insert_deployment(&self, deployment: impl Into<&Deployment> + Send) -> Result<()> {
+        self.mode.insert_deployment(deployment).await
+    }
+
+    async fn get_deployment(&self, id: &Uuid) -> Result<Option<Deployment>> {
+        self.mode.get_deployment(id).await
+    }
+
+    async fn get_deployments(
+        &self,
+        service_id: &Ulid,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<Deployment>> {
+        self.mode.get_deployments(service_id, offset, limit).await
+    }
+
+    async fn get_active_deployment(&self, service_id: &Ulid) -> Result<Option<Deployment>> {
+        self.mode.get_active_deployment(service_id).await
+    }
+
+    async fn cleanup_invalid_states(&self) -> Result<()> {
+        self.mode.cleanup_invalid_states().await
+    }
+
+    async fn get_service_by_name(&self, name: &str) -> Result<Option<Service>> {
+        self.mode.get_service_by_name(name).await
+    }
+
+    async fn get_or_create_service(&self, name: &str) -> Result<Service> {
+        self.mode.get_or_create_service(name).await
+    }
+
+    async fn delete_service(&self, id: &Ulid) -> Result<()> {
+        self.mode.delete_service(id).await
+    }
+
+    async fn get_all_services(&self) -> Result<Vec<Service>> {
+        self.mode.get_all_services().await
+    }
+
+    async fn get_all_runnable_deployments(&self) -> Result<Vec<DeploymentRunnable>> {
+        self.mode.get_all_runnable_deployments().await
+    }
+
+    async fn get_runnable_deployment(&self, id: &Uuid) -> Result<Option<DeploymentRunnable>> {
+        self.mode.get_runnable_deployment(id).await
     }
 }
 
@@ -625,19 +913,7 @@ impl ActiveDeploymentsGetter for Persistence {
         &self,
         service_id: &Ulid,
     ) -> std::result::Result<Vec<Uuid>, Self::Err> {
-        let ids: Vec<_> = sqlx::query_as::<_, Deployment>(
-            "SELECT * FROM deployments WHERE service_id = ? AND state = ?",
-        )
-        .bind(service_id.to_string())
-        .bind(State::Running)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(Error::from)?
-        .into_iter()
-        .map(|deployment| deployment.id)
-        .collect();
-
-        Ok(ids)
+        self.mode.get_active_deployments(service_id).await
     }
 }
 
@@ -663,7 +939,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_updates() {
         let (p, _) = Persistence::new_in_memory().await;
-        let service_id = add_service(&p.pool).await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let service_id = add_service(pool).await.unwrap();
 
         let id = Uuid::new_v4();
         let deployment = Deployment {
@@ -678,13 +957,10 @@ mod tests {
         p.insert_deployment(&deployment).await.unwrap();
         assert_eq!(p.get_deployment(&id).await.unwrap().unwrap(), deployment);
 
-        update_deployment(
-            &p.pool,
-            DeploymentState {
-                id,
-                state: State::Built,
-            },
-        )
+        p.update_deployment(DeploymentState {
+            id,
+            state: State::Built,
+        })
         .await
         .unwrap();
 
@@ -704,7 +980,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn get_deployments() {
         let (p, _) = Persistence::new_in_memory().await;
-        let service_id = add_service(&p.pool).await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let service_id = add_service(pool).await.unwrap();
 
         let mut deployments: Vec<_> = (0..10)
             .map(|_| Deployment {
@@ -741,9 +1020,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_active() {
         let (p, _) = Persistence::new_in_memory().await;
-
-        let xyz_id = add_service(&p.pool).await.unwrap();
-        let service_id = add_service(&p.pool).await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let xyz_id = add_service(pool).await.unwrap();
+        let service_id = add_service(pool).await.unwrap();
 
         let deployment_crashed = Deployment {
             id: Uuid::new_v4(),
@@ -801,8 +1082,11 @@ mod tests {
     async fn deployment_order() {
         let (p, _) = Persistence::new_in_memory().await;
 
-        let service_id = add_service(&p.pool).await.unwrap();
-        let other_id = add_service(&p.pool).await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let service_id = add_service(pool).await.unwrap();
+        let other_id = add_service(pool).await.unwrap();
 
         let deployment_other = Deployment {
             id: Uuid::new_v4(),
@@ -864,8 +1148,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn cleanup_invalid_states() {
         let (p, _) = Persistence::new_in_memory().await;
-
-        let service_id = add_service(&p.pool).await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let service_id = add_service(pool).await.unwrap();
         let time = Utc::now();
 
         let deployment_crashed = Deployment {
@@ -971,11 +1257,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn fetching_runnable_deployments() {
         let (p, _) = Persistence::new_in_memory().await;
-
-        let bar_id = add_service_named(&p.pool, "bar").await.unwrap();
-        let foo_id = add_service_named(&p.pool, "foo").await.unwrap();
-        let service_id = add_service(&p.pool).await.unwrap();
-        let service_id2 = add_service(&p.pool).await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let bar_id = add_service_named(pool, "bar").await.unwrap();
+        let foo_id = add_service_named(pool, "foo").await.unwrap();
+        let service_id = add_service(pool).await.unwrap();
+        let service_id2 = add_service(pool).await.unwrap();
 
         let id_1 = Uuid::new_v4();
         let id_2 = Uuid::new_v4();
@@ -1099,8 +1387,11 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn address_getter() {
         let (p, _) = Persistence::new_in_memory().await;
-        let service_id = add_service_named(&p.pool, "service-name").await.unwrap();
-        let service_other_id = add_service_named(&p.pool, "other-name").await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let service_id = add_service_named(pool, "service-name").await.unwrap();
+        let service_other_id = add_service_named(pool, "other-name").await.unwrap();
 
         sqlx::query(
             "INSERT INTO deployments (id, service_id, state, last_update, address) VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)",
@@ -1123,7 +1414,7 @@ mod tests {
         .bind(State::Running)
         .bind(Utc::now())
         .bind("10.0.0.5:5678")
-        .execute(&p.pool)
+        .execute(pool)
         .await
         .unwrap();
 
@@ -1139,7 +1430,10 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn active_deployment_getter() {
         let (p, _) = Persistence::new_in_memory().await;
-        let service_id = add_service_named(&p.pool, "service-name").await.unwrap();
+        let Mode::Local(pool) = &p.mode else {
+            unreachable!()
+        };
+        let service_id = add_service_named(pool, "service-name").await.unwrap();
         let id_1 = Uuid::new_v4();
         let id_2 = Uuid::new_v4();
 

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -7,6 +7,11 @@ use error::{Error, Result};
 use hyper::Uri;
 use shuttle_common::{
     claims::{Claim, ClaimLayer, InjectPropagationLayer},
+    persistence::{
+        deployment::{Deployment, DeploymentRunnable, DeploymentUpdater},
+        service::Service,
+        state::{DeploymentState, State, StateRecorder},
+    },
     resource::Type,
 };
 use shuttle_proto::{
@@ -28,23 +33,13 @@ use tracing::{error, info, instrument, trace};
 use ulid::Ulid;
 use uuid::Uuid;
 
-pub mod deployment;
 mod error;
 pub mod resource;
-pub mod service;
-mod state;
 mod user;
 
-pub use self::deployment::{Deployment, DeploymentUpdater};
 pub use self::error::Error as PersistenceError;
-pub use self::service::Service;
-pub use self::state::DeploymentState;
-pub use self::state::{State, StateRecorder};
+use self::resource::{Resource, ResourceManager};
 pub use self::user::User;
-use self::{
-    deployment::DeploymentRunnable,
-    resource::{Resource, ResourceManager},
-};
 use crate::deployment::ActiveDeploymentsGetter;
 use crate::proxy::AddressGetter;
 
@@ -664,10 +659,6 @@ mod tests {
     use rand::Rng;
 
     use super::*;
-    use crate::persistence::{
-        deployment::{Deployment, DeploymentRunnable},
-        state::State,
-    };
 
     #[tokio::test(flavor = "multi_thread")]
     async fn deployment_updates() {

--- a/deployer/src/proxy.rs
+++ b/deployer/src/proxy.rs
@@ -3,7 +3,6 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use async_trait::async_trait;
 use axum::headers::HeaderMapExt;
 use fqdn::FQDN;
 use hyper::{
@@ -15,7 +14,7 @@ use hyper_reverse_proxy::{ProxyError, ReverseProxy};
 use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry_http::HeaderExtractor;
-use shuttle_common::backends::headers::XShuttleProject;
+use shuttle_common::{backends::headers::XShuttleProject, persistence::deployment::AddressGetter};
 use tracing::{error, field, instrument, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -141,14 +140,6 @@ pub async fn handle(
                 .unwrap())
         }
     }
-}
-
-#[async_trait]
-pub trait AddressGetter: Clone + Send + Sync + 'static {
-    async fn get_address_for_service(
-        &self,
-        service_name: &str,
-    ) -> crate::handlers::Result<Option<SocketAddr>>;
 }
 
 #[instrument(skip(req))]

--- a/deployer/tests/integration_run.rs
+++ b/deployer/tests/integration_run.rs
@@ -7,7 +7,9 @@ use std::{
 
 use async_trait::async_trait;
 use portpicker::pick_unused_port;
-use shuttle_common::{claims::Claim, constants::EXECUTABLE_DIRNAME};
+use shuttle_common::{
+    claims::Claim, constants::EXECUTABLE_DIRNAME, persistence::deployment::DeploymentUpdater,
+};
 use shuttle_common_tests::logger::{get_mocked_logger_client, MockedLogger};
 use shuttle_proto::{
     logger::Batcher,
@@ -29,10 +31,7 @@ use ulid::Ulid;
 use uuid::Uuid;
 
 use shuttle_deployer::{
-    deployment::Built,
-    error,
-    persistence::{resource::ResourceManager, DeploymentUpdater},
-    RuntimeManager,
+    deployment::Built, error, persistence::resource::ResourceManager, RuntimeManager,
 };
 
 const RESOURCES_PATH: &str = "tests/resources";

--- a/deployer/tests/integration_run.rs
+++ b/deployer/tests/integration_run.rs
@@ -8,7 +8,9 @@ use std::{
 use async_trait::async_trait;
 use portpicker::pick_unused_port;
 use shuttle_common::{
-    claims::Claim, constants::EXECUTABLE_DIRNAME, persistence::deployment::DeploymentUpdater,
+    claims::Claim,
+    constants::EXECUTABLE_DIRNAME,
+    persistence::{deployment::DeploymentUpdater, state::DeploymentState},
 };
 use shuttle_common_tests::logger::{get_mocked_logger_client, MockedLogger};
 use shuttle_proto::{
@@ -158,6 +160,14 @@ impl DeploymentUpdater for StubDeploymentUpdater {
     }
 
     async fn set_is_next(&self, _id: &Uuid, _is_next: bool) -> Result<(), Self::Err> {
+        Ok(())
+    }
+
+    async fn set_state(&self, _state: DeploymentState) -> Result<(), Self::Err> {
+        Ok(())
+    }
+
+    async fn update_deployment(&self, _state: DeploymentState) -> Result<(), Self::Err> {
         Ok(())
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       - "--state=/var/lib/shuttle"
       - "start"
       - "--control=0.0.0.0:8001"
+      - "--deployer-api=0.0.0.0:8002"
       - "--user=0.0.0.0:8000"
       - "--bouncer=0.0.0.0:7999"
       - "--image=${CONTAINER_REGISTRY}/deployer:${DEPLOYER_TAG}"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -43,6 +43,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["sqlite", "json", "migrate"] }
 strum = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tower = { workspace = true, features = ["steer"] }
 tower-http = { workspace = true }

--- a/gateway/migrations/0006_add_deployments_info.sql
+++ b/gateway/migrations/0006_add_deployments_info.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS services (
+    id TEXT PRIMARY KEY,    -- Identifier of the service.
+    project_id ULID,        -- The project the service is bound to
+    name TEXT,              -- Name of the service.
+    FOREIGN KEY(project_id) REFERENCES projects(id)
+);
+
+CREATE TABLE IF NOT EXISTS deployments (
+    id TEXT PRIMARY KEY, -- Identifier of the deployment.
+    service_id TEXT,     -- Identifier of the service this deployment belongs to.
+    state TEXT,          -- Enum indicating the current state of the deployment.
+    last_update INTEGER, -- Unix epoch of the last status update
+    address TEXT,        -- Address a running deployment is active on
+    is_next BOOLEAN DEFAULT 0 NOT NULL, -- Whether the deployment is based on a shuttle-next runtime
+    git_commit_id TEXT,  -- Commit id of the underlying git repo of the deployed project
+    git_commit_msg TEXT, -- Commit message of the underlying git repo of the deployed project
+    git_branch TEXT,     -- Git branch of the underlying git repo of the deployed project
+    git_dirty BOOLEAN,   -- Whether the deployed project had uncommited git changes
+    FOREIGN KEY(service_id) REFERENCES services(id)
+);

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -36,6 +36,9 @@ pub struct StartArgs {
     /// Address to bind the user proxy to
     #[arg(long, default_value = "127.0.0.1:8000")]
     pub user: SocketAddr,
+    /// Address to bind the deployer API to
+    #[arg(long, default_value = "127.0.0.1:8002")]
+    pub deployer_api: SocketAddr,
     /// Allows to disable the use of TLS in the user proxy service (DANGEROUS)
     #[arg(long, default_value = "enable")]
     pub use_tls: UseTls,

--- a/gateway/src/deployer/api/authz.rs
+++ b/gateway/src/deployer/api/authz.rs
@@ -1,0 +1,61 @@
+use axum::extract::{FromRef, FromRequestParts};
+use axum::headers::HeaderMapExt;
+use axum::http::request::Parts;
+use shuttle_common::backends::headers::XShuttleAdminSecret;
+use shuttle_common::models::project::ProjectName;
+use tracing::Span;
+
+use super::DeployerApiState;
+use crate::deployer::dal::Dal;
+use crate::{Error, ErrorKind};
+
+/// This needs to be used for every API request handler that will be
+/// authorized through the admin secret, set as a deployer flag.
+pub struct ScopedProject(pub ProjectName);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for ScopedProject
+where
+    S: Send + Sync,
+    DeployerApiState: FromRef<S>,
+{
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let project_name = match parts.headers.typed_try_get::<XShuttleAdminSecret>() {
+            Ok(Some(secret)) => {
+                let deployer_api_state = DeployerApiState::from_ref(state);
+                // For this particular case, we expect the secret to be the deployer admin secret.
+                deployer_api_state
+                    .service
+                    .db
+                    .project_name_by_admin_secret(secret.0.as_str())
+                    .await
+                    .map_err(|_| {
+                        Error::custom(
+                            ErrorKind::Internal,
+                            "Couldn't validate the authority of the deployer request",
+                        )
+                    })?
+                    .ok_or(Error::custom(
+                        ErrorKind::Unauthorized,
+                        "Authority check failed",
+                    ))
+            }
+            Ok(_) => Err(Error::custom(
+                ErrorKind::Unauthorized,
+                "Authority check failed",
+            )),
+            // Returning forbidden for the cases where we don't understand why we can not authorize.
+            Err(_) => Err(Error::custom(
+                ErrorKind::Forbidden,
+                "We can not authorize this request",
+            )),
+        }?;
+
+        // Record current project name for tracing purposes
+        Span::current().record("shuttle.project.name", project_name.to_string());
+
+        Ok(ScopedProject(project_name))
+    }
+}

--- a/gateway/src/deployer/api/handlers.rs
+++ b/gateway/src/deployer/api/handlers.rs
@@ -1,0 +1,51 @@
+use std::str::FromStr;
+
+use axum::{extract::State, Json};
+use shuttle_common::models::error::axum::CustomErrorPath;
+use shuttle_common::models::project::ProjectName;
+
+use crate::deployer::dal::Dal;
+use crate::project::ContainerInspectResponseExt;
+
+use super::super::error::{Error, Result};
+use super::{authz::ScopedProject, DeployerApiState};
+
+pub(crate) async fn get_service(
+    _scoped_project: ScopedProject,
+    State(DeployerApiState { service, .. }): State<DeployerApiState>,
+    CustomErrorPath((project_name, service_name)): CustomErrorPath<(String, String)>,
+) -> Result<Json<shuttle_common::models::service::Summary>> {
+    if let Some(user_service) = service.db.get_service_by_name(&service_name).await? {
+        let deployment = service
+            .db
+            .get_active_deployment(&user_service.id)
+            .await?
+            .map(Into::into);
+
+        let project_name = ProjectName::from_str(project_name.as_str()).map_err(Error::from)?;
+        let project = service
+            .find_project(&project_name)
+            .await
+            .map_err(Error::from)?;
+        let proxy_fqdn = project
+            .state
+            .container()
+            .ok_or(Error::ProxyFqdnMissing(
+                "Project state container missing the proxy fqdn information".to_string(),
+            ))?
+            .fqdn()
+            .map_err(|err| {
+                Error::ProxyFqdnMissing(format!("Project is in errored state: {err}"))
+            })?;
+
+        let response = shuttle_common::models::service::Summary {
+            uri: format!("https://{proxy_fqdn}"),
+            name: user_service.name,
+            deployment,
+        };
+
+        Ok(Json(response))
+    } else {
+        Err(Error::NotFound("service not found".to_string()))
+    }
+}

--- a/gateway/src/deployer/api/mod.rs
+++ b/gateway/src/deployer/api/mod.rs
@@ -1,0 +1,95 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use axum::{middleware::from_extractor, Extension, Router};
+use futures::Future;
+use http::Uri;
+use shuttle_common::{
+    backends::{
+        auth::{AuthPublicKey, JwtAuthenticationLayer},
+        metrics::{Metrics, TraceLayer},
+    },
+    request_span,
+};
+use tracing::field;
+
+use crate::service::GatewayService;
+
+pub mod authz;
+
+#[derive(Clone)]
+pub struct DeployerApiState {
+    pub service: Arc<GatewayService>,
+}
+
+pub struct Builder {
+    router: Router<DeployerApiState>,
+    service: Option<Arc<GatewayService>>,
+    bind: Option<SocketAddr>,
+}
+
+impl Builder {
+    pub fn with_binding(mut self, bind: SocketAddr) -> Self {
+        self.bind = Some(bind);
+        self
+    }
+
+    pub fn with_service(mut self, service: Arc<GatewayService>) -> Self {
+        self.service = Some(service);
+        self
+    }
+
+    pub fn with_jwt_guarded_routes(mut self, auth_uri: Uri) -> Self {
+        let auth_public_key = AuthPublicKey::new(auth_uri.clone());
+        // TODO add routes
+        self.router = self
+            .router
+            // TODO add more routes
+            .layer(JwtAuthenticationLayer::new(auth_public_key));
+        self
+    }
+
+    pub fn with_admin_secret_guarded_routes(self) -> Self {
+        self
+    }
+
+    pub fn with_default_traces(mut self) -> Self {
+        self.router = self.router.route_layer(from_extractor::<Metrics>()).layer(
+            TraceLayer::new(|request| {
+                request_span!(
+                    request,
+                    account.name = field::Empty,
+                    request.params.project_name = field::Empty,
+                    request.params.account_name = field::Empty
+                )
+            })
+            .with_propagation()
+            .build(),
+        );
+        self
+    }
+
+    pub fn into_router(self) -> Router {
+        let service = self.service.expect("a service to be set");
+        self.router
+            .with_state(DeployerApiState {
+                service: service.clone(),
+            })
+            .layer(Extension(service.db.clone()))
+    }
+
+    pub fn serve(self) -> impl Future<Output = Result<(), hyper::Error>> {
+        let bind = self.bind.expect("a socket address to bind to is required");
+        let router = self.into_router();
+        axum::Server::bind(&bind).serve(router.into_make_service())
+    }
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Builder {
+            router: Router::new(),
+            service: None,
+            bind: None,
+        }
+    }
+}

--- a/gateway/src/deployer/api/mod.rs
+++ b/gateway/src/deployer/api/mod.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, sync::Arc};
 
-use axum::{middleware::from_extractor, Extension, Router};
+use axum::{middleware::from_extractor, routing::get, Extension, Router};
 use futures::Future;
 use http::Uri;
 use shuttle_common::{
@@ -14,7 +14,10 @@ use tracing::field;
 
 use crate::service::GatewayService;
 
+use self::handlers::get_service;
+
 pub mod authz;
+pub mod handlers;
 
 #[derive(Clone)]
 pub struct DeployerApiState {
@@ -40,7 +43,6 @@ impl Builder {
 
     pub fn with_jwt_guarded_routes(mut self, auth_uri: Uri) -> Self {
         let auth_public_key = AuthPublicKey::new(auth_uri.clone());
-        // TODO add routes
         self.router = self
             .router
             // TODO add more routes
@@ -48,7 +50,12 @@ impl Builder {
         self
     }
 
-    pub fn with_admin_secret_guarded_routes(self) -> Self {
+    pub fn with_admin_secret_guarded_routes(mut self) -> Self {
+        self.router = self.router.route(
+            "/projects/:project_name/services/:service_name",
+            get(get_service),
+        );
+
         self
     }
 

--- a/gateway/src/deployer/dal.rs
+++ b/gateway/src/deployer/dal.rs
@@ -1,0 +1,24 @@
+use shuttle_common::models::project::ProjectName;
+use sqlx::{Row, SqlitePool};
+
+use super::error::{Error, Result};
+
+pub trait Dal {
+    async fn project_name_by_admin_secret(&self, secret: &str) -> Result<Option<ProjectName>>;
+}
+
+impl Dal for SqlitePool {
+    async fn project_name_by_admin_secret(&self, secret: &str) -> Result<Option<ProjectName>> {
+        sqlx::query("SELECT project_name FROM projects WHERE initial_key = ?")
+            .bind(secret)
+            .fetch_optional(self)
+            .await
+            .map(|o| {
+                o.map(|r| {
+                    r.try_get::<ProjectName, _>("project_name")
+                        .expect("to have a value")
+                })
+            })
+            .map_err(Error::from)
+    }
+}

--- a/gateway/src/deployer/dal.rs
+++ b/gateway/src/deployer/dal.rs
@@ -1,10 +1,16 @@
-use shuttle_common::models::project::ProjectName;
+use shuttle_common::{
+    models::project::ProjectName,
+    persistence::{deployment::Deployment, service::Service, state::State},
+};
 use sqlx::{Row, SqlitePool};
+use ulid::Ulid;
 
 use super::error::{Error, Result};
 
 pub trait Dal {
     async fn project_name_by_admin_secret(&self, secret: &str) -> Result<Option<ProjectName>>;
+    async fn get_service_by_name(&self, name: &str) -> Result<Option<Service>>;
+    async fn get_active_deployment(&self, service_id: &Ulid) -> Result<Option<Deployment>>;
 }
 
 impl Dal for SqlitePool {
@@ -19,6 +25,23 @@ impl Dal for SqlitePool {
                         .expect("to have a value")
                 })
             })
+            .map_err(Error::from)
+    }
+
+    async fn get_service_by_name(&self, name: &str) -> Result<Option<Service>> {
+        sqlx::query_as("SELECT * FROM services WHERE name = ?")
+            .bind(name)
+            .fetch_optional(self)
+            .await
+            .map_err(Error::from)
+    }
+
+    async fn get_active_deployment(&self, service_id: &Ulid) -> Result<Option<Deployment>> {
+        sqlx::query_as("SELECT * FROM deployments WHERE service_id = ? AND state = ?")
+            .bind(service_id.to_string())
+            .bind(State::Running)
+            .fetch_optional(self)
+            .await
             .map_err(Error::from)
     }
 }

--- a/gateway/src/deployer/error.rs
+++ b/gateway/src/deployer/error.rs
@@ -1,0 +1,54 @@
+use std::error::Error as StdError;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use serde::{ser::SerializeMap, Serialize};
+use shuttle_common::models::error::ApiError;
+use tracing::error;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Streaming error: {0}")]
+    Streaming(#[from] axum::Error),
+    #[error("Persistence failure: {0}")]
+    Persistence(#[from] sqlx::Error),
+    #[error("{0}, try running `cargo shuttle deploy`")]
+    NotFound(String),
+    #[error("Invalid project name: {0}")]
+    InvalidProjectName(#[from] shuttle_common::models::error::InvalidProjectName),
+    #[error("Service query error: {0}")]
+    GatewayServiceQuery(#[from] crate::Error),
+}
+
+impl Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", &format!("{:?}", self))?;
+        // use the error source if available, if not use display implementation
+        map.serialize_entry("msg", &self.source().unwrap_or(self).to_string())?;
+        map.end()
+    }
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        error!(error = &self as &dyn std::error::Error, "request error");
+
+        let code = match self {
+            Error::NotFound(_) => StatusCode::NOT_FOUND,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+        ApiError {
+            message: self.to_string(),
+            status_code: code.as_u16(),
+        }
+        .into_response()
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/gateway/src/deployer/error.rs
+++ b/gateway/src/deployer/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
     Streaming(#[from] axum::Error),
     #[error("Persistence failure: {0}")]
     Persistence(#[from] sqlx::Error),
+    #[error("{0}")]
+    ProxyFqdnMissing(String),
     #[error("{0}, try running `cargo shuttle deploy`")]
     NotFound(String),
     #[error("Invalid project name: {0}")]

--- a/gateway/src/deployer/mod.rs
+++ b/gateway/src/deployer/mod.rs
@@ -1,0 +1,3 @@
+pub mod api;
+mod dal;
+pub mod error;

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -29,6 +29,7 @@ pub mod acme;
 pub mod api;
 pub mod args;
 pub mod auth;
+pub mod deployer;
 pub mod project;
 pub mod proxy;
 pub mod service;
@@ -529,7 +530,9 @@ pub mod tests {
             let user = control + 1;
             let bouncer = user + 1;
             let auth_port = bouncer + 1;
+            let deployer_api = auth_port + 1;
             let control = format!("127.0.0.1:{control}").parse().unwrap();
+            let deployer_api = format!("127.0.0.1:{deployer_api}").parse().unwrap();
             let user = format!("127.0.0.1:{user}").parse().unwrap();
             let bouncer = format!("127.0.0.1:{bouncer}").parse().unwrap();
             let auth: SocketAddr = format!("0.0.0.0:{auth_port}").parse().unwrap();
@@ -563,6 +566,7 @@ pub mod tests {
                 control,
                 user,
                 bouncer,
+                deployer_api,
                 use_tls: UseTls::Disable,
                 context: ContextArgs {
                     docker_host,

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -250,7 +250,7 @@ impl GatewayContextProvider {
 
 pub struct GatewayService {
     provider: GatewayContextProvider,
-    db: SqlitePool,
+    pub db: SqlitePool,
     task_router: TaskRouter,
     pub state_location: PathBuf,
 


### PR DESCRIPTION
## Description of change

This PR is the beginning of the work required to move the deployer sqlite state to a central store. This PR will focus on a few bits of work:

1) Create a new migration for deployments and services tables.
2) Set up a `DeployerApi` router (for a REST API) inside the gateway that will respond to calls from the deployer (for its remote persistence, see point 3.), authorized by using an `admin_secret` (which is a unique key generated per project).
3) Create a deployer persistence `Mode` that abstracts the underlying storage, with two variants (`Local` and `Remote`). 
3.a Some persistence models from the deployer will be used by the gateway too, so moved them to common
3.b Deployer persistence interactions will have separate implementations based on the persistence mode, but the interactions will be represented by a few traits stored in common.
4) Implement the deployer persistence traits for the `Remote` mode (including the routes on the `DeployerApi`).

## Next work that will be covered in another PR

The migration admin endpoints which will move the sqlite state to the remote persistence and will change the persistence mode without user action.

## TODO for this PR

Part 4.

## How has this been tested? (if applicable)

TODO

