### PR TITLE
chore: remove utopia openAPI docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5418,41 +5418,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e7d90385b59f0a6bf3d3b757f3ca4ece2048265d70db20a2016043d4509a40"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3d8c6fd84090ae348e63a84336b112b5c3918b3bf0493a581f7bd8ee623c29"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "shellexpand",
- "syn 2.0.39",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873feff8cb7bf86fdf0a71bb21c95159f4e4a37dd7a4bd1855a940909b583ada"
-dependencies = [
- "sha2 0.10.8",
- "walkdir",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6048,7 +6013,6 @@ dependencies = [
  "tracing-subscriber",
  "ttl_cache",
  "url",
- "utoipa",
  "uuid",
  "wiremock",
  "zeroize",
@@ -6119,8 +6083,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ulid",
- "utoipa",
- "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -6183,8 +6145,6 @@ dependencies = [
  "tracing-subscriber",
  "ttl_cache",
  "ulid",
- "utoipa",
- "utoipa-swagger-ui",
  "uuid",
  "x509-parser",
 ]
@@ -7769,47 +7729,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "utoipa"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff05e3bac2c9428f57ade702667753ca3f5cf085e2011fe697de5bfd49aa72d"
-dependencies = [
- "indexmap 2.1.0",
- "serde",
- "serde_json",
- "utoipa-gen",
-]
-
-[[package]]
-name = "utoipa-gen"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0b6f4667edd64be0e820d6631a60433a269710b6ee89ac39525b872b76d61d"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.39",
- "uuid",
-]
-
-[[package]]
-name = "utoipa-swagger-ui"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154517adf0d0b6e22e8e1f385628f14fcaa3db43531dc74303d3edef89d6dfe5"
-dependencies = [
- "axum",
- "mime_guess",
- "regex",
- "rust-embed",
- "serde",
- "serde_json",
- "utoipa",
- "zip",
-]
-
-[[package]]
 name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8957,18 +8876,6 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,6 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
   "json"
 ] }
 ttl_cache = "0.5.1"
-utoipa = { version = "4.0.0", features = [ "uuid", "chrono" ] }
-utoipa-swagger-ui = { version = "4.0.0", features = ["axum"] }
 ulid = "1.0.0"
 url = "2.4.0"
 uuid = "1.2.2"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -47,7 +47,6 @@ tracing-core = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 ttl_cache = { workspace = true, optional = true }
-utoipa = { workspace = true, optional = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 zeroize = { workspace = true }
@@ -88,7 +87,6 @@ claims = [
     "tracing-opentelemetry",
 ]
 display = ["chrono/clock", "comfy-table", "crossterm"]
-openapi = ["utoipa/chrono", "utoipa/uuid"]
 models = ["async-trait", "http", "reqwest", "service", "thiserror"]
 persist = ["sqlx", "rand"]
 service = ["chrono/serde", "display", "tracing", "tracing-subscriber", "uuid"]

--- a/common/src/database.rs
+++ b/common/src/database.rs
@@ -2,13 +2,9 @@ use std::{fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::database::Type))]
 pub enum Type {
     AwsRds(AwsRdsEngine),
     Shared(SharedEngine),
@@ -17,7 +13,6 @@ pub enum Type {
 #[derive(Clone, Copy, Debug, Deserialize, Display, Serialize, EnumString, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum AwsRdsEngine {
     Postgres,
     MySql,
@@ -27,7 +22,6 @@ pub enum AwsRdsEngine {
 #[derive(Clone, Copy, Debug, Deserialize, Display, Serialize, EnumString, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum SharedEngine {
     Postgres,
     MongoDb,

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -2,15 +2,11 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Display, Serialize, EnumString)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 #[strum(ascii_case_insensitive)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::deployment::State))]
 pub enum State {
     Queued,
     Building,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -33,8 +33,6 @@ use std::fmt::Debug;
 
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "openapi")]
-use utoipa::openapi::{Object, ObjectBuilder};
 use zeroize::Zeroize;
 
 pub type ApiUrl = String;
@@ -163,17 +161,6 @@ impl DatabaseInfo {
             self.database_name,
         )
     }
