### PR TITLE
feat: disable trace_layer on_failure, only emit error event for 500s

### DIFF
--- a/common/src/backends/metrics.rs
+++ b/common/src/backends/metrics.rs
@@ -9,7 +9,7 @@ use axum::http::{request::Parts, Request, Response};
 use opentelemetry::global;
 use opentelemetry_http::HeaderExtractor;
 use tower_http::classify::{ServerErrorsAsFailures, SharedClassifier};
-use tower_http::trace::DefaultOnRequest;
+use tower_http::trace::{DefaultOnBodyChunk, DefaultOnEos, DefaultOnRequest};
 use tracing::{debug, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -83,10 +83,14 @@ impl<MakeSpan: tower_http::trace::MakeSpan<Body> + MakeSpanBuilder> TraceLayer<M
         MakeSpan,
         DefaultOnRequest,
         OnResponseStatusCode,
+        DefaultOnBodyChunk,
+        DefaultOnEos,
+        (),
     > {
         tower_http::trace::TraceLayer::new_for_http()
             .make_span_with(MakeSpan::new(self.fn_span))
             .on_response(OnResponseStatusCode)
+            .on_failure(())
     }
 }
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -114,9 +114,12 @@ impl From<AcmeClientError> for Error {
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        error!(error = %self, "request had an error");
-
         let error: ApiError = self.kind.into();
+
+        if error.status_code >= 500 {
+            // We only want to emit error events for internal errors, not e.g. 404s.
+            error!(error = error.message, "control plane request error");
+        }
 
         error.into_response()
     }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

### Motivation
- We were emitting two events for every 5xx, one from the IntoResponse implementation, which can know more about what the error was, and one from the trace layer [on_failure default implementation](https://docs.rs/tower-http/0.4.4/src/tower_http/trace/on_failure.rs.html#84-100), which only knows the status code (and some metadata).
- We were emitting error events for 4xx in the IntoResponse implementation, but they don't really warrant an error event. Trying to fetch a project that doesn't exist isn't possible, so it's not something we need to highlight as an error. The span will still have the 404 status code.
- With the trace_layer on_failure disabled, we only get the error event in IntoResponse, and we still set the status code on the span so we can track 4xx's.

### Alternatives

- With the current solution, we have to create an event in the IntoResponse implementation for three crates, rather than having the same behavior for all creates defined in the trace layer. We could disable the events in the IntoResponse instead, and just use the trace layer on_failure, but we would have less data in the event about what the error was.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested with local env and Datadog.
