### PR TITLE
feat(cargo-shuttle): `--secrets` arg to use non-default secrets file

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -291,7 +291,7 @@ pub struct RunArgs {
 #[derive(Parser, Debug, Default)]
 pub struct SecretsArgs {
     /// Use this secrets file instead
-    #[arg(long, value_parser = OsStringValueParser::new().try_map(parse_path_exists))]
+    #[arg(long, value_parser = OsStringValueParser::new().try_map(parse_path))]
     pub secrets: Option<PathBuf>,
 }
 
@@ -413,19 +413,6 @@ fn parse_path(path: OsString) -> Result<PathBuf, io::Error> {
             format!("could not turn {path:?} into a real path: {e}"),
         )
     })
-}
-
-/// Helper function to parse and check if the path exists
-fn parse_path_exists(path: OsString) -> Result<PathBuf, io::Error> {
-    let path = parse_path(path)?;
-    if !path.exists() {
-        return Err(io::Error::new(
-            ErrorKind::InvalidInput,
-            format!("{path:?} does not exist"),
-        ));
-    }
-
-    Ok(path)
 }
 
 /// Helper function to parse, create if not exists, and return the absolute path

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -38,7 +38,7 @@ pub struct ShuttleArgs {
 }
 
 // Common args for subcommands that deal with projects.
