### PR TITLE
ci: move more tasks to cargo make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ commands:
   install-rust:
     steps:
       - run:
-          name: Install Rust
+          name: Install Rust and wasm32-wasi
           # Note: Let CI use our MSRV, rather than latest
           command: which cargo || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.75.0
       - run: rustup target add wasm32-wasi
@@ -259,12 +259,8 @@ jobs:
       - restore-cargo-and-sccache:
           sccache-size: << parameters.sccache-size >>
       - apply-patches
-      - run:
-          name: Run unit tests
-          command: cargo make test-member << parameters.crate >>
-      - run:
-          name: Run integration tests
-          command: cargo make test-member-integration << parameters.crate >>
+      - run: cargo make test-member << parameters.crate >>
+      - run: cargo make test-member-integration << parameters.crate >>
       - save-sccache
   test-workspace-member-with-integration-docker:
     parameters:
@@ -288,9 +284,7 @@ jobs:
       - restore-cargo-and-sccache:
           sccache-size: << parameters.sccache-size >>
       - apply-patches
-      - run:
-          name: Run integration tests that need docker
-          command: cargo make test-member-integration-docker << parameters.crate >>
+      - run: cargo make test-member-integration-docker << parameters.crate >>
       - save-sccache
   e2e-test: # outdated
     executor: machine-ubuntu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,17 @@ commands:
       - run:
           name: Sccache stats
           command: sccache --show-stats
+      - run:
+          name: Prune old sccache items
+          # Delete files that have not been accessed in 5 days
+          command: |
+            du -sh ~/.cache/sccache
+            find ~/.cache/sccache -atime +5 | wc -l
+            find ~/.cache/sccache -atime +5 -delete
+            du -sh ~/.cache/sccache
+      - run:
+          name: Sccache stats
+          command: sccache --show-stats
       - save_cache:
           name: Save sccache cache
           # We use {{ .Branch }}-{{ .Revision }} to upload a fresh cache for each commit on a branch.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,8 @@ jobs:
       - restore-cargo-and-sccache
       - install-cargo-make
       - run: cargo make ci-workspace
+      - install-protoc
+      - run: cargo make proto validate
       - save-sccache
       - save-cargo-cache
   cargo-audit:
@@ -215,28 +217,13 @@ jobs:
       path:
         description: "Path to crate external from workspace"
         type: string
-      features:
-        description: "Features to enable"
-        type: string
-        default: --all-features
     executor: docker-rust
     steps:
       - checkout
       - restore-cargo-and-sccache
+      - install-cargo-make
       - apply-patches
-      - run: cargo fmt --all --check --manifest-path << parameters.path >>/Cargo.toml
-      - run: |
-          cargo clippy --tests \
-                       --all-targets \
-                       << parameters.features >> \
-                       --manifest-path << parameters.path >>/Cargo.toml \
-                       --no-deps -- \
-                       --D warnings
-      - run: |
-          cargo test << parameters.features >> \
-                     --manifest-path << parameters.path >>/Cargo.toml \
-                     -- \
-                     --nocapture
+      - run: cargo make ci-standalone << parameters.path >>
       - save-sccache
   test-workspace-member:
     parameters:
@@ -248,7 +235,8 @@ jobs:
       - install-rust
       - checkout
       - restore-cargo-and-sccache
-      - run: cargo test -p << parameters.crate >> --all-features --lib -- --nocapture
+      - install-cargo-make
+      - run: cargo make test-member << parameters.crate >>
       - save-sccache
   test-workspace-member-with-integration:
     parameters:
@@ -265,7 +253,6 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - install-rust
-      - install-protoc
       - install-cargo-make
       - checkout
       - run: git submodule update --init
@@ -274,18 +261,10 @@ jobs:
       - apply-patches
       - run:
           name: Run unit tests
-          command: cargo test -p << parameters.crate >> --all-features --lib -- --nocapture
+          command: cargo make test-member << parameters.crate >>
       - run:
           name: Run integration tests
