### PR TITLE
chore: disable unused builder service until it is needed

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,7 +45,7 @@ COPY --from=chef-planner /build .
 RUN cargo build \
     $(if [ "$CARGO_PROFILE" = "release" ]; then echo --release; fi) \
     --bin shuttle-auth \
-    --bin shuttle-builder \
+    # --bin shuttle-builder \
     --bin shuttle-deployer \
     --bin shuttle-gateway \
     --bin shuttle-logger \
@@ -72,17 +72,17 @@ FROM shuttle-auth AS shuttle-auth-dev
 
 
 #### BUILDER
-ARG RUSTUP_TOOLCHAIN
-FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-bookworm AS shuttle-builder
-ARG SHUTTLE_SERVICE_VERSION
-ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
-ARG CARGO_PROFILE
-ARG prepare_args
-COPY builder/prepare.sh /prepare.sh
-RUN /prepare.sh "${prepare_args}"
-COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-builder /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/shuttle-builder"]
-FROM shuttle-builder AS shuttle-builder-dev
+# ARG RUSTUP_TOOLCHAIN
+# FROM docker.io/library/rust:${RUSTUP_TOOLCHAIN}-bookworm AS shuttle-builder
+# ARG SHUTTLE_SERVICE_VERSION
+# ENV SHUTTLE_SERVICE_VERSION=${SHUTTLE_SERVICE_VERSION}
+# ARG CARGO_PROFILE
+# ARG prepare_args
+# COPY builder/prepare.sh /prepare.sh
+# RUN /prepare.sh "${prepare_args}"
+# COPY --from=chef-builder /build/target/${CARGO_PROFILE}/shuttle-builder /usr/local/bin
+# ENTRYPOINT ["/usr/local/bin/shuttle-builder"]
+# FROM shuttle-builder AS shuttle-builder-dev
 
 
 #### DEPLOYER

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ cargo-clean:
 
 images: the-shuttle-images postgres panamax otel
 
-the-shuttle-images: shuttle-auth shuttle-builder shuttle-deployer shuttle-gateway shuttle-logger shuttle-provisioner shuttle-resource-recorder
+the-shuttle-images: shuttle-auth shuttle-deployer shuttle-gateway shuttle-logger shuttle-provisioner shuttle-resource-recorder # shuttle-builder
 
 shuttle-%:
 	$(DOCKER_BUILD) \

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -8,7 +8,7 @@ use shuttle_common::{
 };
 use shuttle_deployer::{start, start_proxy, Args, Persistence, RuntimeManager, StateChangeLayer};
 use shuttle_proto::{
-    builder::builder_client::BuilderClient,
+    // builder::builder_client::BuilderClient,
     logger::{logger_client::LoggerClient, Batcher},
 };
 use tokio::select;
@@ -46,18 +46,19 @@ async fn main() {
     let logger_client = LoggerClient::new(channel);
     let logger_batcher = Batcher::wrap(logger_client.clone());
 
-    let builder_client = match args.builder_uri.connect().await {
-        Ok(channel) => Some(BuilderClient::new(
-            ServiceBuilder::new()
-                .layer(ClaimLayer)
-                .layer(InjectPropagationLayer)
-                .service(channel),
-        )),
-        Err(err) => {
-            error!("Couldn't connect to the shuttle-builder: {err}");
-            None
-        }
-    };
+    let builder_client = None;
+    // let builder_client = match args.builder_uri.connect().await {
+    //     Ok(channel) => Some(BuilderClient::new(
+    //         ServiceBuilder::new()
+    //             .layer(ClaimLayer)
+    //             .layer(InjectPropagationLayer)
+    //             .service(channel),
+    //     )),
+    //     Err(err) => {
+    //         error!("Couldn't connect to the shuttle-builder: {err}");
+    //         None
+    //     }
+    // };
 
     setup_tracing(
         tracing_subscriber::registry()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 volumes:
   auth-vol:
-  builder-store-vol:
+  # builder-store-vol:
   gateway-vol:
   postgres-vol:
   panamax-crates-vol:
@@ -64,37 +64,37 @@ services:
       # Using them will result in error because they are not handled gracefully.
       # start_period: 10s
       # start_interval: 2s
-  builder:
-    image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"
-    depends_on:
-      - auth
-    ports:
-      - 8009:8000
-    deploy:
-      restart_policy:
-        condition: on-failure
-        delay: 5s
-        max_attempts: 3
-      update_config:
-        order: start-first
-        failure_action: rollback
-        delay: 10s
-      rollback_config:
-        parallelism: 0
-        order: stop-first
-      placement:
-        constraints:
-          - node.hostname==builder
-    networks:
-      user-net:
-    volumes:
-      - builder-store-vol:/nix/store
-    environment:
-      - RUST_LOG=${RUST_LOG}
-      - SHUTTLE_ENV=${SHUTTLE_ENV}
-    command:
-      - "--address=0.0.0.0:8000"
-      - "--auth-uri=http://auth:8000"
+  # builder:
+  #   image: "${CONTAINER_REGISTRY}/builder:${BUILDER_TAG}"
+  #   depends_on:
+  #     - auth
+  #   ports:
+  #     - 8009:8000
+  #   deploy:
+  #     restart_policy:
+  #       condition: on-failure
+  #       delay: 5s
+  #       max_attempts: 3
+  #     update_config:
+  #       order: start-first
+  #       failure_action: rollback
+  #       delay: 10s
+  #     rollback_config:
+  #       parallelism: 0
+  #       order: stop-first
+  #     placement:
+  #       constraints:
+  #         - node.hostname==builder
+  #   networks:
+  #     user-net:
+  #   volumes:
+  #     - builder-store-vol:/nix/store
+  #   environment:
+  #     - RUST_LOG=${RUST_LOG}
+  #     - SHUTTLE_ENV=${SHUTTLE_ENV}
+  #   command:
+  #     - "--address=0.0.0.0:8000"
+  #     - "--auth-uri=http://auth:8000"
   gateway:
     image: "${CONTAINER_REGISTRY}/gateway:${GATEWAY_TAG}"
     depends_on:


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Builder will be rewritten, so having this version build things is a waste of resources until the new version is ready.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Local stack goes up and deployments go through. Deployers never depended on the builder.
