### PR TITLE
feat: quite flag implemented

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -280,6 +280,9 @@ pub struct RunArgs {
     /// Use release mode for building the project
     #[arg(long, short = 'r')]
     pub release: bool,
+    /// Use quite mode for running the project
+    #[arg(long, short = 'q')]
+    pub quite: bool,
 }
 
 #[derive(Parser, Clone, Debug, Default)]

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1064,6 +1064,8 @@ impl Shuttle {
         let service_name = service.service_name()?;
         let deployment_id: Uuid = Default::default();
 
+        let quite_mode = run_args.quite;
+
         // Clones to send to spawn
         let service_name_clone = service_name.clone().to_string();
 
@@ -1079,7 +1081,13 @@ impl Shuttle {
                     shuttle_common::log::Backend::Runtime(service_name_clone.clone()),
                     line,
                 );
-                println!("{log_item}");
+                if !quite_mode {
+                    println!("{log_item}");
+                } else {
+                    if log_item.line.contains("ERROR") {
+                        println!("{log_item}");
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
Implemented `--quite` flag for `cargo-shuttle run` command.
I added extra flag in `RunArgs` struct, then in `spin_local_run` function I checked if flag is true or not and accordingly I let print statement do the work
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Closes #1602 


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
Tested Via running locally.
used this command `cargo run -p cargo-shuttle -- run --wd ../temp-project --quite`

and output is something like this
![Screenshot 2024-02-02 at 21 59 28](https://github.com/shuttle-hq/shuttle/assets/91935072/504c6fa2-88b3-468c-a0ff-2ec00cb9e282)

![Screenshot 2024-02-02 at 22 02 25](https://github.com/shuttle-hq/shuttle/assets/91935072/717af56f-2bff-4790-bccc-3a189129ee8c)


> This is very first implementation that came to my mind, but if it needs to be improved please suggest : )


