### PR TITLE
feat(auth): add subscriptions table to auth, add rds quota to claim limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5843,6 +5843,7 @@ dependencies = [
  "axum-extra",
  "axum-sessions",
  "base64 0.21.5",
+ "chrono",
  "clap",
  "ctor",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5852,6 +5852,7 @@ dependencies = [
  "opentelemetry 0.21.0",
  "pem 2.0.1",
  "portpicker",
+ "pretty_assertions",
  "rand 0.8.5",
  "ring 0.17.7",
  "serde",

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = { workspace = true }
 axum = { workspace = true, features = ["headers"] }
 axum-sessions = { workspace = true }
 base64 = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 http = { workspace = true }
 jsonwebtoken = { workspace = true }
@@ -26,7 +27,7 @@ pem = "2"
 rand = { workspace = true }
 ring = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-sqlx = { workspace = true, features = ["postgres", "json", "migrate"] }
+sqlx = { workspace = true, features = ["postgres", "json", "migrate", "chrono"] }
 strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -40,6 +40,7 @@ ctor = { workspace = true }
 hyper = { workspace = true }
 once_cell = { workspace = true }
 portpicker = { workspace = true }
+pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 shuttle-common-tests = { workspace = true }
 tower = { workspace = true, features = ["util"] }

--- a/auth/migrations/0001_sync_updated_at.sql
+++ b/auth/migrations/0001_sync_updated_at.sql
@@ -1,4 +1,4 @@
--- Create a trigger to automatically set updated_at to current_timestamp
+-- Create a function (that can be registered on triggers) to automatically set updated_at to current_timestamp
 CREATE OR REPLACE FUNCTION sync_updated_at() 
    RETURNS TRIGGER 
    LANGUAGE PLPGSQL

--- a/auth/migrations/0001_sync_updated_at.sql
+++ b/auth/migrations/0001_sync_updated_at.sql
@@ -1,0 +1,10 @@
+-- Create a trigger to automatically set updated_at to current_timestamp
+CREATE OR REPLACE FUNCTION sync_updated_at() 
+   RETURNS TRIGGER 
+   LANGUAGE PLPGSQL
+AS $$
+BEGIN
+   NEW.updated_at = current_timestamp;
+   RETURN NEW;
+END;
+$$

--- a/auth/migrations/0002_subscriptions.sql
+++ b/auth/migrations/0002_subscriptions.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   account_name TEXT NOT NULL,
   type TEXT NOT NULL,
   quantity INT DEFAULT 1,
+  created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, 
   UNIQUE (account_name, type),
   FOREIGN KEY (account_name) REFERENCES users(account_name)

--- a/auth/migrations/0002_subscriptions.sql
+++ b/auth/migrations/0002_subscriptions.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS subscriptions (
+  subscription_id TEXT PRIMARY KEY,
+  account_name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, 
+  UNIQUE (account_name, type),
+  FOREIGN KEY (account_name) REFERENCES users(account_name)
+);
+
+-- Create a trigger to automatically update updated_at
+CREATE TRIGGER sync_users_updated_at
+BEFORE UPDATE
+ON subscriptions
+FOR EACH ROW
+EXECUTE PROCEDURE sync_updated_at();
+
+-- Insert existing subscriptions into the new subscriptions table
+INSERT INTO subscriptions (subscription_id, account_name, type)
+SELECT subscription_id, account_name, 'pro'
+FROM users
+WHERE subscription_id IS NOT NULL;
+
+-- Drop the subscription_id column from the users table
+ALTER TABLE users
+DROP COLUMN subscription_id;

--- a/auth/migrations/0002_subscriptions.sql
+++ b/auth/migrations/0002_subscriptions.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   FOREIGN KEY (account_name) REFERENCES users(account_name)
 );
 
--- Create a trigger to automatically update updated_at
+-- Create a trigger to automatically update the updated_at column
 CREATE TRIGGER sync_users_updated_at
 BEFORE UPDATE
 ON subscriptions

--- a/auth/migrations/0002_subscriptions.sql
+++ b/auth/migrations/0002_subscriptions.sql
@@ -2,7 +2,8 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   subscription_id TEXT PRIMARY KEY,
   account_name TEXT NOT NULL,
   type TEXT NOT NULL,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, 
+  quantity INT DEFAULT 1,
+  updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP, 
   UNIQUE (account_name, type),
   FOREIGN KEY (account_name) REFERENCES users(account_name)
 );

