### PR TITLE
feat(installer): always check for cargo install first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,7 +133,7 @@ _install_binary() {
 }
 
 _install_rust_and_cargo() {
-  while true; do
+  while ! command -v cargo &>/dev/null; do
     read -r -p "Do you wish to attempt to install Rust and Cargo via rustup? [Y/N] " yn </dev/tty
     case $yn in
     [Yy]*)

--- a/install.sh
+++ b/install.sh
@@ -164,8 +164,6 @@ _install_unsupported() {
   if ! command -v cargo &>/dev/null; then
     if ! command -v rustup &>/dev/null; then
       _install_rust_and_cargo
-      _install_with_cargo
-      return 0
     else
       echo "rustup was found, but cargo wasn't. Something is up with your install"
       exit 1

--- a/install.sh
+++ b/install.sh
@@ -144,11 +144,11 @@ _install_rust_and_cargo() {
     *) echo "Please answer yes or no." ;;
     esac
   done
-  echo "rustup installed! Installing with cargo"
-  _install_cargo
+  echo "rustup installed!"
 }
 
-_install_cargo() {
+_install_with_cargo() {
+  echo "Installing with cargo..."
   cargo install --locked cargo-shuttle
 }
 
@@ -164,36 +164,36 @@ _install_unsupported() {
   if ! command -v cargo &>/dev/null; then
     if ! command -v rustup &>/dev/null; then
       _install_rust_and_cargo
+      _install_with_cargo
       return 0
     else
       echo "rustup was found, but cargo wasn't. Something is up with your install"
       exit 1
-    fi
-  else
-    while true; do
+    fi    
+  fi
+
+  while true; do
+    read -r -p "Do you wish to attempt to install the pre-built binary? [Y/N] " yn </dev/tty
+    case $yn in
+    [Yy]*)
+      echo "Installing pre-built binary..."
+      _install_binary
+      break
+      ;;
+    [Nn]*)
       read -r -p "Do you wish to attempt an install with cargo? [Y/N] " yn </dev/tty
       case $yn in
       [Yy]*)
-        echo "Installing with cargo..."
-        _install_cargo
+        _install_with_cargo
         break
         ;;
-      [Nn]*)
-        read -r -p "Do you wish to attempt to install the pre-built binary? [Y/N] " yn </dev/tty
-        case $yn in
-        [Yy]*)
-          echo "Installing pre-built binary..."
-          _install_binary
-          break
-          ;;
-        [Nn]*) exit ;;
-        *) echo "Please answer yes or no." ;;
-        esac
-        ;;
+      [Nn]*) exit ;;
       *) echo "Please answer yes or no." ;;
       esac
-    done
-  fi
+      ;;
+    *) echo "Please answer yes or no." ;;
+    esac
+  done
 }
 
 if command -v cargo-shuttle &>/dev/null; then

--- a/install.sh
+++ b/install.sh
@@ -144,7 +144,6 @@ _install_rust_and_cargo() {
     *) echo "Please answer yes or no." ;;
     esac
   done
-  echo "rustup installed!"
 }
 
 _install_with_cargo() {


### PR DESCRIPTION
Hey 👋 This is my very first contribution that I dared 👉👈

## Description of change
Closes https://github.com/shuttle-hq/shuttle/issues/1603

- `_install_cargo()` function is checking if cargo and rustup are installed in the mid of `_install_unsupported()` whereas it could have been checked earlier to propose better ways of installation. I hope this would make sense and help distinguishing flows better

## How has this been tested? (if applicable)
- checked for syntax mistakes
- ran through chat gpt lol
- ran locally and updated cargo-shuttle



