### PR TITLE
wip: use cargo-make for tasks and ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
   apply-patches:
     steps:
       - run:
-          name: Patch crates
+          name: Patch local crates
           command: ./scripts/apply-patches.sh
   install-rust:
     steps:
@@ -144,6 +144,17 @@ commands:
               unzip cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip && \
               mv cargo-make-v0.37.8-x86_64-unknown-linux-musl/cargo-make ~/.cargo/bin && \
               rm -rf cargo-make-v$VERSION-x86_64-unknown-linux-musl*
+  install-cargo-audit:
+    steps:
+      - run:
+          name: Install cargo-audit
+          environment:
+            VERSION: "v0.18.3"
+          command: |
+            curl -L https://github.com/rustsec/rustsec/releases/download/cargo-audit/$VERSION/cargo-audit-x86_64-unknown-linux-musl-$VERSION.tgz \
+              | tar -xOz cargo-audit-x86_64-unknown-linux-musl-$VERSION/cargo-audit \
+              > ~/.cargo/bin/cargo-audit \
+              && chmod +x ~/.cargo/bin/cargo-audit
   make-artifact:
     parameters:
       target:
@@ -196,17 +207,9 @@ jobs:
     executor: docker-rust
     steps:
       - checkout
-      - run:
-          name: Install cargo-audit
-          command: |
-            CARGO_AUDIT_VERSION='v0.18.3'
-            ls ~/.cargo/bin/cargo-audit \
-              || curl -L https://github.com/rustsec/rustsec/releases/download/cargo-audit/$CARGO_AUDIT_VERSION/cargo-audit-x86_64-unknown-linux-musl-$CARGO_AUDIT_VERSION.tgz \
-              | tar -xOz cargo-audit-x86_64-unknown-linux-musl-$CARGO_AUDIT_VERSION/cargo-audit \
-              > ~/.cargo/bin/cargo-audit \
-              && chmod +x ~/.cargo/bin/cargo-audit
-      - run: |
-          cargo audit -D warnings
+      - install-cargo-make
+      - install-cargo-audit
+      - run: cargo make audit
   test-standalone:
     parameters:
       path:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -652,10 +652,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Install Protobuf"
-          command: |
-            choco install -y protoc
-      - run:
           name: Install Rust
           command: |
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,9 @@ commands:
             VERSION: "0.37.8"
           command: |
             curl -OL https://github.com/sagiegurari/cargo-make/releases/download/$VERSION/cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip && \
-              unzip -o cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip cargo-make-v0.37.8-x86_64-unknown-linux-musl/cargo-make -d ~/.cargo/bin && \
-              rm -f cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip
+              unzip cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip && \
+              mv cargo-make-v0.37.8-x86_64-unknown-linux-musl/cargo-make ~/.cargo/bin && \
+              rm -rf cargo-make-v$VERSION-x86_64-unknown-linux-musl*
   make-artifact:
     parameters:
       target:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,15 +123,26 @@ commands:
           name: Install protoc and proto-gen
           environment:
             ARCH: "linux-x86_64"
-            VERSION: "22.2"
+            PROTOC_VERSION: "22.2"
+            PROTOGEN_VERSION: "v0.2.0"
           command: |
-            curl -OL "https://github.com/protocolbuffers/protobuf/releases/download/v$VERSION/protoc-$VERSION-$ARCH.zip" && \
-                sudo unzip -o "protoc-$VERSION-$ARCH.zip" bin/protoc "include/*" -d /usr/local && \
-                rm -f "protoc-$VERSION-$ARCH.zip"
-            curl -L https://github.com/EmbarkStudios/proto-gen/releases/download/v0.2.0/proto-gen-v0.2.0-x86_64-unknown-linux-musl.tar.gz \
-              | tar -xOz proto-gen-v0.2.0-x86_64-unknown-linux-musl/proto-gen \
+            curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-$ARCH.zip && \
+              sudo unzip -o protoc-$PROTOC_VERSION-$ARCH.zip bin/protoc "include/*" -d /usr/local && \
+              rm -f protoc-$PROTOC_VERSION-$ARCH.zip
+            curl -L https://github.com/EmbarkStudios/proto-gen/releases/download/$PROTOGEN_VERSION/proto-gen-$PROTOGEN_VERSION-x86_64-unknown-linux-musl.tar.gz \
+              | tar -xOz proto-gen-$PROTOGEN_VERSION-x86_64-unknown-linux-musl/proto-gen \
               > ~/.cargo/bin/proto-gen
             chmod +x ~/.cargo/bin/proto-gen