-}
-
-#[cfg(feature = "openapi")]
-pub fn ulid_type() -> Object {
-    ObjectBuilder::new()
-        .schema_type(utoipa::openapi::SchemaType::String)
-        .format(Some(utoipa::openapi::SchemaFormat::Custom(
-            "ulid".to_string(),
-        )))
-        .description(Some("String represention of an Ulid according to the spec found here: https://github.com/ulid/spec."))
-        .build()
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/common/src/log.rs
+++ b/common/src/log.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 use strum::EnumString;
 use tracing::{field::Visit, span, warn, Event, Level, Metadata, Subscriber};
 use tracing_subscriber::Layer;
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::tracing::JsonVisitor;
@@ -18,7 +16,6 @@ use crate::tracing::JsonVisitor;
 /// Used to determine settings based on which backend crate does what
 #[derive(Clone, Debug, Default, EnumString, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "display", derive(strum::Display))]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub enum Backend {
     /// Is considered an error
     #[default]
@@ -35,19 +32,14 @@ pub enum Backend {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::log::LogItem))]
 pub struct LogItem {
     /// Deployment id
-    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::Uuid))]
     pub id: Uuid,
 
     /// Internal service that produced this log
-    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::log::InternalLogOrigin))]
     pub internal_origin: Backend,
 
     /// Time log was captured
-    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::DateTime))]
     pub timestamp: DateTime<Utc>,
 
     /// The log line

--- a/common/src/models/admin.rs
+++ b/common/src/models/admin.rs
@@ -1,11 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
-
 #[derive(Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::admin::ProjectResponse))]
 pub struct ProjectResponse {
     pub project_name: String,
     pub account_name: String,

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -1,6 +1,3 @@
-use crate::deployment::State;
-#[cfg(feature = "openapi")]
-use crate::ulid_type;
 use chrono::{DateTime, Utc};
 use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS,
@@ -10,9 +7,9 @@ use comfy_table::{
 use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, str::FromStr};
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 use uuid::Uuid;
+
+use crate::deployment::State;
 
 /// Max length of strings in the git metadata
 pub const GIT_STRINGS_MAX_LENGTH: usize = 80;
@@ -21,16 +18,10 @@ pub const CREATE_SERVICE_BODY_LIMIT: usize = 50_000_000;
 const GIT_OPTION_NONE_TEXT: &str = "N/A";
 
 #[derive(Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::deployment::Response))]
 pub struct Response {
-    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::Uuid))]
     pub id: Uuid,
-    #[cfg_attr(feature = "openapi", schema(schema_with = ulid_type))]
     pub service_id: String,
-    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::deployment::State))]
     pub state: State,
-    #[cfg_attr(feature = "openapi", schema(value_type = KnownFormat::DateTime))]
     pub last_update: DateTime<Utc>,
     pub git_commit_id: Option<String>,
     pub git_commit_msg: Option<String>,
@@ -210,8 +201,6 @@ pub fn get_deployments_table(
 }
 
 #[derive(Default, Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::deployment::DeploymentRequest))]
 pub struct DeploymentRequest {
     pub data: Vec<u8>,
     pub no_test: bool,

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -11,27 +11,16 @@ use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
 
-#[cfg(feature = "openapi")]
-use crate::ulid_type;
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
-
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::project::Response))]
 pub struct Response {
-    #[cfg_attr(feature = "openapi", schema(schema_with = ulid_type))]
     pub id: String,
     pub name: String,
-    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::models::project::State))]
     pub state: State,
     pub idle_minutes: Option<u64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, EnumString)]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::project::State))]
 pub enum State {
     Creating { recreate_count: usize },
     Attaching { recreate_count: usize },

--- a/common/src/models/service.rs
+++ b/common/src/models/service.rs
@@ -1,29 +1,19 @@
-#[cfg(feature = "openapi")]
-use crate::ulid_type;
 use crossterm::style::{Color, Stylize};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::FromStr;
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 
 use crate::models::deployment;
 
 #[derive(Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::service::Response))]
 pub struct Response {
-    #[cfg_attr(feature = "openapi", schema(schema_with = ulid_type))]
     pub id: String,
     pub name: String,
 }
 
 #[derive(Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::service::Summary))]
 pub struct Summary {
     pub name: String,
-    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::models::deployment::Response))]
     pub deployment: Option<deployment::Response>,
     pub uri: String,
 }

