### PR TITLE
feat(cargo-shuttle): new template system for init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common"
-version = "0.40.2"
+version = "0.40.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
  "shuttle-common-tests",
  "shuttle-proto",
  "shuttle-service",
- "strum 0.25.0",
+ "strum 0.26.1",
  "tar",
  "tempfile",
  "tokio",
@@ -1498,9 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
- "fuzzy-matcher",
  "shell-words",
- "tempfile",
  "thiserror",
  "zeroize",
 ]
@@ -1872,15 +1870,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
 ]
 
 [[package]]
@@ -5243,7 +5232,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum 0.25.0",
+ "strum 0.26.1",
  "test-context 0.3.0",
  "thiserror",
  "tokio",
@@ -5308,7 +5297,7 @@ dependencies = [
  "shuttle-proto",
  "shuttle-service",
  "sqlx",
- "strum 0.25.0",
+ "strum 0.26.1",
  "tar",
  "tempfile",
  "thiserror",
@@ -5369,7 +5358,7 @@ dependencies = [
  "shuttle-proto",
  "snailquote",
  "sqlx",
- "strum 0.25.0",
+ "strum 0.26.1",
  "tar",
  "tempfile",
  "test-context 0.3.0",
@@ -5478,7 +5467,7 @@ dependencies = [
  "shuttle-common-tests",
  "shuttle-proto",
  "sqlx",
- "strum 0.25.0",
+ "strum 0.26.1",
  "thiserror",
  "tokio",
  "tonic 0.10.2",
@@ -5934,11 +5923,11 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -5956,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,9 @@ bollard = "0.15.0"
 bytes = "1.3.0"
 cargo_metadata = "0.18.1"
 chrono = { version = "0.4.23", default-features = false }
-colored = "2.0.0"
 clap = { version = "4.2.7", features = ["derive"] }
+colored = "2.0.0"
+comfy-table = "6.2.0"
 crossterm = "0.27.0"
 ctor = "0.2.5"
 dirs = "5.0.0"
@@ -59,6 +60,7 @@ futures = "0.3.27"
 headers = "0.3.8"
 home = "0.5.4"
 http = "0.2.8"
+http-body = "0.4.5"
 hyper = "0.14.23"
 # not great, but waiting for WebSocket changes to be merged
 hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "bug/host_header" }
@@ -86,7 +88,7 @@ serde = { version = "1.0.148", default-features = false }
 serde_json = "1.0.89"
 sqlx = { version = "0.7.1", features = ["runtime-tokio", "tls-rustls"] }
 strfmt = "0.2.2"
-strum = { version = "0.25.0", features = ["derive"] }
+strum = { version = "0.26.1", features = ["derive"] }
 tar = "0.4.38"
 tempfile = "3.4.0"
 test-context = "0.3.0"
@@ -108,5 +110,5 @@ ttl_cache = "0.5.1"
 ulid = "1.0.0"
 url = "2.4.0"
 uuid = "1.2.2"
-wiremock = "0.6.0-rc.3"
+wiremock = "0.6.0"
 zeroize = "1.6.0"

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -21,7 +21,7 @@ clap = { workspace = true, features = ["env"] }
 clap_complete = "4.3.1"
 clap_mangen = "0.2.15"
 crossterm = { workspace = true }
-dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
+dialoguer = { version = "0.11", default-features = false, features = ["password"] }
 dirs = { workspace = true }
 dunce = { workspace = true }
 flate2 = { workspace = true }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -33,6 +33,10 @@ pub struct ShuttleArgs {
     /// (allows targeting a custom deployed instance for this command only, mainly for development)
     #[arg(long, env = "SHUTTLE_API")]
     pub api_url: Option<String>,
+    /// Disable network requests that are not strictly necessary. Limits some features.
+    #[arg(long, env = "SHUTTLE_OFFLINE")]
+    pub offline: bool,
+
     #[command(subcommand)]
     pub cmd: Command,
 }
@@ -320,6 +324,7 @@ pub struct InitArgs {
     /// Don't initialize a new git repository
     #[arg(long)]
     pub no_git: bool,
+
     #[command(flatten)]
     pub login_args: LoginArgs,
 }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -12,7 +12,7 @@ use clap::{
     Parser, ValueEnum,
 };
 use clap_complete::Shell;
-use shuttle_common::constants::DEFAULT_IDLE_MINUTES;
+use shuttle_common::constants::{DEFAULT_IDLE_MINUTES, EXAMPLES_REPO};
 use shuttle_common::resource;
 use uuid::Uuid;
 
@@ -324,38 +324,35 @@ pub struct InitArgs {
     pub login_args: LoginArgs,
 }
 
-#[derive(ValueEnum, Clone, Debug, strum::Display, strum::EnumIter)]
-#[strum(serialize_all = "kebab-case")]
+#[derive(ValueEnum, Clone, Debug, strum::EnumMessage, strum::VariantArray)]
 pub enum InitTemplateArg {
-    /// Actix Web framework
-    ActixWeb,
-    /// Axum web framework
+    /// Axum - Modular web framework from the Tokio ecosystem
     Axum,
-    /// Loco web framework
-    Loco,
-    /// Poem web framework
-    Poem,
-    /// Poise Discord framework
-    Poise,
-    /// Rocket web framework
+    /// Actix Web - Powerful and fast web framework
+    ActixWeb,
+    /// Rocket - Simple and easy-to-use web framework
     Rocket,
-    /// Salvo web framework
+    /// Loco - Batteries included web framework based on Axum
+    Loco,
+    /// Salvo - Powerful and simple web framework
     Salvo,
-    /// Serenity Discord framework
+    /// Poem - Full-featured and easy-to-use web framework
+    Poem,
+    /// Poise - Discord Bot framework with good slash command support
+    Poise,
+    /// Serenity - Discord Bot framework
     Serenity,
-    /// Thruster web framework
-    Thruster,
-    /// Tide web framework
-    Tide,
-    /// Tower web framework
+    /// Tower - Modular service library
     Tower,
-    /// Warp web framework
+    /// Thruster - Web framework
+    Thruster,
+    /// Tide - Web framework
+    Tide,
+    /// Warp - Web framework
     Warp,
-    /// No template - Custom empty service
+    /// No template - Make a custom service
     None,
 }
-
-pub const EXAMPLES_REPO: &str = "https://github.com/shuttle-hq/shuttle-examples";
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TemplateLocation {

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -12,7 +12,7 @@ use gix::create::{self, Kind};
 use gix::remote::fetch::Shallow;
 use gix::{open, progress};
 use regex::Regex;
-use shuttle_common::constants::SHUTTLE_EXAMPLES_README;
+use shuttle_common::constants::EXAMPLES_README;
 use tempfile::{Builder, TempDir};
 use toml_edit::{value, Document};
 use url::Url;
@@ -101,8 +101,8 @@ fn setup_template(auto_path: &str) -> Result<TempDir> {
         // `owner` and `name` are required for the regex to
         // match. Thus, we don't need to check if they exist.
         let url = format!("{vendor}{}/{}.git", &caps["owner"], &caps["name"]);
-        gix_clone(&url, temp_dir.path())
-            .with_context(|| format!("Failed to clone template Git repository at {url}"))?;
+        println!(r#"Cloning from "{}"..."#, url);
+        gix_clone(&url, temp_dir.path()).context("Failed to clone git repository")?;
     } else if Path::new(auto_path).is_absolute() || auto_path.starts_with('.') {
         if Path::new(auto_path).exists() {
             copy_dirs(Path::new(auto_path), temp_dir.path(), GitDir::Copy)?;
@@ -121,7 +121,7 @@ fn setup_template(auto_path: &str) -> Result<TempDir> {
                 or use another method of specifying the template location."
             );
             println!(
-                "HINT: You can find examples of how to select a template here: {SHUTTLE_EXAMPLES_README}"
+                "HINT: You can find examples of how to select a template here: {EXAMPLES_README}"
             );
             anyhow::bail!("invalid URL scheme")
         }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -441,30 +441,12 @@ impl Shuttle {
         let template = match git_template {
             Some(git_template) => git_template,
             None => {
-                // /// Can be used during testing
-                // async fn get_schema() -> Result<TemplatesSchema> {
-                //     Ok(toml::from_str(include_str!(
-                //         "../../examples/templates.toml"
-                //     ))?)
-                // }
-                async fn get_schema() -> Result<TemplatesSchema> {
-                    let client = reqwest::Client::new();
-                    Ok(toml::from_str(
-                        &client
-                            .get(shuttle_common::constants::EXAMPLES_TEMPLATES_TOML)
-                            .send()
-                            .await?
-                            .text()
-                            .await?,
-                    )?)
-                }
-
                 // Try to present choices from our up-to-date examples.
                 // Fall back to the internal (potentially outdated) list.
                 let schema = if offline {
                     None
                 } else {
-                    get_schema()
+                    get_templates_schema()
                         .await
                         .map_err(|_| {
                             println!(
@@ -2231,6 +2213,24 @@ impl Shuttle {
 
         Ok(bytes)
     }
+}
+
+// /// Can be used during testing
+// async fn get_templates_schema() -> Result<TemplatesSchema> {
+//     Ok(toml::from_str(include_str!(
+//         "../../examples/templates.toml"
+//     ))?)
+// }
+async fn get_templates_schema() -> Result<TemplatesSchema> {
+    let client = reqwest::Client::new();
+    Ok(toml::from_str(
+        &client
+            .get(shuttle_common::constants::EXAMPLES_TEMPLATES_TOML)
+            .send()
+            .await?
+            .text()
+            .await?,
+    )?)
 }
 
 fn is_dirty(repo: &Repository) -> Result<()> {

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -225,7 +225,13 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
 
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
-    command.args(["init", "--force-name", "--api-key", "dh9z58jttoes3qvt"]);
+    command.args([
+        "--offline",
+        "init",
+        "--force-name",
+        "--api-key",
+        "dh9z58jttoes3qvt",
+    ]);
     let mut session = rexpect::session::spawn_command(command, Some(EXPECT_TIMEOUT_MS))?;
 
     session.exp_string("What do you want to name your project?")?;
@@ -234,12 +240,8 @@ fn interactive_rocket_init() -> Result<(), Box<dyn std::error::Error>> {
     session.exp_string("Where should we create this project?")?;
     session.exp_string("Directory")?;
     session.send_line(temp_dir_path.join("my-project").to_str().unwrap())?;
-    session.exp_string(
-        "Shuttle works with a range of web frameworks. Which one do you want to use?",
-    )?;
-    session.exp_string("Framework")?;
-    // Partial input should be enough to match "rocket"
-    session.send_line("roc")?;
+    session.exp_string("Which one do you want to use?")?;
+    session.send_line("\t\t")?;
     session.exp_string("Creating project")?;
     session.exp_string("container on Shuttle?")?;
     session.send("n")?;
@@ -260,7 +262,13 @@ fn interactive_rocket_init_manually_choose_template() -> Result<(), Box<dyn std:
 
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
-    command.args(["init", "--force-name", "--api-key", "dh9z58jttoes3qvt"]);
+    command.args([
+        "--offline",
+        "init",
+        "--force-name",
+        "--api-key",
+        "dh9z58jttoes3qvt",
+    ]);
     let mut session = rexpect::session::spawn_command(command, Some(EXPECT_TIMEOUT_MS))?;
 
     session.exp_string("What do you want to name your project?")?;
@@ -269,12 +277,8 @@ fn interactive_rocket_init_manually_choose_template() -> Result<(), Box<dyn std:
     session.exp_string("Where should we create this project?")?;
     session.exp_string("Directory")?;
     session.send_line(temp_dir_path.join("my-project").to_str().unwrap())?;
-    session.exp_string(
-        "Shuttle works with a range of web frameworks. Which one do you want to use?",
-    )?;
-    session.exp_string("Framework")?;
-    // Partial input should be enough to match "rocket"
-    session.send_line("roc")?;
+    session.exp_string("Which one do you want to use?")?;
+    session.send_line("\t\t")?;
     session.exp_string("Creating project")?;
     session.exp_string("container on Shuttle?")?;
     session.send("n")?;
@@ -296,6 +300,7 @@ fn interactive_rocket_init_dont_prompt_framework() -> Result<(), Box<dyn std::er
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
     command.args([
+        "--offline",
         "init",
         "--force-name",
         "--api-key",
@@ -332,6 +337,7 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
     command.args([
+        "--offline",
         "init",
         "--force-name",
         "--api-key",
@@ -344,12 +350,8 @@ fn interactive_rocket_init_dont_prompt_name() -> Result<(), Box<dyn std::error::
     session.exp_string("Where should we create this project?")?;
     session.exp_string("Directory")?;
     session.send_line(temp_dir_path.join("my-project").to_str().unwrap())?;
-    session.exp_string(
-        "Shuttle works with a range of web frameworks. Which one do you want to use?",
-    )?;
-    session.exp_string("Framework")?;
-    // Partial input should be enough to match "rocket"
-    session.send_line("roc")?;
+    session.exp_string("Which one do you want to use?")?;
+    session.send_line("\t\t")?;
     session.exp_string("Creating project")?;
     session.exp_string("container on Shuttle?")?;
     session.send("n")?;
@@ -373,6 +375,7 @@ fn interactive_rocket_init_prompt_path_dirty_dir() -> Result<(), Box<dyn std::er
     let bin_path = assert_cmd::cargo::cargo_bin("cargo-shuttle");
     let mut command = Command::new(bin_path);
     command.args([
+        "--offline",
         "init",
         "--api-key",
         "dh9z58jttoes3qvt",

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -20,6 +20,7 @@ async fn cargo_shuttle_command(
                     working_directory,
                     name: None,
                 },
+                offline: false,
                 cmd,
             },
             false,

--- a/common-tests/src/cargo_shuttle.rs
+++ b/common-tests/src/cargo_shuttle.rs
@@ -40,6 +40,7 @@ pub async fn cargo_shuttle_run(working_directory: &str, external: bool) -> Strin
                 working_directory: working_directory.clone(),
                 name: None,
             },
+            offline: false,
             cmd: Command::Run(run_args),
         },
         false,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shuttle-common"
-version = "0.40.2"
+version = "0.40.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,11 +14,11 @@ async-trait = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 bytes = { workspace = true, optional = true }
 chrono = { workspace = true }
-comfy-table = { version = "6.2.0", optional = true }
+comfy-table = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
 headers = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
-http-body = { version = "0.4.5", optional = true }
+http-body = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true, optional = true }
 once_cell = { workspace = true, optional = true }

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -30,6 +30,9 @@ pub const RUNTIME_NAME: &str = "shuttle-runtime";
 /// Current version field in requests to provisioner
 pub const RESOURCE_SCHEMA_VERSION: u32 = 1;
 
+/// Current version field in `examples/templates.toml`
+pub const TEMPLATES_SCHEMA_VERSION: u32 = 0;
+
 /// Timeframe before a project is considered idle
 pub const DEFAULT_IDLE_MINUTES: u64 = 30;
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -31,7 +31,7 @@ pub const RUNTIME_NAME: &str = "shuttle-runtime";
 pub const RESOURCE_SCHEMA_VERSION: u32 = 1;
 
 /// Current version field in `examples/templates.toml`
-pub const TEMPLATES_SCHEMA_VERSION: u32 = 0;
+pub const TEMPLATES_SCHEMA_VERSION: u32 = 1;
 
 /// Timeframe before a project is considered idle
 pub const DEFAULT_IDLE_MINUTES: u64 = 30;

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -17,10 +17,12 @@ pub const SHUTTLE_STATUS_URL: &str = "https://status.shuttle.rs";
 pub const SHUTTLE_LOGIN_URL: &str = "https://console.shuttle.rs/new-project";
 pub const SHUTTLE_GH_ISSUE_URL: &str = "https://github.com/shuttle-hq/shuttle/issues/new/choose";
 pub const SHUTTLE_INSTALL_DOCS_URL: &str = "https://docs.shuttle.rs/getting-started/installation";
-pub const SHUTTLE_CLI_DOCS_URL: &str = "https://docs.shuttle.rs/getting-started/shuttle-commands";
 pub const SHUTTLE_IDLE_DOCS_URL: &str = "https://docs.shuttle.rs/getting-started/idle-projects";
-pub const SHUTTLE_EXAMPLES_README: &str =
+pub const EXAMPLES_REPO: &str = "https://github.com/shuttle-hq/shuttle-examples";
+pub const EXAMPLES_README: &str =
     "https://github.com/shuttle-hq/shuttle-examples#how-to-clone-run-and-deploy-an-example";
+pub const EXAMPLES_TEMPLATES_TOML: &str =
+    "https://raw.githubusercontent.com/shuttle-hq/shuttle-examples/main/templates.toml";
 
 // Crate name for checking cargo metadata
 pub const RUNTIME_NAME: &str = "shuttle-runtime";

--- a/common/src/templates.rs
+++ b/common/src/templates.rs
@@ -16,7 +16,7 @@ pub struct TemplateDefinition {
     pub description: Option<String>,
     /// Path relative to the repo root
     pub path: Option<String>,
-    /// "starter" OR "template" (default) OR "tutorial"
+    /// High-level classification of what this template is
     #[serde(default)]
     pub r#type: TemplateType,
     /// List of areas where this template is useful. Examples: "Web app", "Discord bot", "Monitoring", "Automation", "Utility"
@@ -37,11 +37,16 @@ pub struct TemplateDefinition {
     pub repo: Option<String>,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TemplateType {
+    /// A very basic template, typically Hello World
     Starter,
+    /// A non-starter template
     #[default]
     Template,
+    /// An example not meant to be a template
+    Example,
+    /// An example app with an attached tutorial
     Tutorial,
 }

--- a/common/src/templates.rs
+++ b/common/src/templates.rs
@@ -5,7 +5,16 @@ use serde::{Deserialize, Serialize};
 /// Schema used in `examples/templates.toml` and services that parses it
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TemplatesSchema {
+    /// Very basic templates, typically Hello World
+    pub starters: HashMap<String, TemplateDefinition>,
+    /// Non-starter templates
     pub templates: HashMap<String, TemplateDefinition>,
+    /// Examples not meant to be templates
+    pub examples: HashMap<String, TemplateDefinition>,
+    /// Examples with attached tutorials
+    pub tutorials: HashMap<String, TemplateDefinition>,
+    /// Templates made by community members
+    pub community_templates: HashMap<String, TemplateDefinition>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -13,12 +22,9 @@ pub struct TemplateDefinition {
     /// Title of the template
     pub title: String,
     /// A short description of the template
-    pub description: Option<String>,
+    pub description: String,
     /// Path relative to the repo root
     pub path: Option<String>,
-    /// High-level classification of what this template is
-    #[serde(default)]
-    pub r#type: TemplateType,
     /// List of areas where this template is useful. Examples: "Web app", "Discord bot", "Monitoring", "Automation", "Utility"
     pub use_cases: Vec<String>,
     /// List of keywords that describe the template. Examples: "axum", "serenity", "typescript", "saas", "fullstack", "database"
@@ -29,24 +35,9 @@ pub struct TemplateDefinition {
     /// If this template is available in the `cargo shuttle init --template` short-hand options, add that name here
     pub template: Option<String>,
 
-    /// Set this to true if this is a community template outside of the shuttle-examples repo
-    pub community: Option<bool>,
+    ////// Fields for community templates
     /// GitHub username of the author of the community template
     pub author: Option<String>,
     /// URL to the repo of the community template
     pub repo: Option<String>,
-}
-
-#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TemplateType {
-    /// A very basic template, typically Hello World
-    Starter,
-    /// A non-starter template
-    #[default]
-    Template,
-    /// An example not meant to be a template
-    Example,
-    /// An example app with an attached tutorial
-    Tutorial,
 }

--- a/common/src/templates.rs
+++ b/common/src/templates.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-/// Schema used in `examples/templates.toml` and services that parses it
+/// Schema used in `examples/templates.toml` and services that parse it
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TemplatesSchema {
+    /// Version of this schema
+    pub version: u32,
     /// Very basic templates, typically Hello World
     pub starters: HashMap<String, TemplateDefinition>,
     /// Non-starter templates


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

New flow in the init command that allows browsing the full list of templates.

WIP preview:
![image](https://github.com/shuttle-hq/shuttle/assets/54029719/f4325796-14be-466c-8615-77ac6345a320)


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

updated tests
