### PR TITLE
refactor: uniform client wrappers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,7 +6102,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
- "tower",
  "tracing-subscriber",
  "uuid",
  "wasi-common",
@@ -6125,7 +6124,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.8.8",
- "tower",
  "tracing",
 ]
 

--- a/common-tests/src/builder.rs
+++ b/common-tests/src/builder.rs
@@ -4,21 +4,13 @@ use std::{
 };
 
 use portpicker::pick_unused_port;
-use shuttle_common::claims::{ClaimLayer, InjectPropagationLayer};
 use shuttle_proto::builder::{
-    builder_client::BuilderClient,
+    self,
     builder_server::{Builder, BuilderServer},
 };
-use tonic::transport::{Endpoint, Server};
-use tower::ServiceBuilder;
+use tonic::transport::Server;
 
-pub async fn get_mocked_builder_client(
-    builder: impl Builder,
-) -> BuilderClient<
-    shuttle_common::claims::ClaimService<
-        shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-    >,
-> {
+pub async fn get_mocked_builder_client(builder: impl Builder) -> builder::Client {
     let builder_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pick_unused_port().unwrap());
     let builder_uri = format!("http://{}", builder_addr);
     tokio::spawn(async move {
@@ -31,16 +23,5 @@ pub async fn get_mocked_builder_client(
     // Wait for the builder server to start before creating a client.
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    let channel = Endpoint::try_from(builder_uri.to_string())
-        .unwrap()
-        .connect()
-        .await
-        .expect("failed to connect to builder");
-
-    let channel = ServiceBuilder::new()
-        .layer(ClaimLayer)
-        .layer(InjectPropagationLayer)
-        .service(channel);
-
-    BuilderClient::new(channel)
+    builder::get_client(builder_uri.parse().unwrap()).await
 }

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -4,7 +4,6 @@ use clap::Parser;
 use fqdn::FQDN;
 use hyper::Uri;
 use shuttle_common::models::project::ProjectName;
-use tonic::transport::Endpoint;
 
 /// Program to handle the deploys for a single project
 /// Handling includes, building, testing, and running each service
@@ -61,7 +60,7 @@ pub struct Args {
 
     /// Address to reach the builder service at
     #[clap(long, default_value = "http://builder:8000")]
-    pub builder_uri: Endpoint,
+    pub builder_uri: Uri,
 
     /// Uri to folder to store all artifacts
     #[clap(long, default_value = "/tmp")]

--- a/deployer/src/args.rs
+++ b/deployer/src/args.rs
@@ -21,7 +21,7 @@ pub struct Args {
 
     /// Address to connect to the logger service
     #[clap(long, default_value = "http://logger:8000")]
-    pub logger_uri: Endpoint,
+    pub logger_uri: Uri,
 
     /// FQDN where the proxy can be reached at
     #[clap(long)]

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -4,10 +4,7 @@ use std::{
 };
 
 use shuttle_common::log::LogRecorder;
-use shuttle_proto::{
-    builder::builder_client::BuilderClient,
-    logger::{self},
-};
+use shuttle_proto::{builder, logger};
 use tokio::{
     sync::{mpsc, Mutex},
     task::JoinSet,
@@ -41,13 +38,7 @@ pub struct DeploymentManagerBuilder<LR, ADG, DU, RM, QC> {
     deployment_updater: Option<DU>,
     resource_manager: Option<RM>,
     queue_client: Option<QC>,
-    builder_client: Option<
-        BuilderClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-            >,
-        >,
-    >,
+    builder_client: Option<builder::Client>,
 }
 
 impl<LR, ADG, DU, RM, QC> DeploymentManagerBuilder<LR, ADG, DU, RM, QC>
@@ -70,16 +61,7 @@ where
         self
     }
 
-    pub fn builder_client(
-        mut self,
-        builder_client: Option<
-            BuilderClient<
-                shuttle_common::claims::ClaimService<
-                    shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-                >,
-            >,
-        >,
-    ) -> Self {
+    pub fn builder_client(mut self, builder_client: Option<builder::Client>) -> Self {
         self.builder_client = builder_client;
 
         self

--- a/deployer/src/deployment/mod.rs
+++ b/deployer/src/deployment/mod.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use shuttle_common::log::LogRecorder;
-use shuttle_proto::{builder::builder_client::BuilderClient, logger::logger_client::LoggerClient};
+use shuttle_proto::{
+    builder::builder_client::BuilderClient,
+    logger::{self},
+};
 use tokio::{
     sync::{mpsc, Mutex},
     task::JoinSet,
@@ -31,13 +34,7 @@ const RUN_BUFFER_SIZE: usize = 100;
 
 pub struct DeploymentManagerBuilder<LR, ADG, DU, RM, QC> {
     build_log_recorder: Option<LR>,
-    logs_fetcher: Option<
-        LoggerClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-            >,
-        >,
-    >,
+    logs_fetcher: Option<logger::Client>,
     active_deployment_getter: Option<ADG>,
     artifacts_path: Option<PathBuf>,
     runtime_manager: Option<Arc<Mutex<RuntimeManager>>>,
@@ -67,14 +64,7 @@ where
         self
     }
 
-    pub fn log_fetcher(
-        mut self,
-        logs_fetcher: LoggerClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-            >,
-        >,
-    ) -> Self {
+    pub fn log_fetcher(mut self, logs_fetcher: logger::Client) -> Self {
         self.logs_fetcher = Some(logs_fetcher);
 
         self
@@ -195,11 +185,7 @@ pub struct DeploymentManager {
     queue_send: QueueSender,
     run_send: RunSender,
     runtime_manager: Arc<Mutex<RuntimeManager>>,
-    logs_fetcher: LoggerClient<
-        shuttle_common::claims::ClaimService<
-            shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-        >,
-    >,
+    logs_fetcher: logger::Client,
     _join_set: Arc<Mutex<JoinSet<()>>>,
     builds_path: PathBuf,
 }
@@ -259,13 +245,7 @@ impl DeploymentManager {
         self.builds_path.as_path()
     }
 
-    pub fn logs_fetcher(
-        &self,
-    ) -> &LoggerClient<
-        shuttle_common::claims::ClaimService<
-            shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-        >,
-    > {
+    pub fn logs_fetcher(&self) -> &logger::Client {
         &self.logs_fetcher
     }
 }

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -14,8 +14,7 @@ use shuttle_common::{
     log::LogRecorder,
     LogItem,
 };
-use shuttle_proto::builder::builder_client::BuilderClient;
-use shuttle_proto::builder::BuildRequest;
+use shuttle_proto::builder::{self, BuildRequest};
 use shuttle_service::builder::{build_workspace, BuiltService};
 use tar::Archive;
 use tokio::{
@@ -42,13 +41,7 @@ pub async fn task(
     deployment_updater: impl DeploymentUpdater,
     log_recorder: impl LogRecorder,
     queue_client: impl BuildQueueClient,
-    builder_client: Option<
-        BuilderClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-            >,
-        >,
-    >,
+    builder_client: Option<builder::Client>,
     builds_path: PathBuf,
 ) {
     info!("Queue task started");

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use opentelemetry::global;
 use portpicker::pick_unused_port;
 use shuttle_common::{
-    claims::{Claim, ClaimService, InjectPropagation},
+    claims::Claim,
     constants::EXECUTABLE_DIRNAME,
     deployment::{
         DEPLOYER_END_MSG_COMPLETED, DEPLOYER_END_MSG_CRASHED, DEPLOYER_END_MSG_STARTUP_ERR,
@@ -20,15 +20,14 @@ use shuttle_common::{
 use shuttle_proto::{
     resource_recorder::record_request,
     runtime::{
-        runtime_client::RuntimeClient, LoadRequest, StartRequest, StopReason, SubscribeStopRequest,
-        SubscribeStopResponse,
+        self, LoadRequest, StartRequest, StopReason, SubscribeStopRequest, SubscribeStopResponse,
     },
 };
 use tokio::{
     sync::Mutex,
     task::{JoinHandle, JoinSet},
 };
-use tonic::{transport::Channel, Code};
+use tonic::Code;
 use tracing::{debug, debug_span, error, info, instrument, warn, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use ulid::Ulid;
@@ -313,7 +312,7 @@ async fn load(
     service_id: Ulid,
     executable_path: PathBuf,
     mut resource_manager: impl ResourceManager,
-    mut runtime_client: RuntimeClient<ClaimService<InjectPropagation<Channel>>>,
+    mut runtime_client: runtime::Client,
     claim: Claim,
     mut secrets: HashMap<String, String>,
 ) -> Result<()> {
@@ -414,7 +413,7 @@ async fn load(
 async fn run(
     id: Uuid,
     service_name: String,
-    mut runtime_client: RuntimeClient<ClaimService<InjectPropagation<Channel>>>,
+    mut runtime_client: runtime::Client,
     address: SocketAddr,
     deployment_updater: impl DeploymentUpdater,
     cleanup: impl FnOnce(Option<SubscribeStopResponse>) + Send + 'static,

--- a/deployer/src/deployment/state_change_layer.rs
+++ b/deployer/src/deployment/state_change_layer.rs
@@ -153,8 +153,8 @@ mod tests {
     use shuttle_proto::{
         builder::{builder_server::Builder, BuildRequest, BuildResponse},
         logger::{
-            logger_client::LoggerClient, logger_server::Logger, Batcher, LogLine, LogsRequest,
-            LogsResponse, StoreLogsRequest, StoreLogsResponse,
+            self, logger_server::Logger, Batcher, LogLine, LogsRequest, LogsResponse,
+            StoreLogsRequest, StoreLogsResponse,
         },
         provisioner::{
             provisioner_server::{Provisioner, ProvisionerServer},
@@ -360,13 +360,7 @@ mod tests {
     }
 
     async fn get_runtime_manager(
-        logger_client: Batcher<
-            LoggerClient<
-                shuttle_common::claims::ClaimService<
-                    shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-                >,
-            >,
-        >,
+        logger_client: Batcher<logger::Client>,
     ) -> Arc<tokio::sync::Mutex<RuntimeManager>> {
         let provisioner_addr =
             SocketAddr::new(Ipv4Addr::LOCALHOST.into(), pick_unused_port().unwrap());

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -9,10 +9,7 @@ pub use persistence::Persistence;
 use proxy::AddressGetter;
 pub use runtime_manager::RuntimeManager;
 use shuttle_common::log::LogRecorder;
-use shuttle_proto::{
-    builder::builder_client::BuilderClient,
-    logger::{self},
-};
+use shuttle_proto::{builder, logger};
 use tokio::sync::Mutex;
 use tracing::{error, info};
 use ulid::Ulid;
@@ -37,13 +34,7 @@ pub async fn start(
     runtime_manager: Arc<Mutex<RuntimeManager>>,
     log_recorder: impl LogRecorder,
     log_fetcher: logger::Client,
-    builder_client: Option<
-        BuilderClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-            >,
-        >,
-    >,
+    builder_client: Option<builder::Client>,
     args: Args,
 ) {
     // when _set is dropped once axum exits, the deployment tasks will be aborted.

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -9,7 +9,10 @@ pub use persistence::Persistence;
 use proxy::AddressGetter;
 pub use runtime_manager::RuntimeManager;
 use shuttle_common::log::LogRecorder;
-use shuttle_proto::{builder::builder_client::BuilderClient, logger::logger_client::LoggerClient};
+use shuttle_proto::{
+    builder::builder_client::BuilderClient,
+    logger::{self},
+};
 use tokio::sync::Mutex;
 use tracing::{error, info};
 use ulid::Ulid;
@@ -33,11 +36,7 @@ pub async fn start(
     persistence: Persistence,
     runtime_manager: Arc<Mutex<RuntimeManager>>,
     log_recorder: impl LogRecorder,
-    log_fetcher: LoggerClient<
-        shuttle_common::claims::ClaimService<
-            shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-        >,
-    >,
+    log_fetcher: logger::Client,
     builder_client: Option<
         BuilderClient<
             shuttle_common::claims::ClaimService<

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -3,16 +3,14 @@ use std::process::exit;
 use clap::Parser;
 use shuttle_common::{
     backends::trace::setup_tracing,
-    claims::{ClaimLayer, InjectPropagationLayer},
     log::{Backend, DeploymentLogLayer},
 };
 use shuttle_deployer::{start, start_proxy, Args, Persistence, RuntimeManager, StateChangeLayer};
 use shuttle_proto::{
     // builder::builder_client::BuilderClient,
-    logger::{logger_client::LoggerClient, Batcher},
+    logger::{self, Batcher},
 };
 use tokio::select;
-use tower::ServiceBuilder;
 use tracing::{error, trace};
 use tracing_subscriber::prelude::*;
 use ulid::Ulid;
@@ -34,16 +32,7 @@ async fn main() {
     )
     .await;
 
-    let channel = ServiceBuilder::new()
-        .layer(ClaimLayer)
-        .layer(InjectPropagationLayer)
-        .service(
-            args.logger_uri
-                .connect()
-                .await
-                .expect("failed to connect to logger"),
-        );
-    let logger_client = LoggerClient::new(channel);
+    let logger_client = logger::get_client(args.logger_uri.clone()).await;
     let logger_batcher = Batcher::wrap(logger_client.clone());
 
     let builder_client = None;

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -28,7 +28,7 @@ async fn main() {
     let (persistence, _) = Persistence::new(
         &args.state,
         args.resource_recorder.clone(),
-        &args.provisioner_address,
+        args.provisioner_address.clone(),
         Ulid::from_string(args.project_id.as_str())
             .expect("to get a valid ULID for project_id arg"),
     )

--- a/deployer/src/runtime_manager.rs
+++ b/deployer/src/runtime_manager.rs
@@ -12,7 +12,7 @@ use shuttle_common::{
     log::Backend,
 };
 use shuttle_proto::{
-    logger::{logger_client::LoggerClient, Batcher, LogItem, LogLine},
+    logger::{self, Batcher, LogItem, LogLine},
     runtime::{runtime_client::RuntimeClient, StopRequest},
 };
 use shuttle_service::{runner, Environment};
@@ -41,26 +41,14 @@ type Runtimes = Arc<
 pub struct RuntimeManager {
     runtimes: Runtimes,
     provisioner_address: String,
-    logger_client: Batcher<
-        LoggerClient<
-            shuttle_common::claims::ClaimService<
-                shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-            >,
-        >,
-    >,
+    logger_client: Batcher<logger::Client>,
     auth_uri: Option<String>,
 }
 
 impl RuntimeManager {
     pub fn new(
         provisioner_address: String,
-        logger_client: Batcher<
-            LoggerClient<
-                shuttle_common::claims::ClaimService<
-                    shuttle_common::claims::InjectPropagation<tonic::transport::Channel>,
-                >,
-            >,
-        >,
+        logger_client: Batcher<logger::Client>,
         auth_uri: Option<String>,
     ) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -41,4 +41,4 @@ logger = [
 ]
 provisioner = ["http", "tower"]
 resource-recorder = ["anyhow", "async-trait", "http", "serde_json", "shuttle-common/backend", "tower"]
-runtime = ["tower"]
+runtime = ["anyhow", "tokio", "tower", "tracing"]

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -30,14 +30,15 @@ portpicker = { workspace = true }
 default = []
 test-utils = ["portpicker"]
 
-builder = []
+builder = ["http", "tower"]
 logger = [
     "shuttle-common/service",
     "chrono",
+    "http",
     "tracing",
     "tokio/macros",
     "tokio/time",
 ]
-provisioner = []
+provisioner = ["http", "tower"]
 resource-recorder = ["anyhow", "async-trait", "http", "serde_json", "shuttle-common/backend", "tower"]
-runtime = []
+runtime = ["tower"]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -34,7 +34,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
-tower = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 wasi-common = { version = "13.0.0", optional = true }
 wasmtime = { version = "13.0.0", optional = true }

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -21,7 +21,7 @@ use shuttle_common::{
     secrets::Secret,
 };
 use shuttle_proto::{
-    provisioner::{self},
+    provisioner,
     runtime::{
         runtime_server::{Runtime, RuntimeServer},
         LoadRequest, LoadResponse, StartRequest, StartResponse, StopReason, StopRequest,

--- a/runtime/src/alpha/mod.rs
+++ b/runtime/src/alpha/mod.rs
@@ -16,12 +16,12 @@ use shuttle_common::{
         auth::{AuthPublicKey, JwtAuthenticationLayer},
         trace::ExtractPropagationLayer,
     },
-    claims::{Claim, ClaimLayer, InjectPropagationLayer},
+    claims::Claim,
     resource,
     secrets::Secret,
 };
 use shuttle_proto::{
-    provisioner::provisioner_client::ProvisionerClient,
+    provisioner::{self},
     runtime::{
         runtime_server::{Runtime, RuntimeServer},
         LoadRequest, LoadResponse, StartRequest, StartResponse, StopReason, StopRequest,
@@ -38,7 +38,6 @@ use tonic::{
     transport::{Endpoint, Server},
     Request, Response, Status,
 };
-use tower::ServiceBuilder;
 
 use crate::__internals::{print_version, ProvisionerFactory, ResourceTracker};
 
@@ -204,19 +203,8 @@ where
         } = request.into_inner();
         println!("loading alpha service at {path}");
 
-        let channel = self
-            .provisioner_address
-            .clone()
-            .connect()
-            .await
-            .context("failed to connect to provisioner")
-            .map_err(|err| Status::internal(err.to_string()))?;
-        let channel = ServiceBuilder::new()
-            .layer(ClaimLayer)
-            .layer(InjectPropagationLayer)
-            .service(channel);
-
-        let provisioner_client = ProvisionerClient::new(channel);
+        let provisioner_client =
+            provisioner::get_client(self.provisioner_address.uri().clone()).await;
 
         // TODO: merge new & old secrets
 

--- a/runtime/src/provisioner_factory.rs
+++ b/runtime/src/provisioner_factory.rs
@@ -2,22 +2,16 @@ use std::{collections::BTreeMap, path::PathBuf};
 
 use async_trait::async_trait;
 use shuttle_common::{
-    claims::{Claim, ClaimService, InjectPropagation},
-    constants::STORAGE_DIRNAME,
-    database,
-    secrets::Secret,
-    DatabaseInfo,
+    claims::Claim, constants::STORAGE_DIRNAME, database, secrets::Secret, DatabaseInfo,
 };
-use shuttle_proto::provisioner::{
-    provisioner_client::ProvisionerClient, ContainerRequest, ContainerResponse, DatabaseRequest,
-};
+use shuttle_proto::provisioner::{self, ContainerRequest, ContainerResponse, DatabaseRequest};
 use shuttle_service::{DeploymentMetadata, Environment, Factory};
-use tonic::{transport::Channel, Request};
+use tonic::Request;
 
 /// A factory (service locator) which goes through the provisioner crate
 pub struct ProvisionerFactory {
     service_name: String,
-    provisioner_client: ProvisionerClient<ClaimService<InjectPropagation<Channel>>>,
+    provisioner_client: provisioner::Client,
     secrets: BTreeMap<String, Secret<String>>,
     env: Environment,
     claim: Option<Claim>,
@@ -25,7 +19,7 @@ pub struct ProvisionerFactory {
 
 impl ProvisionerFactory {
     pub(crate) fn new(
-        provisioner_client: ProvisionerClient<ClaimService<InjectPropagation<Channel>>>,
+        provisioner_client: provisioner::Client,
         service_name: String,
         secrets: BTreeMap<String, Secret<String>>,
         env: Environment,

--- a/runtime/tests/integration/helpers.rs
+++ b/runtime/tests/integration/helpers.rs
@@ -6,24 +6,20 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use shuttle_common::claims::{ClaimService, InjectPropagation};
 use shuttle_proto::{
     provisioner::{
         provisioner_server::{Provisioner, ProvisionerServer},
         ContainerRequest, ContainerResponse, DatabaseDeletionResponse, DatabaseRequest,
         DatabaseResponse, Ping, Pong,
     },
-    runtime::runtime_client::RuntimeClient,
+    runtime,
 };
 use shuttle_service::{builder::build_workspace, runner, Environment};
 use tokio::process::Child;
-use tonic::{
-    transport::{Channel, Server},
-    Request, Response, Status,
-};
+use tonic::{transport::Server, Request, Response, Status};
 
 pub struct TestRuntime {
-    pub runtime_client: RuntimeClient<ClaimService<InjectPropagation<Channel>>>,
+    pub runtime_client: runtime::Client,
     pub bin_path: String,
     pub service_name: String,
     pub runtime_address: SocketAddr,

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -29,7 +29,6 @@ serde = { workspace = true, features = ["derive"] }
 strfmt = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
-tower = { workspace = true, optional = true }
 toml = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
@@ -48,4 +47,4 @@ builder = [
     "toml",
     "tracing",
 ]
-runner = ["shuttle-proto/runtime", "tokio/process", "dunce", "tower"]
+runner = ["shuttle-proto/runtime", "tokio/process", "dunce"]


### PR DESCRIPTION
## Description of change
During the RDS work a pattern was starting for client code to connect to our internal services. This PR extends that pattern to the clients of all our services.

Ie. the client of a service can be found at: `use service_mod::Client`.
And the client can be constructed using `service_mod::get_client().await`.


## How has this been tested? (if applicable)
The compiler is still happy :smile: 