--- a/common/src/models/stats.rs
+++ b/common/src/models/stats.rs
@@ -1,18 +1,12 @@
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 use uuid::Uuid;
 
 #[derive(Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::stats::LoadRequest))]
 pub struct LoadRequest {
     pub id: Uuid,
 }
 
 #[derive(Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::models::stats::LoadResponse))]
 pub struct LoadResponse {
     pub builds_count: usize,
     pub has_capacity: bool,

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -2,35 +2,25 @@ use std::{fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-#[cfg(feature = "openapi")]
-use utoipa::ToSchema;
 
 use crate::database;
 
 /// Common type to hold all the information we need for a generic resource
 #[derive(Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::resource::Response))]
 pub struct Response {
     /// The type of this resource.
-    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::resource::Type))]
     pub r#type: Type,
 
     /// The config used when creating this resource. Use the [Self::r#type] to know how to parse this data.
-    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub config: Value,
 
     /// The data associated with this resource. Use the [Self::r#type] to know how to parse this data.
-    #[cfg_attr(feature = "openapi", schema(value_type = Object))]
     pub data: Value,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(feature = "openapi", schema(as = shuttle_common::resource::Type))]
 pub enum Type {
-    #[cfg_attr(feature = "openapi", schema(value_type = shuttle_common::database::Type))]
     Database(database::Type),
     Secrets,
     StaticFolder,

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "Service with instances created per project for handling the compilation, loading, and execution of Shuttle services"
 
 [dependencies]
-shuttle-common = { workspace = true, features = ["backend", "models", "openapi"] }
+shuttle-common = { workspace = true, features = ["backend", "models"] }
 shuttle-proto = { workspace = true, features = ["resource-recorder"] }
 shuttle-service = { workspace = true, features = ["builder", "runner"] }
 
@@ -53,8 +53,6 @@ tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
 ] }
-utoipa = { workspace = true }
-utoipa-swagger-ui = { workspace = true }
 ulid = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 

--- a/deployer/src/handlers/error.rs
+++ b/deployer/src/handlers/error.rs
@@ -6,7 +6,6 @@ use axum::response::{IntoResponse, Response};
 use serde::{ser::SerializeMap, Serialize};
 use shuttle_common::models::error::ApiError;
 use tracing::error;