-          command: |
-            set +o pipefail
-            path=$(echo "<< parameters.crate >>" | sed "s/shuttle-\(.*\)/\1/")
-            if [ -f "$path/integration.sh" ]; then
-              bash "$path/integration.sh"
-            else
-              echo "nothing to test here, adjust CI file or add an integration script"
-              exit 1
-            fi
+          command: cargo make test-member-integration << parameters.crate >>
       - save-sccache
   test-workspace-member-with-integration-docker:
     parameters:
@@ -303,7 +282,7 @@ jobs:
     resource_class: << parameters.resource_class >>
     steps:
       - install-rust
-      - install-protoc
+      - install-cargo-make
       - checkout
       - run: git submodule update --init
       - restore-cargo-and-sccache:
@@ -311,17 +290,9 @@ jobs:
       - apply-patches
       - run:
           name: Run integration tests that need docker
-          command: |
-            set +o pipefail
-            path=$(echo "<< parameters.crate >>" | sed "s/shuttle-\(.*\)/\1/")
-            if [ -f "$path/integration_docker.sh" ]; then
-              bash "$path/integration_docker.sh"
-            else
-              echo "nothing to test here, adjust CI file or add an integration script"
-              exit 1
-            fi
+          command: cargo make test-member-integration-docker << parameters.crate >>
       - save-sccache
-  e2e-test:
+  e2e-test: # outdated
     executor: machine-ubuntu
     resource_class: medium
     steps:
@@ -717,51 +688,19 @@ workflows:
                 - resources/persist
                 - resources/qdrant
                 - resources/secrets
+                - resources/shared-db
                 - resources/turso
                 - services/shuttle-actix-web
+                - services/shuttle-axum
                 - services/shuttle-next
                 - services/shuttle-poem
                 - services/shuttle-rocket
                 - services/shuttle-salvo
+                - services/shuttle-serenity
                 - services/shuttle-thruster
                 - services/shuttle-tide
                 - services/shuttle-tower
                 - services/shuttle-warp
-      - test-standalone:
-          # Has mutually exclusive features, so we run checks for each feature separately
-          name: "resources/shared-db: << matrix.features >>"
-          matrix:
-            alias: test-standalone-shared-db
-            parameters:
-              path:
-                - resources/shared-db
-              features:
-                - "-F mongodb"
-                - "-F postgres"
-                - "-F postgres,sqlx"
-                - "-F postgres,sqlx-native-tls"
-      - test-standalone:
-          # Has mutually exclusive features, so we run checks for each feature separately
-          name: "services/shuttle-axum: << matrix.features >>"
-          matrix:
-            alias: test-standalone-services-shuttle-axum
-            parameters:
-              path:
-                - services/shuttle-axum
-              features:
-                - "-F axum"
-                - "-F axum-0-6 --no-default-features"
-      - test-standalone:
-          # Has mutually exclusive features, so we run checks for each feature separately
-          name: "services/shuttle-serenity: << matrix.features >>"
-          matrix:
-            alias: test-standalone-services-shuttle-serenity
-            parameters:
-              path:
-                - services/shuttle-serenity
-              features:
-                - "-F serenity"
-                - "-F serenity-0-11-rustls_backend --no-default-features"
       - test-workspace-member:
           name: << matrix.crate >>
           matrix:
@@ -779,7 +718,6 @@ workflows:
               resource_class:
                 - medium
               crate:
-                - shuttle-proto
                 - shuttle-resource-recorder
       - test-workspace-member-with-integration:
           name: << matrix.crate >>
@@ -829,19 +767,19 @@ workflows:
           filters:
             branches:
               only: main
-      - e2e-test:
-          requires:
-            - test-standalone
-            - test-standalone-shared-db
-            - test-workspace-member
-            - test-workspace-member-with-integration-medium
-            - test-workspace-member-with-integration-large
-            - test-workspace-member-with-integration-xlarge
-            - test-workspace-member-with-integration-docker-medium
-            - test-workspace-member-with-integration-docker-large
-          filters:
-            branches:
-              only: production
+      # - e2e-test:
+      #     requires:
+      #       - test-standalone
+      #       - test-standalone-shared-db
+      #       - test-workspace-member
+      #       - test-workspace-member-with-integration-medium
+      #       - test-workspace-member-with-integration-large
+      #       - test-workspace-member-with-integration-xlarge
+      #       - test-workspace-member-with-integration-docker-medium
+      #       - test-workspace-member-with-integration-docker-large
+      #     filters:
+      #       branches:
+      #         only: production
   unstable:
     jobs:
       - approve-deploy-images-unstable:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -9,14 +9,6 @@ default_to_workspace = false
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 # TAG = { script = ["git describe --tags --abbrev=0"] }
 
