### PR TITLE
feat: base api and gateway client

### DIFF
--- a/common/src/backends/client/gateway.rs
+++ b/common/src/backends/client/gateway.rs
@@ -1,0 +1,55 @@
+use headers::Authorization;
+use http::{Method, Uri};
+
+use crate::models;
+
+use super::{Error, ServicesApiClient};
+
+#[derive(Clone)]
+pub struct GatewayClient {
+    public_client: ServicesApiClient,
+    private_client: ServicesApiClient,
+}
+
+impl GatewayClient {
+    pub fn new(public_uri: Uri, private_uri: Uri) -> Self {
+        Self {
+            public_client: ServicesApiClient::new(public_uri),
+            private_client: ServicesApiClient::new(private_uri),
+        }
+    }
+
+    pub fn public_client(&self) -> &ServicesApiClient {
+        &self.public_client
+    }
+
+    pub fn private_client(&self) -> &ServicesApiClient {
+        &self.private_client
+    }
+
+    /// Get the projects that belong to a user
+    pub async fn get_user_projects(
+        &self,
+        user_token: &str,
+    ) -> Result<Vec<models::project::Response>, Error> {
+        let projects = self
+            .public_client
+            .request(
+                Method::GET,
+                "projects",
+                None::<()>,
+                Some(Authorization::bearer(user_token).expect("to build an authorization bearer")),
+            )
+            .await?;
+
+        Ok(projects)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn failing_test() {
+        assert!(false);
+    }
+}

--- a/common/src/backends/client/mod.rs
+++ b/common/src/backends/client/mod.rs
@@ -1,0 +1,84 @@
+use headers::{ContentType, Header, HeaderMapExt};
+use http::{Method, Request, Uri};
+use hyper::{body, client::HttpConnector, Body, Client};
+use opentelemetry::global;
+use opentelemetry_http::HeaderInjector;
+use serde::{de::DeserializeOwned, Serialize};
+use thiserror::Error;
+use tracing::{trace, Span};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+mod gateway;
+
+pub use gateway::GatewayClient;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("Hyper error: {0}")]
+    Hyper(#[from] hyper::Error),
+    #[error("Serde JSON error: {0}")]
+    SerdeJson(#[from] serde_json::Error),
+    #[error("Hyper error: {0}")]
+    Http(#[from] hyper::http::Error),
+}
+
+/// `Hyper` wrapper to make request to RESTful Shuttle services easy
+#[derive(Clone)]
+pub struct ServicesApiClient {
+    client: Client<HttpConnector>,
+    base: Uri,
+}
+
+impl ServicesApiClient {
+    fn new(base: Uri) -> Self {
+        Self {
+            client: Client::new(),
+            base,
+        }
+    }
+
+    /// Make a get request to the service
+    pub async fn request<B: Serialize, T: DeserializeOwned, H: Header>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<B>,
+        extra_header: Option<H>,
+    ) -> Result<T, Error> {
+        let uri = format!("{}{path}", self.base);
+        trace!(uri, "calling inner service");
+
+        let mut req = Request::builder().method(method).uri(uri);
+        let headers = req
+            .headers_mut()
+            .expect("new request to have mutable headers");
+
+        headers.typed_insert(ContentType::json());
+
+        if let Some(extra_header) = extra_header {
+            headers.typed_insert(extra_header);
+        }
+
+        let cx = Span::current().context();
+
+        global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&cx, &mut HeaderInjector(req.headers_mut().unwrap()))
+        });
+
+        let req = if let Some(body) = body {
+            req.body(Body::from(serde_json::to_vec(&body)?))
+        } else {
+            req.body(Body::empty())
+        };
+
+        let resp = self.client.request(req?).await?;
+
+        trace!(response = ?resp, "Load response");
+
+        let body = resp.into_body();
+        let bytes = body::to_bytes(body).await?;
+        let json = serde_json::from_slice(&bytes)?;
+
+        Ok(json)
+    }
+}

--- a/common/src/backends/mod.rs
+++ b/common/src/backends/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod cache;
+pub mod client;
 mod future;
 pub mod headers;
 pub mod metrics;

--- a/deployer/src/error.rs
+++ b/deployer/src/error.rs
@@ -1,8 +1,7 @@
 use std::error::Error as StdError;
+use shuttle_common::backends;
 use std::io;
 use thiserror::Error;
-
-use crate::deployment::gateway_client;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -29,7 +28,7 @@ pub enum Error {
     #[error("Failed to cleanup old deployments: {0}")]
     OldCleanup(#[source] Box<dyn StdError + Send>),
     #[error("Gateway client error: {0}")]
-    GatewayClient(#[from] gateway_client::Error),
+    GatewayClient(#[from] backends::client::Error),
     #[error("Failed to get runtime: {0}")]
     Runtime(#[source] anyhow::Error),
     #[error("Failed to call start on runtime: {0}")]

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -24,7 +24,8 @@ mod runtime_manager;
 
 pub use crate::args::Args;
 pub use crate::deployment::state_change_layer::StateChangeLayer;
-use crate::deployment::{gateway_client::GatewayClient, DeploymentManager};
+use crate::deployment::DeploymentManager;
+use shuttle_common::backends::client::GatewayClient;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -55,7 +56,10 @@ pub async fn start(
         .deployment_updater(persistence.clone())
         .resource_manager(persistence.clone())
         .builder_client(builder_client)
-        .queue_client(GatewayClient::new(args.gateway_uri))
+        .queue_client(GatewayClient::new(
+            args.gateway_uri.clone(),
+            args.gateway_uri,
+        ))
         .log_fetcher(log_fetcher)
         .build();
 


### PR DESCRIPTION
## Description of change
Make a base API client that can be used to build API clients for other services. We want this to allow `provisioner` to call `gateway` and `resource-recorder` soon.

## How has this been tested? (if applicable)
Will add tests


