### PR TITLE
fix(gateway): rename scope field to shuttle.project.name

### DIFF
--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -434,7 +434,7 @@ async fn delete_project(
     Ok(AxumJson("project successfully deleted".to_owned()))
 }
 
-#[instrument(skip_all, fields(scope = %scoped_user.scope))]
+#[instrument(skip_all, fields(shuttle.project.name = %scoped_user.scope))]
 async fn route_project(
     State(RouterState {
         service,


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Change `scope` field for route_project to shuttle.project.name, to match our convention.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Not tested, but the same is done here: <https://github.com/shuttle-hq/shuttle/blob/main/gateway/src/api/latest.rs#L316>, and that works as expected in Datadog.