--- a/auth/migrations/0002_subscriptions.sql
+++ b/auth/migrations/0002_subscriptions.sql
@@ -14,7 +14,7 @@ ON subscriptions
 FOR EACH ROW
 EXECUTE PROCEDURE sync_updated_at();
 
--- Insert existing subscriptions into the new subscriptions table
+-- Insert existing subscriptions into the new subscriptions table, all of which are of the pro type
 INSERT INTO subscriptions (subscription_id, account_name, type)
 SELECT subscription_id, account_name, 'pro'
 FROM users

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -65,7 +65,10 @@ pub async fn pgpool_init(db_uri: &str) -> io::Result<PgPool> {
     let pool = PgPool::connect_with(opts)
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    MIGRATIONS.run(&pool).await.unwrap();
+    MIGRATIONS
+        .run(&pool)
+        .await
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     Ok(pool)
 }

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -143,7 +143,7 @@ impl UserManagement for UserManager {
         .ok_or(Error::UserNotFound)?;
 
         let subscriptions: Vec<Subscription> = sqlx::query_as(
-            "SELECT subscription_id, type, quantity, updated_at FROM subscriptions WHERE account_name = $1",
+            "SELECT subscription_id, type, quantity, created_at, updated_at FROM subscriptions WHERE account_name = $1",
         )
         .bind(&user.name.to_string())
         .fetch_all(&self.pool)
@@ -173,7 +173,7 @@ impl UserManagement for UserManager {
                 .ok_or(Error::UserNotFound)?;
 
         let subscriptions: Vec<Subscription> = sqlx::query_as(
-            "SELECT subscription_id, type, quantity, updated_at FROM subscriptions WHERE account_name = $1",
+            "SELECT subscription_id, type, quantity, created_at, updated_at FROM subscriptions WHERE account_name = $1",
         )
         .bind(&user.name.to_string())
         .fetch_all(&self.pool)
@@ -222,6 +222,7 @@ pub struct Subscription {
     pub id: stripe::SubscriptionId,
     pub r#type: ShuttleSubscriptionType,
     pub quantity: i32,
+    pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
 
@@ -343,6 +344,7 @@ impl FromRow<'_, PgRow> for Subscription {
                 },
             )?,
             quantity: row.try_get("quantity").unwrap(),
+            created_at: row.try_get("created_at").unwrap(),
             updated_at: row.try_get("updated_at").unwrap(),
         })
     }

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -10,6 +10,7 @@ mod needs_docker {
     };
     use axum::body::Body;
     use hyper::http::{header::AUTHORIZATION, Request, StatusCode};
