### PR TITLE
feat(deployer): load phase caching, automatic startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,14 @@ DOCKER_COMPOSE_ENV=\
 	SHUTTLE_ENV=$(SHUTTLE_ENV)\
 	SHUTTLE_SERVICE_VERSION=$(SHUTTLE_SERVICE_VERSION)
 
-.PHONY: clean cargo-clean images the-shuttle-images shuttle-% postgres otel deploy test docker-compose.rendered.yml up down
+.PHONY: clean deep-clean images the-shuttle-images shuttle-% postgres otel deploy test docker-compose.rendered.yml up down
 
 clean:
 	rm .shuttle-*
 	rm docker-compose.rendered.yml
 
-cargo-clean:
-	find . -type d \( -name target -or -name .shuttle-executables \) | xargs rm -rf
+deep-clean:
+	find . -type d \( -name target -or -name .shuttle-executables -or -name node_modules \) | xargs rm -rf
 
 images: the-shuttle-images postgres otel
 

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -245,7 +245,7 @@ impl Queued {
             project_id: self.project_id,
             tracing_context: Default::default(),
             is_next,
-            claim: self.claim,
+            claim: Some(self.claim),
             secrets,
         };
 

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -280,7 +280,7 @@ impl Built {
             .await
             .map_err(Error::Runtime)?;
 
-        // Check for cached resources for this deployment id. This only happens on wakeup from idle.
+        // Check for cached resources for this deployment id. This only succeeds on wakeup from idle or project restart.
         let resources = if let Some(bytes) = std::fs::read(&cached_resources_path)
             .ok()
             .and_then(|bytes| serde_json::from_slice(bytes.as_slice()).ok())

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -256,6 +256,9 @@ impl Built {
         let executable_path = project_path
             .join(EXECUTABLE_DIRNAME)
             .join(self.id.to_string());
+        let cached_resources_path = project_path
+            .join(EXECUTABLE_DIRNAME)
+            .join(format!("{}.resources", self.id));
 
         // Let the runtime expose its user HTTP port on port 8000
         let address = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 8000);
@@ -281,60 +284,80 @@ impl Built {
 
         info!("Loading resources");
 
-        let mut new_secrets = self.secrets;
-        let prev_resources = resource_manager
-            .get_resources(&self.service_id, self.claim.clone())
-            .await
-            .map_err(|err| Error::Load(err.to_string()))?
-            .resources
-            .into_iter()
-            .map(resource::Response::try_from)
-            // Ignore and trace the errors for resources with corrupted data, returning just the valid resources.
-            // TODO: investigate how the resource data can get corrupted.
-            .filter_map(|resource| {
-                resource
-                    .map_err(|err| {
-                        error!(error = ?err, "failed to parse resource data");
-                    })
-                    .ok()
-            })
-            // inject old secrets into the secrets added in this deployment
-            .inspect(|r| {
-                if r.r#type == shuttle_common::resource::Type::Secrets {
-                    match serde_json::from_value::<SecretStore>(r.data.clone()) {
-                        Ok(ss) => {
-                            // Combine old and new, but insert old first so that new ones override.
-                            let mut combined = HashMap::from_iter(ss.into_iter());
-                            combined.extend(new_secrets.clone().into_iter());
-                            new_secrets = combined;
-                        }
-                        Err(err) => {
-                            error!(error = ?err, "failed to parse old secrets data");
+        // Check for cached resources for this deployment id. This only happens on wakeup from idle.
+        let resources = if let Some(bytes) = std::fs::read(&cached_resources_path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice(bytes.as_slice()).ok())
+        {
+            bytes
+        }
+        // Default case for handling resources and provisioning
+        else {
+            let mut new_secrets = self.secrets;
+            let prev_resources = resource_manager
+                .get_resources(&self.service_id, self.claim.clone())
+                .await
+                .map_err(|err| Error::Load(err.to_string()))?
+                .resources
+                .into_iter()
+                .map(resource::Response::try_from)
+                // Ignore and trace the errors for resources with corrupted data, returning just the valid resources.
+                // TODO: investigate how the resource data can get corrupted.
+                .filter_map(|resource| {
+                    resource
+                        .map_err(|err| {
+                            error!(error = ?err, "failed to parse resource data");
+                        })
+                        .ok()
+                })
+                // inject old secrets into the secrets added in this deployment
+                .inspect(|r| {
+                    if r.r#type == shuttle_common::resource::Type::Secrets {
+                        match serde_json::from_value::<SecretStore>(r.data.clone()) {
+                            Ok(ss) => {
+                                // Combine old and new, but insert old first so that new ones override.
+                                let mut combined = HashMap::from_iter(ss.into_iter());
+                                combined.extend(new_secrets.clone().into_iter());
+                                new_secrets = combined;
+                            }
+                            Err(err) => {
+                                error!(error = ?err, "failed to parse old secrets data");
+                            }
                         }
                     }
-                }
-            })
-            .collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
 
-        let resources = load(
-            self.service_name.clone(),
-            runtime_client.clone(),
-            &new_secrets,
-        )
-        .await?;
+            let resources = load(
+                self.service_name.clone(),
+                runtime_client.clone(),
+                &new_secrets,
+            )
+            .await?;
 
-        let resources = provision(
-            self.service_name.as_str(),
-            self.service_id,
-            provisioner_client,
-            resource_manager,
-            self.claim,
-            prev_resources,
-            resources,
-            new_secrets,
-        )
-        .await
-        .map_err(Error::Provision)?;
+            let resources = provision(
+                self.service_name.as_str(),
+                self.service_id,
+                provisioner_client,
+                resource_manager,
+                self.claim,
+                prev_resources,
+                resources,
+                new_secrets,
+            )
+            .await
+            .map_err(Error::Provision)?;
+
+            // cache the final resources output for use in wakeups
+            // this should only happen on deployment, and not on wakeups
+            std::fs::write(
+                &cached_resources_path,
+                serde_json::to_vec(&resources).expect("resources to serialize"),
+            )
+            .map_err(|_| Error::Load("Failed to save resource cache".into()))?;
+
+            resources
+        };
 
         kill_old_deployments.await?;
 

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -39,7 +39,7 @@ use shuttle_proto::logger::LogsRequest;
 
 use crate::persistence::{Deployment, Persistence, State};
 use crate::{
-    deployment::{Built, DeploymentManager, Queued},
+    deployment::{DeploymentManager, Queued},
     persistence::resource::ResourceManager,
 };
 pub use {self::error::Error, self::error::Result, self::local::set_jwt_bearer};
@@ -430,32 +430,10 @@ pub async fn delete_deployment(
     }
 }
 
-#[instrument(skip_all, fields(shuttle.project.name = %project_name, %deployment_id))]
-pub async fn start_deployment(
-    Extension(persistence): Extension<Persistence>,
-    Extension(deployment_manager): Extension<DeploymentManager>,
-    Extension(claim): Extension<Claim>,
-    Extension(project_id): Extension<Ulid>,
-    CustomErrorPath((project_name, deployment_id)): CustomErrorPath<(String, Uuid)>,
-) -> Result<()> {
-    if let Some(deployment) = persistence.get_runnable_deployment(&deployment_id).await? {
-        let built = Built {
-            id: deployment.id,
-            service_name: deployment.service_name,
-            service_id: deployment.service_id,
-            project_id,
-            tracing_context: Default::default(),
-            is_next: deployment.is_next,
-            claim,
-            secrets: Default::default(),
-        };
-        deployment_manager.run_push(built).await;
-
-        Ok(())
-    } else {
-        Err(Error::NotFound("deployment not found".to_string()))
-    }
-}
+/// Deprecated.
+/// Now always starts the last running deployment on start up / wake up.
+/// Kept around for compatibility.
+pub async fn start_deployment() {}
 
 #[instrument(skip_all, fields(shuttle.project.name = %project_name, %deployment_id))]
 pub async fn get_logs(

--- a/deployer/tests/integration_run.rs
+++ b/deployer/tests/integration_run.rs
@@ -311,13 +311,15 @@ async fn panic_in_bind() {
 }
 
 async fn make_and_built(crate_name: &str) -> (Built, PathBuf) {
+    // relative to deployer crate root
     let crate_dir: PathBuf = [RESOURCES_PATH, crate_name].iter().collect();
+    let target_dir: PathBuf = [RESOURCES_PATH, "target"].iter().collect();
 
     Command::new("cargo")
         .args(["build"])
         .current_dir(&crate_dir)
         // Let all tests compile against the same target dir, since their dependency trees are identical
-        .env("CARGO_TARGET_DIR", "../target")
+        .env("CARGO_TARGET_DIR", "../target") // relative to current_dir
         .spawn()
         .unwrap()
         .wait()
@@ -331,7 +333,7 @@ async fn make_and_built(crate_name: &str) -> (Built, PathBuf) {
     };
 
     let id = Uuid::new_v4();
-    let exe_path = crate_dir.join("target/debug").join(bin_name);
+    let exe_path = target_dir.join("debug").join(bin_name);
     let new_dir = crate_dir.join(EXECUTABLE_DIRNAME);
     let new_exe_path = new_dir.join(id.to_string());
 

--- a/deployer/tests/integration_run.rs
+++ b/deployer/tests/integration_run.rs
@@ -316,6 +316,8 @@ async fn make_and_built(crate_name: &str) -> (Built, PathBuf) {
     Command::new("cargo")
         .args(["build"])
         .current_dir(&crate_dir)
+        // Let all tests compile against the same target dir, since their dependency trees are identical
+        .env("CARGO_TARGET_DIR", "../target")
         .spawn()
         .unwrap()
         .wait()
@@ -343,7 +345,12 @@ async fn make_and_built(crate_name: &str) -> (Built, PathBuf) {
             project_id: Ulid::new(),
             tracing_context: Default::default(),
             is_next: false,
-            claim: Default::default(),
+            claim: Some(Claim::new(
+                "test".into(),
+                Vec::new(),
+                shuttle_common::claims::AccountTier::Basic,
+                shuttle_common::claims::AccountTier::Basic,
+            )),
             secrets: Default::default(),
         },
         RESOURCES_PATH.into(), // is later joined with `service_name` to arrive at `crate_name`

--- a/deployer/tests/resources/bind-panic/Cargo.toml
+++ b/deployer/tests/resources/bind-panic/Cargo.toml
@@ -9,4 +9,3 @@ edition = "2021"
 
 [dependencies]
 shuttle-runtime = { path = "../../../../runtime" }
-tokio = "1.22"

--- a/deployer/tests/resources/load-panic/Cargo.toml
+++ b/deployer/tests/resources/load-panic/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 [workspace]
 
 [dependencies]
-shuttle-runtime = "0.39.0"
-shuttle-service = "0.39.0"
-tokio = "1.22"
+shuttle-runtime = { path = "../../../../runtime" }
+shuttle-service = { path = "../../../../service" }

--- a/deployer/tests/resources/main-panic/Cargo.toml
+++ b/deployer/tests/resources/main-panic/Cargo.toml
@@ -8,4 +8,3 @@ edition = "2021"
 
 [dependencies]
 shuttle-runtime = { path = "../../../../runtime" }
-tokio = "1.22"

--- a/deployer/tests/resources/sleep-async/Cargo.toml
+++ b/deployer/tests/resources/sleep-async/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 
 [dependencies]
 shuttle-runtime = { path = "../../../../runtime" }
-tokio = { version = "1.0", features = ["time"]}
+tokio = { version = "1.0", features = ["time"] }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- Make deployer always start its last running deploy on startup (restart / wakeup) instead of waiting for gateway's request for doing it manually
- Save resources when a service is started with a claim (deployment request with contact with backends), and read it on subsequent wakeups/restarts to not need any backend request.
- Fix incorrect deployment id of 'running' service being returned by `status`

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

- On staging, no 503/502 was observed on first idle hit against a hello world, (same test gave 502 on prod)
