### PR TITLE
gateway: add operation_name field for task polling

### DIFF
--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -905,7 +905,10 @@ impl GatewayService {
 
     /// Create a builder for a new [ProjectTask]
     pub fn new_task(self: &Arc<Self>) -> TaskBuilder {
-        TaskBuilder::new(self.clone())
+        TaskBuilder::new(
+            self.clone(),
+            Span::current().metadata().map(|m| m.name().to_string()),
+        )
     }
 
     /// Find a project by name. And start the project if it is idle, waiting for it to start up

--- a/gateway/src/task.rs
+++ b/gateway/src/task.rs
@@ -496,6 +496,7 @@ impl Task<()> for ProjectTask {
         let span = info_span!(
             "polling project",
             shuttle.project.name = %project_ctx.project_name,
+            shuttle.operation_name = field::Empty,
             ctx.state = project_ctx.state.state(),
             ctx.state_after = field::Empty,
             ctx.operation_name = field::Empty
@@ -546,6 +547,7 @@ impl Task<()> for ProjectTask {
                         // an API call or the ambulance.
                         if let Some(operation) = &self.operation_name {
                             Span::current().record("ctx.operation_name", operation);
+                            Span::current().record("shuttle.operation_name", operation);
                         }
                         TaskResult::Done(())
                     } else {
@@ -555,12 +557,14 @@ impl Task<()> for ProjectTask {
                 TaskResult::Cancelled => {
                     if let Some(operation) = &self.operation_name {
                         Span::current().record("ctx.operation_name", operation);
+                        Span::current().record("shuttle.operation_name", operation);
                     }
                     TaskResult::Cancelled
                 }
                 TaskResult::Err(err) => {
                     if let Some(operation) = &self.operation_name {
                         Span::current().record("ctx.operation_name", operation);
+                        Span::current().record("shuttle.operation_name", operation);
                     }
                     error!(err = %err, "project task failure");
                     TaskResult::Err(err)

--- a/gateway/src/task.rs
+++ b/gateway/src/task.rs
@@ -146,13 +146,15 @@ pub fn delete_project() -> impl Task<ProjectContext, Output = Project> {
 
 pub struct TaskBuilder {
     project_name: Option<ProjectName>,
+    operation_name: Option<String>,
     service: Arc<GatewayService>,
     tasks: VecDeque<BoxedTask<ProjectContext, Project>>,
 }
 
 impl TaskBuilder {
-    pub fn new(service: Arc<GatewayService>) -> Self {
+    pub fn new(service: Arc<GatewayService>, operation_name: Option<String>) -> Self {
         Self {
+            operation_name,
             service,
             project_name: None,
             tasks: VecDeque::new(),
@@ -189,6 +191,7 @@ impl TaskBuilder {
                 service: self.service,
                 tasks: self.tasks,
                 tracing_context,
+                operation_name: self.operation_name,
             },
         ))
     }
@@ -434,6 +437,7 @@ pub struct ProjectTask {
     service: Arc<GatewayService>,
     tasks: VecDeque<BoxedTask<ProjectContext, Project>>,
     tracing_context: HashMap<String, String>,
+    operation_name: Option<String>,
 }
 
 /// A context for tasks which are scoped to a specific project.
@@ -493,7 +497,8 @@ impl Task<()> for ProjectTask {
             "polling project",
             shuttle.project.name = %project_ctx.project_name,
             ctx.state = project_ctx.state.state(),
-            ctx.state_after = field::Empty
+            ctx.state_after = field::Empty,
+            ctx.operation_name = field::Empty
         );
         span.set_parent(parent_cx);
 
@@ -537,13 +542,26 @@ impl Task<()> for ProjectTask {
                 TaskResult::Done(_) => {
                     let _ = self.tasks.pop_front().unwrap();
                     if self.tasks.is_empty() {
+                        // Should coincide with the end of a project task started by
+                        // an API call or the ambulance.
+                        if let Some(operation) = &self.operation_name {
+                            Span::current().record("ctx.operation_name", operation);
+                        }
                         TaskResult::Done(())
                     } else {
                         TaskResult::Pending(())
                     }
                 }
-                TaskResult::Cancelled => TaskResult::Cancelled,
+                TaskResult::Cancelled => {
+                    if let Some(operation) = &self.operation_name {
+                        Span::current().record("ctx.operation_name", operation);
+                    }
+                    TaskResult::Cancelled
+                }
                 TaskResult::Err(err) => {
+                    if let Some(operation) = &self.operation_name {
+                        Span::current().record("ctx.operation_name", operation);
+                    }
                     error!(err = %err, "project task failure");
                     TaskResult::Err(err)
                 }


### PR DESCRIPTION
## Description of change

Each new project task gets created in the context of a parent span. With open telemetry, this boils down to spans linked through context propagation, which can be easily visualized with Datadog in APM Traces. What is difficult though is to filter spans based on the relationship between them (which should get easier after the GA of [1], thanks @Kazy for pointing me to the article), so that only a certain selection of spans can be returned and counted for certain metrics.

In my specific case, I want to filter for all spans created by the `poll` function of a `ProjectTask` that has an attribute called `ctx.operation_name`. This attribute is attached to the span only in case the result of the `poll` function is `TaskResult::Done(_)`. This is relevant because `ProjectTask`s are created and driven in the background as a result of gateway APIs handlers, the ambulance, and `find_or_start_project`. For now, the only difference I am interested in is determining the number of spans that have the `ctx.operation_name` attribute equal to `create_project`. In this way, Datadog will also be able to count all `ProjectTasks` that end with a `TaskResult::Done(_)` and that is started by an operation called `create_project`.

## How has this been tested? (if applicable)

Tested with Jaeger, and the field shows up.