-[tasks.ci-workspace]
-run_task = { name = [
-    "check-lockfile-patches",
-    "fmt",
-    "clippy",
-    "check-lockfile",
-] }
-
 [tasks.fmt]
 command = "cargo"
 args = ["fmt", "--all", "--check"]
@@ -32,6 +24,50 @@ args = [
     "--",
     "--D",
     "warnings",
+]
+
+# Provide the name of the workspace member
+# Example: cargo make test-member shuttle-proto
+[tasks.test-member]
+# run unit tests for a workspace crate
+command = "cargo"
+args = [
+    "test",
+    "-p",
+    "${@}",
+    "--all-features",
+    "--lib",
+    "--",
+    "--nocapture",
+]
+[tasks.test-member-integration]
+# run integration tests for a workspace crate
+command = "cargo"
+args = [
+    "test",
+    "-p",
+    "${@}",
+    "--all-features",
+    "--test",
+    "*",
+    "--",
+    "--skip",
+    "needs_docker",
+    "--nocapture",
+]
+[tasks.test-member-integration-docker]
+# run integration tests for a workspace crate that need access to docker
+command = "cargo"
+args = [
+    "test",
+    "-p",
+    "${@}",
+    "--all-features",
+    "--test",
+    "*",
+    "--",
+    "needs_docker",
+    "--nocapture",
 ]
 
 [tasks.audit]
@@ -83,3 +119,64 @@ proto-gen \
 install_crate = { crate_name = "git-cliff", binary = "git-cliff", test_arg = ["-V"], min_version = "1.4.0" }
 command = "git-cliff"
 args = ["-o", "CHANGELOG.md", "-t", "${@}"]
+
+### CI TASKS
+
+[tasks.ci-workspace]
+run_task = { name = [
+    "check-lockfile-patches",
+    "fmt",
+    "clippy",
+    "check-lockfile",
+] }
+
+[tasks.ci-standalone]
+# Provide paths to crates to test
+# Example: cargo make ci-standalone services/shuttle-axum
+script_runner = "@duckscript"
+script = '''
+alias run exec --fail-on-error
+
+for path in ${@}
+
+
+if not ${path}
+    echo No crate path provided
+    exit 1
+end
+manifest = set "${path}/Cargo.toml"
+if not is_path_exists ${manifest}
+    echo manifest not found: ${manifest}
+    exit 1
+end
+
+feature_flags = array "--all-features"
+###### Crates that have mutually exclusive features define
+###### their own set of feature flags to test:
+if eq ${path} "resources/shared-db"
+    feature_flags = array "-F mongodb" "-F postgres" "-F postgres,sqlx" "-F postgres,sqlx-native-tls"
+elseif eq ${path} "services/shuttle-axum"
+    feature_flags = array "-F axum" "-F axum-0-6 --no-default-features"
+elseif eq ${path} "services/shuttle-serenity"
+    feature_flags = array "-F serenity" "-F serenity-0-11-rustls_backend --no-default-features"
+end
+
+echo
+println -s bold "### Manifest:"
+println -s bold "    ${manifest}"
+echo
+
+run cargo fmt --all --check --manifest-path ${manifest}
+
+for f in ${feature_flags}
+    echo
+    println -s bold "### Feature flags:"
+    println -s bold "    ${f}"
+    echo
+    run cargo clippy --tests --all-targets ${f} --manifest-path ${manifest} --no-deps -- --D warnings
+    run cargo test ${f} --manifest-path ${manifest} -- --nocapture
+end
+
+
+end
+'''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -156,9 +156,9 @@ feature_flags = array "--all-features"
 if eq ${path} "resources/shared-db"
     feature_flags = array "-F mongodb" "-F postgres" "-F postgres,sqlx" "-F postgres,sqlx-native-tls"
 elseif eq ${path} "services/shuttle-axum"