+  install-cargo-make:
+    steps:
+      - run:
+          name: Install cargo-make
+          environment:
+            VERSION: "0.37.8"
+          command: |
+            curl -OL https://github.com/sagiegurari/cargo-make/releases/download/$VERSION/cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip && \
+              unzip -o cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip cargo-make-v0.37.8-x86_64-unknown-linux-musl/cargo-make -d ~/.cargo/bin && \
+              rm -f cargo-make-v$VERSION-x86_64-unknown-linux-musl.zip
   make-artifact:
     parameters:
       target:
@@ -176,21 +187,8 @@ jobs:
     steps:
       - checkout
       - restore-cargo-and-sccache
-      # Check this to make sure we do not include patched dependencies in the Cargo.lock
-      - run: |
-          [ -z "$(grep "\[\[patch.unused\]\]" Cargo.lock)" ] || \
-            ( echo "Please remove unused patches from Cargo.lock"; exit 1 )
-      - run: cargo fmt --all --check
-      - run: |
-          cargo clippy --tests \
-                       --all-targets \
-                       --all-features \
-                       --no-deps -- \
-                       --D warnings
-      # An out of date lockfile will be modified after the clippy command has run
-      - run: |
-          git diff --exit-code Cargo.lock || \
-            ( echo "Please commit an up to date Cargo.lock"; exit 1 )
+      - install-cargo-make
+      - run: cargo make ci-workspace
       - save-sccache
       - save-cargo-cache
   cargo-audit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,6 +266,7 @@ jobs:
     steps:
       - install-rust
       - install-protoc
+      - install-cargo-make
       - checkout
       - run: git submodule update --init
       - restore-cargo-and-sccache:

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,3 @@ down: $(DOCKER_COMPOSE_FILES)
 	$(addprefix -f ,$(DOCKER_COMPOSE_FILES)) \
 	-p $(STACK) \
 	down
-
-# make tag=v0.0.0 changelog
-changelog:
-	git cliff -o CHANGELOG.md -t $(tag)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,6 +41,11 @@ args = [
     "warnings",
 ]
 
