### PR TITLE
fix(otel): increase trace_buffer for dd exporter

### DIFF
--- a/extras/otel/otel-collector-config.yaml
+++ b/extras/otel/otel-collector-config.yaml
@@ -63,6 +63,7 @@ exporters:
       key: ${env:DD_API_KEY}
     traces:
       span_name_as_resource_name: true
+      trace_buffer: 25
       # peer_tags_aggregation: true
   otlp:
     endpoint: "api.honeycomb.io:443"


### PR DESCRIPTION
We're seeing messages of "Payload in channel full. Dropped 1 payload.", which indicates that we should increase the size of the buffer. The default is 10, the value of 25 is arbitrary, we'll see how it goes.


