### PR TITLE
Traces add shuttle version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
       - run:
           name: Make and push images
           command: |
-            PUSH=true SHUTTLE_ENV=<< parameters.shuttle-env >> PLATFORMS=linux/amd64 TAG=$TAG make images
+            PUSH=true SHUTTLE_SERVICE_VERSION=$TAG SHUTTLE_ENV=<< parameters.shuttle-env >> PLATFORMS=linux/amd64 TAG=$TAG make images
       - save-buildx-cache
   deploy-images:
     executor: machine-ubuntu

--- a/Containerfile
+++ b/Containerfile
@@ -63,6 +63,8 @@ RUN apt update && apt install -y curl ca-certificates; rm -rf /var/lib/apt/lists
 
 #### AUTH
 FROM bookworm-20230904-slim-plus AS shuttle-auth
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-auth /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/shuttle-auth"]
@@ -72,6 +74,8 @@ FROM shuttle-auth AS shuttle-auth-dev
 #### BUILDER
 ARG RUSTUP_TOOLCHAIN
 FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-bookworm AS shuttle-builder
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 ARG prepare_args
 COPY builder/prepare.sh /prepare.sh
@@ -84,6 +88,8 @@ FROM shuttle-builder AS shuttle-builder-dev
 #### DEPLOYER
 ARG RUSTUP_TOOLCHAIN
 FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-bookworm AS shuttle-deployer
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 ARG prepare_args
 # Fixes some dependencies compiled with incompatible versions of rustc
@@ -115,6 +121,8 @@ COPY --from=chef-planner /build /usr/src/shuttle/
 
 #### GATEWAY
 FROM bookworm-20230904-slim-plus AS shuttle-gateway
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 COPY gateway/ulid0.so /usr/lib/
 COPY gateway/ulid0_aarch64.so /usr/lib/
@@ -132,6 +140,8 @@ COPY --from=chef-planner /build/*.pem /usr/src/shuttle/
 
 #### LOGGER
 FROM docker.io/library/debian:bookworm-20230904-slim AS shuttle-logger
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-logger /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/shuttle-logger"]
@@ -141,6 +151,8 @@ FROM shuttle-logger AS shuttle-logger-dev
 #### PROVISIONER
 ARG RUSTUP_TOOLCHAIN
 FROM bookworm-20230904-slim-plus AS shuttle-provisioner
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-provisioner /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/shuttle-provisioner"]
@@ -149,6 +161,8 @@ FROM shuttle-provisioner AS shuttle-provisioner-dev
 
 #### RESOURCE RECORDER
 FROM docker.io/library/debian:bookworm-20230904-slim AS shuttle-resource-recorder
+ARG SHUTTLE_SERVICE_VERSION
+ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
 ARG CARGO_PROFILE
 COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-resource-recorder /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/shuttle-resource-recorder"]

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,8 @@ DOCKER_COMPOSE_ENV=\
 	USE_TLS=$(USE_TLS)\
 	COMPOSE_PROFILES=$(COMPOSE_PROFILES)\
 	DOCKER_SOCK=$(DOCKER_SOCK)\
-	SHUTTLE_ENV=$(SHUTTLE_ENV)
+	SHUTTLE_ENV=$(SHUTTLE_ENV)\
+	SHUTTLE_SERVICE_VERSION=$(SHUTTLE_SERVICE_VERSION)
 
 .PHONY: clean cargo-clean images the-shuttle-images shuttle-% postgres panamax otel deploy test docker-compose.rendered.yml up down
 
@@ -165,6 +166,7 @@ shuttle-%:
 		--build-arg crate=$(@) \
 		--build-arg prepare_args=$(PREPARE_ARGS) \
 		--build-arg SHUTTLE_ENV=$(SHUTTLE_ENV) \
+		--build-arg SHUTTLE_SERVICE_VERSION=$(SHUTTLE_SERVICE_VERSION) \
 		--build-arg RUSTUP_TOOLCHAIN=$(RUSTUP_TOOLCHAIN) \
 		--build-arg CARGO_PROFILE=$(CARGO_PROFILE) \
 		--tag $(CONTAINER_REGISTRY)/$(*):$(COMMIT_SHA) \


### PR DESCRIPTION
## Description of change

This goal is to enable Datadog to track versions, deployments, and to
be able to automatically detected regressions or new bug associated with
a version.

![image](https://github.com/shuttle-hq/shuttle/assets/59063/30d46e31-ae2e-454e-8612-e46680b398b9)



## How has this been tested? (if applicable)

Locally, with Datadog configured in the `local` environment.