+    use pretty_assertions::assert_eq;
     use serde_json::{self, Value};
 
     #[tokio::test]

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -10,14 +10,22 @@ pub struct Limits {
     /// The amount of projects this user can create.
     project_limit: u32,
     /// Whether this user has permission to provision RDS instances.
+    #[deprecated(
+        since = "0.38.0",
+        note = "This was replaced with rds_quota, but old runtimes might still try to deserialize a claim expecting this field"
+    )]
+    #[serde(skip_deserializing)]
+    rds_access: bool,
     /// The quantity of RDS instances this user can provision.
     rds_quota: u32,
 }
 
 impl Default for Limits {
     fn default() -> Self {
+        #[allow(deprecated)]
         Self {
             project_limit: MAX_PROJECTS_DEFAULT,
+            rds_access: false,
             rds_quota: 0,
         }
     }
@@ -25,8 +33,10 @@ impl Default for Limits {
 
 impl Limits {
     pub fn new(project_limit: u32, rds_quota: u32) -> Self {
+        #[allow(deprecated)]
         Self {
             project_limit,
+            rds_access: false,
             rds_quota,
         }
     }

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -10,7 +10,6 @@ pub struct Limits {
     /// The amount of projects this user can create.
     project_limit: u32,
     /// Whether this user has permission to provision RDS instances.
-    rds_access: bool,
     /// The quantity of RDS instances this user can provision.
     rds_quota: u32,
 }
@@ -19,27 +18,21 @@ impl Default for Limits {
     fn default() -> Self {
         Self {
             project_limit: MAX_PROJECTS_DEFAULT,
-            rds_access: false,
             rds_quota: 0,
         }
     }
 }
 
 impl Limits {
-    pub fn new(project_limit: u32, rds_access: bool, rds_quota: u32) -> Self {
+    pub fn new(project_limit: u32, rds_quota: u32) -> Self {
         Self {
             project_limit,
-            rds_access,
             rds_quota,
         }
     }
 
     pub fn project_limit(&self) -> u32 {
         self.project_limit
-    }
-
-    pub fn rds_access(&self) -> bool {
-        self.rds_access
     }
 
     /// Use the subscription quantity to set the RDS quota for this claim.
@@ -56,7 +49,7 @@ impl From<AccountTier> for Limits {
             | AccountTier::PendingPaymentPro
             | AccountTier::Deployer => Self::default(),
             AccountTier::Pro | AccountTier::CancelledPro | AccountTier::Team => {
-                Self::new(MAX_PROJECTS_EXTRA, true, 1)
+                Self::new(MAX_PROJECTS_EXTRA, 1)
             }
         }
     }
@@ -81,6 +74,6 @@ impl ClaimExt for Claim {
     }
 
     fn can_provision_rds(&self) -> bool {
-        self.is_admin() || self.limits.rds_access
+        self.is_admin() || self.limits.rds_quota > 0
     }
 }

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -43,7 +43,7 @@ impl Limits {
     }
 
     /// Use the subscription quantity to set the RDS quota for this claim.
-    pub fn quota(&mut self, quantity: u32) {
+    pub fn rds_quota(&mut self, quantity: u32) {
         self.rds_quota = quantity;
     }
 }

--- a/common/src/limits.rs
+++ b/common/src/limits.rs
@@ -11,6 +11,8 @@ pub struct Limits {
     project_limit: u32,
     /// Whether this user has permission to provision RDS instances.
     rds_access: bool,
+    /// The quantity of RDS instances this user can provision.
+    rds_quota: u32,
 }
 
 impl Default for Limits {
@@ -18,15 +20,17 @@ impl Default for Limits {
         Self {
             project_limit: MAX_PROJECTS_DEFAULT,
             rds_access: false,
+            rds_quota: 0,
         }
     }
 }
 
 impl Limits {
-    pub fn new(project_limit: u32, rds_limit: bool) -> Self {
+    pub fn new(project_limit: u32, rds_access: bool, rds_quota: u32) -> Self {
         Self {
             project_limit,
-            rds_access: rds_limit,
+            rds_access,
+            rds_quota,
         }
     }
 
@@ -36,6 +40,11 @@ impl Limits {
 
     pub fn rds_access(&self) -> bool {
         self.rds_access
+    }
+
+    /// Use the subscription quantity to set the RDS quota for this claim.
+    pub fn quota(&mut self, quantity: u32) {
+        self.rds_quota = quantity;
     }
 }
 
@@ -47,7 +56,7 @@ impl From<AccountTier> for Limits {
             | AccountTier::PendingPaymentPro
             | AccountTier::Deployer => Self::default(),
             AccountTier::Pro | AccountTier::CancelledPro | AccountTier::Team => {
-                Self::new(MAX_PROJECTS_EXTRA, true)
+                Self::new(MAX_PROJECTS_EXTRA, true, 1)
             }
         }
     }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Add a subscriptions table to auth to support multiple types of subscriptions, and update the claim limits with an rds quota.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Existing tests pass without modification, but new tests will be needed as we add functionality to add more than a pro subscription.
