### PR TITLE
feat: Add `diesel-async` support for `shuttle-shared-db`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -155,7 +155,7 @@ feature_flags = array "--all-features"
 ###### Crates that have mutually exclusive features define
 ###### their own set of feature flags to test:
 if eq ${path} "resources/shared-db"
-    feature_flags = array "-F mongodb" "-F postgres" "-F postgres,sqlx" "-F postgres,sqlx-native-tls"
+    feature_flags = array "-F mongodb" "-F postgres" "-F postgres,sqlx" "-F postgres,sqlx-native-tls" "-F postgres,diesel-async" "-F postgres,diesel-async-bb8" "-F postgres,diesel-async-deadpool"
 elseif eq ${path} "services/shuttle-axum"
     feature_flags = array "-F axum" "-F axum-0-6"
 elseif eq ${path} "services/shuttle-serenity"

--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["shuttle-service", "database"]
 
 [dependencies]
 async-trait = "0.1.56"
+diesel-async = { version = "0.4.1", optional = true }
 mongodb = { version = "2.3.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -21,7 +22,11 @@ default = []
 mongodb = ["dep:mongodb"]
 
 # Postgres
-postgres = ["sqlx?/postgres"]
+postgres = ["diesel-async?/postgres", "sqlx?/postgres"]
+# Postgres with diesel-async support
+diesel-async = ["dep:diesel-async"]
+diesel-async-bb8 = ["diesel-async", "diesel-async/bb8"]
+diesel-async-deadpool = ["diesel-async", "diesel-async/deadpool"]
 # Postgres with an sqlx PgPool
 sqlx = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-rustls"]
 sqlx-native-tls = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-native-tls"]


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

This is the upstreaming of [`shuttle-diesel-async`](https://github.com/aumetra/shuttle-diesel-async), it adds support to output `diesel-async` resources from `#[shuttle_shared_db::Postgres]`.

Supported resources are:

- `diesel_async::AsyncPgConnection`
- `diesel_async::pooled_connection::bb8::Pool` (for the above mentioned `AsyncPgConnection`)
- `diesel_async::pooled_connection::deadpool::Pool` (for the above mentioned `AsyncPgConnection`)

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

This is essentially 1:1 the code upstreamed from the repository, the code was used by me in a few projects and has been used by the community as well.