+[tasks.audit]
+install_crate = { crate_name = "cargo-audit", binary = "cargo", test_arg = ["audit", "-V"], min_version = "0.18.3" }
+command = "cargo"
+args = ["audit", "-D", "warnings"]
+
 [tasks.check-lockfile-patches]
 script = '''
 if [ -n "$(grep "\[\[patch.unused\]\]" Cargo.lock)" ]; then
@@ -61,7 +66,7 @@ fi
 # To generate: cargo make proto
 # To validate: cargo make proto validate
 # Requires `protoc` to be installed
-install_crate = { crate_name = "proto-gen@0.2.0", binary = "proto-gen", test_arg = "-V" }
+install_crate = { crate_name = "proto-gen", binary = "proto-gen", test_arg = "-V", version = "0.2.0" }
 script = '''
 OP="generate"
 if [ "$1" = "validate" ]; then

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,7 @@ default_to_workspace = false
 
 [env]
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
-TAG = { script = ["git describe --tags --abbrev=0"] }
+# TAG = { script = ["git describe --tags --abbrev=0"] }
 
 [tasks.ci-workspace]
 run_task = { name = [

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,6 @@
 # 1. cargo install cargo-make
 # 2. cargo make <task_name>
-# docs: https://github.com/sagiegurari/cargo-make#readme
+# docs: https://sagiegurari.github.io/cargo-make/
 
 [config]
 default_to_workspace = false
@@ -16,13 +16,6 @@ run_task = { name = [
     "clippy",
     "check-lockfile",
 ] }
-
-[tasks.changelog]
-# Provide the version to generate for
-# Example: cargo make changelog 0.37.0
-install_crate = { crate_name = "git-cliff", binary = "git-cliff", test_arg = ["-V"], min_version = "1.4.0" }
-command = "git-cliff"
-args = ["-o", "CHANGELOG.md", "-t", "${@}"]
 
 [tasks.fmt]
 command = "cargo"
@@ -83,3 +76,10 @@ proto-gen \
     -f proto/resource-recorder.proto \
     -f proto/runtime.proto
 '''
+
+[tasks.changelog]
+# Provide the version to generate for
+# Example: cargo make changelog 0.37.0
+install_crate = { crate_name = "git-cliff", binary = "git-cliff", test_arg = ["-V"], min_version = "1.4.0" }
+command = "git-cliff"
+args = ["-o", "CHANGELOG.md", "-t", "${@}"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -20,7 +20,7 @@ run_task = { name = [
 [tasks.changelog]
 # Provide the version to generate for
 # Example: cargo make changelog 0.37.0
-install_crate = "git-cliff"
+install_crate = { crate_name = "git-cliff", binary = "git-cliff", test_arg = ["-V"], min_version = "1.4.0" }
 command = "git-cliff"
 args = ["-o", "CHANGELOG.md", "-t", "${@}"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,56 @@
+# 1. cargo install cargo-make
+# 2. cargo make <task_name>
+# docs: https://github.com/sagiegurari/cargo-make#readme
+
+[config]
+default_to_workspace = false
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+TAG = { script = ["git describe --tags --abbrev=0"] }
+
+[tasks.ci-workspace]
+run_task = { name = [
+    "check-lockfile-patches",
+    "fmt",
+    "clippy",
+    "check-lockfile",
+] }
+
+[tasks.changelog]
+install_crate = "git-cliff"
+command = "git-cliff"
+args = ["-o", "CHANGELOG.md", "-t", "${TAG}"]
+
+[tasks.fmt]
+command = "cargo"
+args = ["fmt", "--all", "--check"]
+
+[tasks.clippy]
+command = "cargo"
+args = [
+    "clippy",
+    "--tests",
+    "--all-targets",
+    "--all-features",
+    "--no-deps",
+    "--",
+    "--D",
+    "warnings",
+]
+
+[tasks.check-lockfile-patches]
+script = '''
+if [ -n "$(grep "\[\[patch.unused\]\]" Cargo.lock)" ]; then
+    echo "Please remove unused patches from Cargo.lock"
+    exit 1
+fi
+'''
+
+[tasks.check-lockfile]
+script = '''
+if ! git diff --exit-code Cargo.lock; then
+    echo "Please commit an up to date Cargo.lock"
+    exit 1
+fi
+'''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,9 +18,11 @@ run_task = { name = [
 ] }
 
 [tasks.changelog]
+# Provide the version to generate for
+# Example: cargo make changelog 0.37.0
 install_crate = "git-cliff"
 command = "git-cliff"
-args = ["-o", "CHANGELOG.md", "-t", "${TAG}"]
+args = ["-o", "CHANGELOG.md", "-t", "${@}"]
 
 [tasks.fmt]
 command = "cargo"
@@ -53,4 +55,26 @@ if ! git diff --exit-code Cargo.lock; then
     echo "Please commit an up to date Cargo.lock"
     exit 1
 fi
+'''
+
+[tasks.proto]
+# To generate: cargo make proto
+# To validate: cargo make proto validate
+# Requires `protoc` to be installed
+install_crate = { crate_name = "proto-gen@0.2.0", binary = "proto-gen", test_arg = "-V" }
+script = '''
+OP="generate"
+if [ "$1" = "validate" ]; then
+    OP="validate"
+fi
+proto-gen \
+    --generate-transport --build-client --build-server --format \
+    $OP \
+    -d proto \
+    -o proto/src/generated \
+    -f proto/builder.proto \
+    -f proto/logger.proto \
+    -f proto/provisioner.proto \
+    -f proto/resource-recorder.proto \
+    -f proto/runtime.proto
 '''

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,13 +1,6 @@
 # shuttle-proto
 
-This crate contains the protofiles used to generate the provisioner and runtime services,
-as well as the generated code.
+This crate contains the protofiles used to generate code for the gRPC APIs.
 Having the generated files commited means users don't need protoc installed to install `cargo-shuttle`.
 
-If you make changes to the protofiles, run
-
-```bash
-./proto/integration.sh generate
-```
-
-to regenerate the generated files in `proto/src/generated`.
+If you make changes to the protofiles, run `cargo make proto` to generate new files.

--- a/proto/integration.sh
+++ b/proto/integration.sh
@@ -1,23 +1,3 @@
 #!/usr/bin/env bash
 
-if ! which proto-gen &>/dev/null; then
-    echo "Need 'proto-gen' to generate/validate protobufs:"
-    echo "cargo (b)install proto-gen"
-    exit 1
-fi
-
-OP="validate"
-if [ "$1" == "generate" ]; then
-    OP="generate"
-fi
-
-proto-gen \
-    --generate-transport --build-client --build-server --format \
-    ${OP} \
-    -d proto \
-    -o proto/src/generated \
-    -f proto/builder.proto \
-    -f proto/logger.proto \
-    -f proto/provisioner.proto \
-    -f proto/resource-recorder.proto \
-    -f proto/runtime.proto
+cargo make proto validate


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Aims to make the common CI tasks runnable locally, ie `cargo make ci-workspace`.

Also `cargo make proto`, `cargo make changelog 0.x.0`, and `cargo make audit`

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

CI + local tests
