### PR TITLE
Improve shuttle-runtime out-of-date hint

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1026,8 +1026,9 @@ impl Shuttle {
                         };
                     } else {
                         printdoc! {"
-                            Hint: A newer version of shuttle-runtime is available. Run this command to update:
-                                cargo add shuttle-runtime@{}",
+                            Hint: A newer version of shuttle-runtime is available.
+                            Change its version to {} in Cargo.toml to update it, or
+                            run this command: cargo add shuttle-runtime@{}",
                             mismatch.cargo_shuttle
                         };
                     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1029,7 +1029,8 @@ impl Shuttle {
                             Hint: A newer version of shuttle-runtime is available.
                             Change its version to {} in Cargo.toml to update it, or
                             run this command: cargo add shuttle-runtime@{}",
-                            mismatch.cargo_shuttle
+                            mismatch.cargo_shuttle,
+                            mismatch.cargo_shuttle,
                         };
                     }
                 } else {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1026,8 +1026,8 @@ impl Shuttle {
                         };
                     } else {
                         printdoc! {"
-                            Hint: A newer version of shuttle-runtime is available.
-                                  Change its version to {} in Cargo.toml to update it.",
+                            Hint: A newer version of shuttle-runtime is available. Run this command to update:
+                                cargo add shuttle-runtime@{}",
                             mismatch.cargo_shuttle
                         };
                     }


### PR DESCRIPTION
## Description of change

<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Hey there! This change just adds a copy-paste friendly command for when the
shuttle runtime is out of date. It looks something like `cargo add shuttle-runtime@{version}`.

This lets the user quickly copy-paste the given line, instead of having to
manually edit `Cargo.toml`. Note that if the user is using other shuttle
crates (ie `shuttle-aws-rds`, `shuttle-rocket`, etc), this copy-paste line will
_not_ update those, and the user _will_ have to update them by manually editing
`Cargo.toml`. I didn't add `shuttle-*` crates to the `cargo update`
command, because that would install every crate, even if the user isn't using
them.

Maybe someone on the team knows if it's easy enough to tell which `shuttle-*`
crates a project is using, and then we can amend the command to explicitly
include those crates?