-#[derive(Parser, Debug)]
+#[derive(Parser, Clone, Debug)]
 pub struct ProjectArgs {
     /// Specify the working directory
     #[arg(global = true, long, visible_alias = "wd", default_value = ".", value_parser = OsStringValueParser::new().try_map(parse_path))]
@@ -259,7 +259,7 @@ pub struct LogoutArgs {
     #[arg(long)]
     pub reset_api_key: bool,
 }
-#[derive(Parser)]
+#[derive(Parser, Default)]
 pub struct DeployArgs {
     /// Allow deployment with uncommitted files
     #[arg(long, visible_alias = "ad")]
@@ -269,7 +269,7 @@ pub struct DeployArgs {
     pub no_test: bool,
 
     #[command(flatten)]
-    pub secrets: SecretsArgs,
+    pub secret_args: SecretsArgs,
 }
 
 #[derive(Parser, Debug)]
@@ -288,7 +288,7 @@ pub struct RunArgs {
     pub secret_args: SecretsArgs,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 pub struct SecretsArgs {
     /// Use this secrets file instead
     #[arg(long, value_parser = OsStringValueParser::new().try_map(parse_path_exists))]

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1612,7 +1612,7 @@ impl Shuttle {
             }
         }
 
-        deployment_req.data = self.make_archive()?;
+        deployment_req.data = self.make_archive(args.secret_args.secrets.clone())?;
         if deployment_req.data.len() > CREATE_SERVICE_BODY_LIMIT {
             bail!(
                 r#"The project is too large - the limit is {} MB. \
@@ -2052,7 +2052,7 @@ impl Shuttle {
         Ok(CommandOutcome::Ok)
     }
 
-    fn make_archive(&self) -> Result<Vec<u8>> {
+    fn make_archive(&self, secrets_file: Option<PathBuf>) -> Result<Vec<u8>> {
         let include_patterns = self.ctx.assets();
         let encoder = GzEncoder::new(Vec::new(), Compression::new(3));
         let mut tar = Builder::new(encoder);
@@ -2088,8 +2088,12 @@ impl Shuttle {
 
         let mut globs = GlobSetBuilder::new();
 
-        // Always include secrets
-        globs.add(Glob::new("**/Secrets.toml").unwrap());
+        if let Some(secrets_file) = secrets_file.clone() {
+            entries.push(secrets_file);
+        } else {
+            // Default: Include all Secrets.toml files
+            globs.add(Glob::new("**/Secrets.toml").unwrap());
+        }
 
         // User provided includes
         if let Some(rules) = include_patterns {
@@ -2119,10 +2123,16 @@ impl Shuttle {
                 continue;
             }
 
-            let name = path
+            let mut name = path
                 .strip_prefix(working_directory.parent().context("get parent dir")?)
                 .context("strip prefix of path")?
                 .to_owned();
+
+            // if this is the custom secrets file, rename it to Secrets.toml
+            if secrets_file.as_ref().is_some_and(|sf| sf == &path) {
+                name.pop();
+                name.push("Secrets.toml");
+            }
 
             archive_files.insert(path, name);
         }
@@ -2309,7 +2319,7 @@ mod tests {
     use flate2::read::GzDecoder;
     use tar::Archive;
 
-    use crate::args::ProjectArgs;
+    use crate::args::{DeployArgs, ProjectArgs, SecretsArgs};
     use crate::Shuttle;
     use std::fs::{self, canonicalize};
     use std::path::PathBuf;
@@ -2322,11 +2332,13 @@ mod tests {
         dunce::canonicalize(path).unwrap()
     }
 
-    fn get_archive_entries(project_args: ProjectArgs) -> Vec<String> {
+    fn get_archive_entries(project_args: ProjectArgs, deploy_args: DeployArgs) -> Vec<String> {
         let mut shuttle = Shuttle::new().unwrap();
         shuttle.load_project(&project_args).unwrap();
 
-        let archive = shuttle.make_archive().unwrap();
+        let archive = shuttle
+            .make_archive(deploy_args.secret_args.secrets)
+            .unwrap();
 
         let tar = GzDecoder::new(&archive[..]);
         let mut archive = Archive::new(tar);
@@ -2366,10 +2378,10 @@ mod tests {
         fs::write(working_directory.join("target").join("binary"), b"12345").unwrap();
 
         let project_args = ProjectArgs {
-            working_directory,
+            working_directory: working_directory.clone(),
             name: Some("archiving-test".to_owned()),
         };
-        let mut entries = get_archive_entries(project_args);
+        let mut entries = get_archive_entries(project_args.clone(), Default::default());
         entries.sort();
 
         assert_eq!(
@@ -2392,10 +2404,43 @@ mod tests {
                 "src/main.rs",
             ]
         );
+
+        fs::remove_file(working_directory.join("Secrets.toml")).unwrap();
+        let mut entries = get_archive_entries(
+            project_args,
+            DeployArgs {
+                secret_args: SecretsArgs {
+                    secrets: Some(working_directory.join("Secrets.toml.example")),
+                },
+                ..Default::default()
+            },
+        );
+        entries.sort();
+
+        assert_eq!(
+            entries,
+            vec![
+                ".gitignore",
+                ".ignore",
+                "Cargo.toml",
+                "Secrets.toml", // got moved here
+                // Secrets.toml.example was the given secrets file, so it got moved
+                "Shuttle.toml",
+                "asset1", // normal file
+                "asset2", // .gitignore'd, but included in Shuttle.toml
+                // asset3 is .ignore'd
+                "asset4",                // .gitignore'd, but un-ignored in .ignore
+                "asset5",                // .ignore'd, but included in Shuttle.toml
+                "dist/dist1",            // .gitignore'd, but included in Shuttle.toml
+                "nested/static/nested1", // normal file
+                // nested/static/nestedignore is .gitignore'd
+                "src/main.rs",
+            ]
+        );
     }
 
     #[test]
-    fn load_project_returns_proper_working_directory_in_project_args() {
+    fn finds_workspace_root() {
         let project_args = ProjectArgs {
             working_directory: path_from_workspace_root("examples/axum/hello-world/src"),
             name: None,

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -935,12 +935,14 @@ impl Shuttle {
         service: &BuiltService,
         idx: u16,
     ) -> Result<Option<(Child, runtime::Client)>> {
-        let crate_directory = service.crate_directory();
-        let secrets_path = if crate_directory.join("Secrets.dev.toml").exists() {
-            crate_directory.join("Secrets.dev.toml")
-        } else {
-            crate_directory.join("Secrets.toml")
-        };
+        let secrets_path = run_args.secret_args.secrets.clone().unwrap_or_else(|| {
+            let crate_dir = service.crate_directory();
+            if crate_dir.join("Secrets.dev.toml").exists() {
+                crate_dir.join("Secrets.dev.toml")
+            } else {
+                crate_dir.join("Secrets.toml")
+            }
+        });
         trace!("Loading secrets from {}", secrets_path.display());
 
         let secrets: HashMap<String, String> = if let Ok(secrets_str) = read_to_string(secrets_path)

--- a/common-tests/src/cargo_shuttle.rs
+++ b/common-tests/src/cargo_shuttle.rs
@@ -30,6 +30,7 @@ pub async fn cargo_shuttle_run(working_directory: &str, external: bool) -> Strin
         port,
         external,
         release: false,
+        secret_args: Default::default(),
     };
 
     let runner = Shuttle::new().unwrap().run(


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Allow non-standard secrets file on run and deploy commands.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Added test,
Local run works,
Deploy works
