### PR TITLE
chore: update test-context dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5243,7 +5243,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum 0.25.0",
- "test-context",
+ "test-context 0.3.0",
  "thiserror",
  "tokio",
  "tonic 0.10.2",
@@ -5371,7 +5371,7 @@ dependencies = [
  "strum 0.25.0",
  "tar",
  "tempfile",
- "test-context",
+ "test-context 0.3.0",
  "tokio",
  "tonic 0.10.2",
  "tower",
@@ -5429,7 +5429,7 @@ dependencies = [
  "prost-types",
  "serde_json",
  "shuttle-common",
- "test-context",
+ "test-context 0.3.0",
  "tokio",
  "tonic 0.10.2",
  "tower",
@@ -6100,7 +6100,17 @@ checksum = "b7b6965c21232186af0092233c18030fe607cfc3960dbabb209325272458eeea"
 dependencies = [
  "async-trait",
  "futures",
- "test-context-macros",
+ "test-context-macros 0.1.6",
+]
+
+[[package]]
+name = "test-context"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6676ab8513edfd2601a108621103fdb45cac9098305ca25ec93f7023b06b05d9"
+dependencies = [
+ "futures",
+ "test-context-macros 0.3.0",
 ]
 
 [[package]]
@@ -6109,6 +6119,17 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d506c7664333e246f564949bee4ed39062aa0f11918e6f5a95f553cdad65c274"
 dependencies = [
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "test-context-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ea17a2dc368aeca6f554343ced1b1e31f76d63683fa8016e5844bd7a5144a1"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn 2.0.52",
 ]
@@ -6306,7 +6327,7 @@ dependencies = [
  "lazy_static",
  "queues",
  "serde_json",
- "test-context",
+ "test-context 0.1.6",
  "tokio",
  "tokio-test",
  "tower-http 0.2.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ strfmt = "0.2.2"
 strum = { version = "0.25.0", features = ["derive"] }
 tar = "0.4.38"
 tempfile = "3.4.0"
-test-context = "0.1.4"
+test-context = "0.3.0"
 thiserror = "1.0.37"
 tokio = "1.22.0"
 tokio-stream = "0.1.11"

--- a/common/src/backends/client/gateway.rs
+++ b/common/src/backends/client/gateway.rs
@@ -114,7 +114,6 @@ impl ProjectsDal for Client {
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
     use test_context::{test_context, AsyncTestContext};
 
     use crate::models::project::{Response, State};
@@ -122,7 +121,6 @@ mod tests {
 
     use super::{Client, ProjectsDal};
 
-    #[async_trait]
     impl AsyncTestContext for Client {
         async fn setup() -> Self {
             let server = get_mocked_gateway_server().await;
@@ -130,7 +128,7 @@ mod tests {
             Client::new(server.uri().parse().unwrap(), server.uri().parse().unwrap())
         }
 
-        async fn teardown(mut self) {}
+        async fn teardown(self) {}
     }
 
     #[test_context(Client)]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -884,7 +884,6 @@ pub mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncTestContext for TestGateway {
         async fn setup() -> Self {
             let world = World::new().await;
@@ -903,7 +902,7 @@ pub mod tests {
             }
         }
 
-        async fn teardown(mut self) {}
+        async fn teardown(self) {}
     }
 
     /// Helper struct to wrap a bunch of commands to run against a test project
@@ -1159,7 +1158,6 @@ pub mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncTestContext for TestProject {
         async fn setup() -> Self {
             let mut world = TestGateway::setup().await;

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -305,7 +305,6 @@ mod _resource_recorder_client {
 
     #[cfg(test)]
     mod tests {
-        use async_trait::async_trait;
         use serde_json::json;
         use shuttle_common::{database, resource};
         use test_context::{test_context, AsyncTestContext};
@@ -316,7 +315,6 @@ mod _resource_recorder_client {
 
         use super::{get_client, Client, ResourceDal};
 
-        #[async_trait]
         impl AsyncTestContext for Client {
             async fn setup() -> Self {
                 let port = get_mocked_resource_recorder().await;
@@ -324,7 +322,7 @@ mod _resource_recorder_client {
                 get_client(format!("http://localhost:{port}").parse().unwrap()).await
             }
 
-            async fn teardown(mut self) {}
+            async fn teardown(self) {}
         }
 
         #[test_context(Client)]


### PR DESCRIPTION
## Description of change
Shuttle is using a very outdated version of `test-context`. I am updating it to the last version.