-    feature_flags = array "-F axum" "-F axum-0-6 --no-default-features"
+    feature_flags = array "-F axum" "-F axum-0-6"
 elseif eq ${path} "services/shuttle-serenity"
-    feature_flags = array "-F serenity" "-F serenity-0-11-rustls_backend --no-default-features"
+    feature_flags = array "-F serenity" "-F serenity-0-11-rustls_backend"
 end
 
 echo
@@ -173,8 +173,10 @@ for f in ${feature_flags}
     println -s bold "### Feature flags:"
     println -s bold "    ${f}"
     echo
-    run cargo clippy --tests --all-targets ${f} --manifest-path ${manifest} --no-deps -- --D warnings
-    run cargo test ${f} --manifest-path ${manifest} -- --nocapture
+    # In the default case, --all-features overrides --no-default-features.
+    # --no-default-features is used for enabling special sets of feature flags.
+    run cargo clippy --tests --all-targets --no-default-features ${f} --manifest-path ${manifest} --no-deps -- --D warnings
+    run cargo test --no-default-features ${f} --manifest-path ${manifest} -- --nocapture
 end
 
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,7 @@
 # 1. cargo install cargo-make
 # 2. cargo make <task_name>
-# docs: https://sagiegurari.github.io/cargo-make/
+# cargo make docs: https://sagiegurari.github.io/cargo-make/
+# duckscript docs: https://github.com/sagiegurari/duckscript/blob/master/docs/sdk.md
 
 [config]
 default_to_workspace = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -158,7 +158,7 @@ if eq ${path} "resources/shared-db"
 elseif eq ${path} "services/shuttle-axum"
     feature_flags = array "-F axum" "-F axum-0-6"
 elseif eq ${path} "services/shuttle-serenity"
-    feature_flags = array "-F serenity" "-F serenity-0-11-rustls_backend"
+    feature_flags = array "-F serenity,rustls_backend" "-F serenity,native_tls_backend" "-F serenity-0-11-rustls_backend" "-F serenity-0-11-native_tls_backend"
 end
 
 echo

--- a/auth/integration.sh
+++ b/auth/integration.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-auth --all-features --test '*' -- --skip needs_docker --nocapture

--- a/auth/integration_docker.sh
+++ b/auth/integration_docker.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-auth --all-features --test '*' -- needs_docker --nocapture

--- a/builder/integration.sh
+++ b/builder/integration.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# Not enabled yet due to requiring nix setup
-# cargo test -p shuttle-builder --all-features --test '*' -- --skip needs_docker --nocapture

--- a/cargo-shuttle/integration.sh
+++ b/cargo-shuttle/integration.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p cargo-shuttle --all-features --test '*' -- --skip needs_docker --nocapture

--- a/cargo-shuttle/integration_docker.sh
+++ b/cargo-shuttle/integration_docker.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p cargo-shuttle --all-features --test '*' -- needs_docker --nocapture

--- a/deployer/integration.sh
+++ b/deployer/integration.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-deployer --all-features --test '*' -- --skip needs_docker --nocapture

--- a/logger/integration_docker.sh
+++ b/logger/integration_docker.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-logger --all-features --test '*' -- needs_docker --nocapture

--- a/proto/integration.sh
+++ b/proto/integration.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cargo make proto validate

--- a/provisioner/integration_docker.sh
+++ b/provisioner/integration_docker.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-provisioner --all-features --test '*' -- needs_docker --nocapture

--- a/resource-recorder/integration.sh
+++ b/resource-recorder/integration.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-resource-recorder --all-features --test '*' -- --skip needs_docker --nocapture

--- a/runtime/integration.sh
+++ b/runtime/integration.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-runtime --all-features --test '*' -- --skip needs_docker --nocapture

--- a/service/integration.sh
+++ b/service/integration.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-cargo test -p shuttle-service --all-features --test '*' -- --skip needs_docker --nocapture


### PR DESCRIPTION
Reduces number of CI jobs 36 -> 30.

The CI cache pruning is a test that will need to run for a while until we see results.