-use utoipa::ToSchema;
 
 #[derive(thiserror::Error, Debug, ToSchema)]
 pub enum Error {

--- a/deployer/src/handlers/error.rs
+++ b/deployer/src/handlers/error.rs
@@ -7,7 +7,7 @@ use serde::{ser::SerializeMap, Serialize};
 use shuttle_common::models::error::ApiError;
 use tracing::error;
 
-#[derive(thiserror::Error, Debug, ToSchema)]
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Streaming error: {0}")]
     Streaming(#[from] axum::Error),

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -20,8 +20,6 @@ use serde::{de::DeserializeOwned, Deserialize};
 use shuttle_service::builder::clean_crate;
 use tracing::{error, field, info, info_span, instrument, trace, warn};
 use ulid::Ulid;
-use utoipa::{IntoParams, OpenApi};
-use utoipa_swagger_ui::SwaggerUi;
 use uuid::Uuid;
 
 use shuttle_common::{
@@ -51,37 +49,6 @@ mod error;
 mod local;
 mod project;
 
-#[derive(OpenApi)]
-#[openapi(
-    paths(
-        get_services,
-        get_service,
-        create_service,
-        stop_service,
-        get_service_resources,
-        delete_service_resource,
-        get_deployments,
-        get_deployment,
-        delete_deployment,
-        get_logs_subscribe,
-        get_logs,
-        clean_project,
-    ),
-    components(schemas(
-        shuttle_common::models::service::Summary,
-        shuttle_common::resource::Response,
-        shuttle_common::resource::Type,
-        shuttle_common::database::Type,
-        shuttle_common::database::AwsRdsEngine,
-        shuttle_common::database::SharedEngine,
-        shuttle_common::models::service::Response,
-        shuttle_common::models::deployment::Response,
-        shuttle_common::log::LogItem,
-        shuttle_common::deployment::State,
-    ))
-)]
-pub struct ApiDoc;
-
 #[derive(Debug, Clone, Copy, Deserialize, IntoParams)]
 pub struct PaginationDetails {
     /// Page to fetch, starting from 0.
@@ -107,12 +74,6 @@ impl RouterBuilder {
         auth_uri: Uri,
     ) -> Self {
         let router = Router::new()
-            // TODO: The `/swagger-ui` responds with a 303 See Other response which is followed in
-            // browsers but leads to 404 Not Found. This must be investigated.
-            .merge(SwaggerUi::new("/projects/:project_name/swagger-ui").url(
-                "/projects/:project_name/api-docs/openapi.json",
-                ApiDoc::openapi(),
-            ))
             .route(
                 "/projects/:project_name/services",
                 get(get_services.layer(ScopedLayer::new(vec![Scope::Service]))),
@@ -221,17 +182,6 @@ impl RouterBuilder {
 }
 
 #[instrument(skip_all)]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/services",
-    responses(
-        (status = 200, description = "Lists the services owned by a project.", body = [shuttle_common::models::service::Response]),
-        (status = 500, description = "Database error.", body = String)
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the services."),
-    )
-)]
 pub async fn get_services(
     Extension(persistence): Extension<Persistence>,
 ) -> Result<Json<Vec<shuttle_common::models::service::Response>>> {
@@ -246,19 +196,6 @@ pub async fn get_services(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, shuttle.service.name = %service_name))]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/services/{service_name}",
-    responses(
-        (status = 200, description = "Gets a specific service summary.", body = shuttle_common::models::service::Summary),
-        (status = 500, description = "Database error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the service."),
-        ("service_name" = String, Path, description = "Name of the service.")
-    )
-)]
 pub async fn get_service(
     Extension(persistence): Extension<Persistence>,
     Extension(proxy_fqdn): Extension<FQDN>,
@@ -283,19 +220,6 @@ pub async fn get_service(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, shuttle.service.name = %service_name))]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/services/{service_name}/resources",
-    responses(
-        (status = 200, description = "Gets a specific service resources.", body = shuttle_common::resource::Response),
-        (status = 500, description = "Database error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the service."),
-        ("service_name" = String, Path, description = "Name of the service.")
-    )
-)]
 pub async fn get_service_resources(
     Extension(mut persistence): Extension<Persistence>,
     Extension(claim): Extension<Claim>,
@@ -327,20 +251,6 @@ pub async fn get_service_resources(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, shuttle.service.name = %service_name, %resource_type))]
-#[utoipa::path(
-    delete,
-    path = "/projects/{project_name}/services/{service_name}/resources/{resource_type}",
-    responses(
-        (status = 200, description = "Deletes a resource owned by a service."),
-        (status = 500, description = "Database error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the service."),
-        ("service_name" = String, Path, description = "Name of the service."),
-        ("resource_type" = String, Path, description = "Resource type.")
-    )
-)]
 pub async fn delete_service_resource(
     Extension(mut persistence): Extension<Persistence>,
     Extension(claim): Extension<Claim>,
@@ -384,19 +294,6 @@ pub async fn delete_service_resource(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, shuttle.service.name = %service_name))]
-#[utoipa::path(
-    post,
-    path = "/projects/{project_name}/services/{service_name}",
-    responses(
-        (status = 200, description = "Creates a specific service owned by a specific project.", body = shuttle_common::models::deployment::Response),
-        (status = 500, description = "Database or streaming error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the service."),
-        ("service_name" = String, Path, description = "Name of the service.")
-    )
-)]
 pub async fn create_service(
     Extension(persistence): Extension<Persistence>,
     Extension(deployment_manager): Extension<DeploymentManager>,
@@ -462,19 +359,6 @@ pub async fn create_service(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, shuttle.service.name = %service_name))]
-#[utoipa::path(
-    delete,
-    path = "/projects/{project_name}/services/{service_name}",
-    responses(
-        (status = 200, description = "Stops a specific service owned by a specific project.", body = shuttle_common::models::service::Summary),
-        (status = 500, description = "Database error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the service."),
-        ("service_name" = String, Path, description = "Name of the service.")
-    )
-)]
 pub async fn stop_service(
     Extension(persistence): Extension<Persistence>,
     Extension(deployment_manager): Extension<DeploymentManager>,
@@ -500,19 +384,6 @@ pub async fn stop_service(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, page, limit))]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/deployments",
-    responses(
-        (status = 200, description = "Gets deployments information associated to a specific project.", body = shuttle_common::models::deployment::Response),
-        (status = 500, description = "Database error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the deployments."),
-        PaginationDetails
-    )
-)]
 pub async fn get_deployments(
     Extension(persistence): Extension<Persistence>,
     CustomErrorPath(project_name): CustomErrorPath<String>,
@@ -535,19 +406,6 @@ pub async fn get_deployments(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, %deployment_id))]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/deployments/{deployment_id}",
-    responses(
-        (status = 200, description = "Gets a specific deployment information.", body = shuttle_common::models::deployment::Response),
-        (status = 500, description = "Database or streaming error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the deployment."),
-        ("deployment_id" = String, Path, description = "The deployment id in uuid format.")
-    )
-)]
 pub async fn get_deployment(
     Extension(persistence): Extension<Persistence>,
     CustomErrorPath((project_name, deployment_id)): CustomErrorPath<(String, Uuid)>,
@@ -560,19 +418,6 @@ pub async fn get_deployment(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, %deployment_id))]
-#[utoipa::path(
-    delete,
-    path = "/projects/{project_name}/deployments/{deployment_id}",
-    responses(
-        (status = 200, description = "Deletes a specific deployment.", body = shuttle_common::models::deployment::Response),
-        (status = 500, description = "Database or streaming error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the deployment."),
-        ("deployment_id" = String, Path, description = "The deployment id in uuid format.")
-    )
-)]
 pub async fn delete_deployment(
     Extension(deployment_manager): Extension<DeploymentManager>,
     Extension(persistence): Extension<Persistence>,
@@ -588,19 +433,6 @@ pub async fn delete_deployment(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, %deployment_id))]
-#[utoipa::path(
-    put,
-    path = "/projects/{project_name}/deployments/{deployment_id}",
-    responses(
-        (status = 200, description = "Started a specific deployment.", body = shuttle_common::models::deployment::Response),
-        (status = 500, description = "Database or streaming error.", body = String),
-        (status = 404, description = "Could not find deployment to start", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the deployment."),
-        ("deployment_id" = String, Path, description = "The deployment id in uuid format.")
-    )
-)]
 pub async fn start_deployment(
     Extension(persistence): Extension<Persistence>,
     Extension(deployment_manager): Extension<DeploymentManager>,
@@ -628,19 +460,6 @@ pub async fn start_deployment(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, %deployment_id))]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/deployments/{deployment_id}/logs",
-    responses(
-        (status = 200, description = "Gets the logs a specific deployment.", body = [shuttle_common::log::LogItem]),
-        (status = 500, description = "Database or streaming error.", body = String),
-        (status = 404, description = "Record could not be found.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the deployment."),
-        ("deployment_id" = String, Path, description = "The deployment id in uuid format.")
-    )
-)]
 pub async fn get_logs(
     Extension(deployment_manager): Extension<DeploymentManager>,
     Extension(claim): Extension<Claim>,
@@ -671,17 +490,6 @@ pub async fn get_logs(
 
 // don't instrument id to prevent it from showing up in deployment log
 #[instrument(skip_all, fields(shuttle.project.name = %project_name))]
-#[utoipa::path(
-    get,
-    path = "/projects/{project_name}/ws/deployments/{deployment_id}/logs",
-    responses(
-        (status = 200, description = "Subscribes to a specific deployment logs.")
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the deployment."),
-        ("deployment_id" = String, Path, description = "The deployment id in uuid format.")
-    )
-)]
 pub async fn get_logs_subscribe(
     Extension(deployment_manager): Extension<DeploymentManager>,
     Extension(claim): Extension<Claim>,
@@ -765,17 +573,6 @@ async fn logs_websocket_handler(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name))]
-#[utoipa::path(
-    post,
-    path = "/projects/{project_name}/clean",
-    responses(
-        (status = 200, description = "Clean a specific project build artifacts.", body = [String]),
-        (status = 500, description = "Clean project error.", body = String),
-    ),
-    params(
-        ("project_name" = String, Path, description = "Name of the project that owns the service."),
-    )
-)]
 pub async fn clean_project(
     Extension(deployment_manager): Extension<DeploymentManager>,
     CustomErrorPath(project_name): CustomErrorPath<String>,

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -49,7 +49,7 @@ mod error;
 mod local;
 mod project;
 
-#[derive(Debug, Clone, Copy, Deserialize, IntoParams)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct PaginationDetails {
     /// Page to fetch, starting from 0.
     pub page: Option<u32>,

--- a/deployer/src/persistence/deployment.rs
+++ b/deployer/src/persistence/deployment.rs
@@ -5,7 +5,6 @@ use chrono::{DateTime, Utc};
 use sqlx::{sqlite::SqliteRow, FromRow, Row};
 use tracing::error;
 use ulid::Ulid;
-use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::state::State;

--- a/deployer/src/persistence/deployment.rs
+++ b/deployer/src/persistence/deployment.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use super::state::State;
 
 // We are using `Option` for the additional `git_*` fields for backward compat.
-#[derive(Clone, Debug, Default, Eq, PartialEq, ToSchema)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Deployment {
     pub id: Uuid,
     pub service_id: Ulid,

--- a/deployer/src/persistence/state.rs
+++ b/deployer/src/persistence/state.rs
@@ -1,5 +1,4 @@
 use strum::{Display, EnumString};
-use utoipa::ToSchema;
 use uuid::Uuid;
 
 /// States a deployment can be in

--- a/deployer/src/persistence/state.rs
+++ b/deployer/src/persistence/state.rs
@@ -2,7 +2,7 @@ use strum::{Display, EnumString};
 use uuid::Uuid;
 
 /// States a deployment can be in
-#[derive(sqlx::Type, Debug, Display, Clone, Copy, EnumString, PartialEq, Eq, ToSchema)]
+#[derive(sqlx::Type, Debug, Display, Clone, Copy, EnumString, PartialEq, Eq)]
 #[strum(ascii_case_insensitive)]
 pub enum State {
     /// Deployment is queued to be build

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 shuttle-common = { workspace = true, features = [
     "backend",
     "models",
-    "openapi",
     "persist",
 ] }
 shuttle-proto = { workspace = true, features = ["provisioner"] }
@@ -51,8 +50,6 @@ tracing = { workspace = true, features = ["default"] }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["default", "env-filter"] }
 ttl_cache = { workspace = true }
-utoipa = { workspace = true }
-utoipa-swagger-ui = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 x509-parser = "0.15.1"
 tonic = { workspace = true }

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -73,7 +73,7 @@ pub struct StatusResponse {
     status: ComponentStatus,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, IntoParams)]
+#[derive(Debug, Clone, Copy, Deserialize)]
 pub struct PaginationDetails {
     /// Page to fetch, starting from 0.
     pub page: Option<u32>,
@@ -245,7 +245,7 @@ async fn destroy_project(
     Ok(AxumJson(response))
 }
 
-#[derive(Deserialize, IntoParams)]
+#[derive(Deserialize)]
 struct DeleteProjectParams {
     // Was added in v0.30.0
     // We have not needed it since 0.34.1, but have to keep in for any old CLI users


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

These docs were not being actively used and they make the code harder to work with.
To help Console development we should instead add `typeshare` soon. I've tried it on a different project and it should work well.
