### PR TITLE
ci: use default ubuntu machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     resource_class: small
   machine-ubuntu:
     machine:
-      image: ubuntu-2204:2023.07.2
+      image: default
       docker_layer_caching: true
     resource_class: large
 


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Current image is being deprecated this year. Replacing it with `default` which uses latest ubuntu, as recommended here https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Works for the ci runs 
