### PR TITLE
feat: limit concurrent active cch23 projects

### DIFF
--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -134,7 +134,7 @@ impl From<ErrorKind> for ApiError {
             ErrorKind::Forbidden => (StatusCode::FORBIDDEN, "Forbidden"),
             ErrorKind::NotReady => (StatusCode::INTERNAL_SERVER_ERROR, "Service not ready"),
             ErrorKind::DeleteProjectFailed => (StatusCode::INTERNAL_SERVER_ERROR, "Deleting project failed"),
-            ErrorKind::CapacityLimit => (StatusCode::SERVICE_UNAVAILABLE, "Our server is at capacity and cannot serve your request at this time"),
+            ErrorKind::CapacityLimit => (StatusCode::SERVICE_UNAVAILABLE, "Our server is at capacity and cannot serve your request at this time. Please try again in a few minutes."),
         };
         Self {
             message: error_message.to_string(),

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -411,6 +411,17 @@ impl GatewayService {
         Ok(ready_count)
     }
 
+    /// The number of cch projects that are currently in the ready state
+    pub async fn count_ready_cch_projects(&self) -> Result<u32, Error> {
+        let ready_count: u32 =
+            query("SELECT COUNT(*) FROM projects, JSON_EACH(project_state) WHERE key = 'ready' AND project_name LIKE 'cch23-%'")
+                .fetch_one(&self.db)
+                .await?
+                .get::<_, usize>(0);
+
+        Ok(ready_count)
+    }
+
     pub async fn find_project(
         &self,
         project_name: &ProjectName,
@@ -983,15 +994,24 @@ impl GatewayService {
         is_cch_project: bool,
         account_tier: &AccountTier,
     ) -> Result<(), Error> {
-        let current_container_count = self.count_ready_projects().await?;
+        const CCH_CONTROL_FILE: &str = "/var/lib/shuttle/BLOCK_CCH23_PROJECT_TRAFFIC";
+        const CCH_CONCURRENT_LIMIT: u32 = 20;
 
-        let has_capacity = if is_cch_project
-            && std::fs::metadata("/var/lib/shuttle/BLOCK_CCH23_PROJECT_TRAFFIC").is_ok()
-        {
-            // If this control file exists, block routing to cch23 projects.
-            // Used for emergency load mitigation
-            return Err(Error::from_kind(ErrorKind::CapacityLimit));
-        } else if current_container_count < self.cch_container_limit {
+        if is_cch_project {
+            if std::fs::metadata(CCH_CONTROL_FILE).is_ok() {
+                // If this control file exists, block routing to cch23 projects.
+                // Used for emergency load mitigation
+                return Err(Error::from_kind(ErrorKind::CapacityLimit));
+            } else if self.count_ready_cch_projects().await? >= CCH_CONCURRENT_LIMIT {
+                // If max concurrent active cch project is reached
+                return Err(Error::from_kind(ErrorKind::CapacityLimit));
+            } else {
+                return Ok(());
+            }
+        }
+
+        let current_container_count = self.count_ready_projects().await?;
+        let has_capacity = if current_container_count < self.cch_container_limit {
             true
         } else if current_container_count < self.soft_container_limit {
             !is_cch_project


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

If 20 cch23 projects are active, all traffic to all cch23 projects is blocked. They will then proceed to start idling (still 5 minutes).
This is not a perfect solution (everyone get locked out), but this limit should be hard to reach anyways, and it should quickly recover.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested that admin can still excede the limit, and a normal user can not access the projects when the limit is reached.

lmk if a unit test must be written
