### PR TITLE
Traces: set shuttle.project.name in more places

### DIFF
--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -367,10 +367,10 @@ async fn load(
 
     load_request.extensions_mut().insert(claim.clone());
 
-    debug!(shuttle.service.name = %service_name, "loading service");
+    debug!(shuttle.project.name = %service_name, shuttle.service.name = %service_name, "loading service");
     let response = runtime_client.load(load_request).await;
 
-    debug!(shuttle.service.name = %service_name, "service loaded");
+    debug!(shuttle.project.name = %service_name, shuttle.service.name = %service_name, "service loaded");
     match response {
         Ok(response) => {
             let response = response.into_inner();

--- a/deployer/src/persistence/mod.rs
+++ b/deployer/src/persistence/mod.rs
@@ -580,7 +580,7 @@ impl ResourceManager for Persistence {
 
 #[async_trait::async_trait]
 impl AddressGetter for Persistence {
-    #[instrument(skip_all, fields(shuttle.service.name = service_name))]
+    #[instrument(skip_all, fields(shuttle.service.name = service_name, shuttle.project.name = service_name))]
     async fn get_address_for_service(
         &self,
         service_name: &str,

--- a/deployer/src/proxy.rs
+++ b/deployer/src/proxy.rs
@@ -23,7 +23,7 @@ static PROXY_CLIENT: Lazy<ReverseProxy<HttpConnector<GaiResolver>>> =
     Lazy::new(|| ReverseProxy::new(Client::new()));
 static SERVER_HEADER: Lazy<HeaderValue> = Lazy::new(|| "shuttle.rs".parse().unwrap());
 
-#[instrument(name = "proxy_request", skip_all, fields(http.method = %req.method(), http.uri = %req.uri(), http.status_code = field::Empty, http.host = field::Empty, shuttle.service.name = field::Empty, proxy.status_code = field::Empty))]
+#[instrument(name = "proxy_request", skip_all, fields(http.method = %req.method(), http.uri = %req.uri(), http.status_code = field::Empty, http.host = field::Empty, shuttle.service.name = field::Empty, shuttle.project.name = field::Empty, proxy.status_code = field::Empty))]
 pub async fn handle(
     remote_address: SocketAddr,
     fqdn: FQDN,
@@ -78,6 +78,7 @@ pub async fn handle(
     };
 
     // Record current service for tracing purposes
+    span.record("shuttle.project.name", &service);
     span.record("shuttle.service.name", &service);
 
     let proxy_address = match address_getter.get_address_for_service(&service).await {

--- a/gateway/src/api/mod.rs
+++ b/gateway/src/api/mod.rs
@@ -2,3 +2,4 @@ mod auth_layer;
 
 pub mod latest;
 mod project_caller;
+mod tracing;

--- a/gateway/src/api/tracing.rs
+++ b/gateway/src/api/tracing.rs
@@ -1,0 +1,19 @@
+use axum::{extract::Path, http::Request, middleware::Next, response::Response};
+
+/// Layer to correctly set the tracing parameters of a :project_name route
+pub(crate) async fn project_name_tracing_layer<B>(
+    // Ideally we would use a custom struct containing `project_name`, but Axum rejects it for some
+    // reason.
+    Path(paths): Path<Vec<(String, String)>>,
+    request: Request<B>,
+    next: Next<B>,
+) -> Response {
+    if let Some((_, project_name)) = paths
+        .into_iter()
+        .find(|(path_name, _)| path_name == "project_name")
+    {
+        let current_span = tracing::Span::current();
+        current_span.record("shuttle.project.name", project_name);
+    }
+    next.run(request).await
+}

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -1395,6 +1395,7 @@ where
         debug!(
             shuttle.container.id = container.id,
             shuttle.service.name = %service.name,
+            shuttle.project.name = %service.name,
             "{} has {} CPU usage per minute",
             service.name,
             cpu_per_minute


### PR DESCRIPTION
## Description of change
Two commits for two changes:
1. For the `gateway`, any call to a route that has `:project` in it will now add to the current span `shuttle.project.name`. This isn't perfect, ideally we would want to set it to every child span as well, but this is already an improvement.
2. Update several places where we set `shuttle.service.name`, but not `shuttle.project.name`. I could have dropped `shuttle.service.name` since we're not really using the concept of a service, but that's fine for now.



## How has this been tested? (if applicable)
Updated the otel-collector to send trace to a local `jaeger` instance instead of DD/HC, and the attribute showed up as expected :)


