### PR TITLE
fix(gateway): proxy wait for service port to open

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ jobs:
           public-registry: << parameters.public-registry >>
           # `registry-id` field is required, although we don't need it (used for private registry).
           # We give it a non-empty env variable name to bypass the `ecr-login` empty check.
-          registry-id: bruh
+          registry-id: TAG
       - docker-buildx/install:
           version: 0.12.1
           qemu-user-static-version: 7.2.0-1

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -36,6 +36,9 @@ pub const fn default_idle_minutes() -> u64 {
     DEFAULT_IDLE_MINUTES
 }
 
+/// The port that deployer tells the runtime to expose its service on
+pub const DEPLOYER_SERVICE_HTTP_PORT: u16 = 8000;
+
 pub mod limits {
     pub const MAX_PROJECTS_DEFAULT: u32 = 3;
     pub const MAX_PROJECTS_EXTRA: u32 = 15;

--- a/deployer/src/deployment/run.rs
+++ b/deployer/src/deployment/run.rs
@@ -12,7 +12,7 @@ use opentelemetry::global;
 use serde::de::DeserializeOwned;
 use shuttle_common::{
     claims::Claim,
-    constants::{EXECUTABLE_DIRNAME, RESOURCE_SCHEMA_VERSION},
+    constants::{DEPLOYER_SERVICE_HTTP_PORT, EXECUTABLE_DIRNAME, RESOURCE_SCHEMA_VERSION},
     deployment::{
         DEPLOYER_END_MSG_COMPLETED, DEPLOYER_END_MSG_CRASHED, DEPLOYER_END_MSG_STARTUP_ERR,
         DEPLOYER_END_MSG_STOPPED, DEPLOYER_RUNTIME_START_FAILED, DEPLOYER_RUNTIME_START_RESPONSE,
@@ -255,8 +255,8 @@ impl Built {
             .join(EXECUTABLE_DIRNAME)
             .join(format!("{}.resources", self.id));
 
-        // Let the runtime expose its user HTTP port on port 8000
-        let address = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 8000);
+        // Let the runtime expose its HTTP port
+        let address = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), DEPLOYER_SERVICE_HTTP_PORT);
 
         let runtime_client = runtime_manager
             .lock()

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -436,7 +436,10 @@ async fn route_project(
             .await?;
     }
 
-    let project = service.find_or_start_project(&project_name, sender).await?;
+    let project = service
+        .find_or_start_project(&project_name, sender)
+        .await?
+        .0;
     service
         .route(&project.state, &project_name, &scoped_user.user.name, req)
         .await

--- a/gateway/src/api/project_caller.rs
+++ b/gateway/src/api/project_caller.rs
@@ -34,7 +34,10 @@ impl ProjectCaller {
             service, sender, ..
         } = state;
         let project_name = scoped_user.scope;
-        let project = service.find_or_start_project(&project_name, sender).await?;
+        let project = service
+            .find_or_start_project(&project_name, sender)
+            .await?
+            .0;
 
         Ok(Self {
             project: project.state,

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::{ConnectInfo, Path, State};
 use axum::headers::{HeaderMapExt, Host};
@@ -23,11 +24,13 @@ use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
 use shuttle_common::backends::cache::{CacheManagement, CacheManager};
 use shuttle_common::backends::headers::XShuttleProject;
+use shuttle_common::constants::DEPLOYER_SERVICE_HTTP_PORT;
 use shuttle_common::models::error::InvalidProjectName;
 use shuttle_common::models::project::ProjectName;
+use tokio::net::TcpSocket;
 use tokio::sync::mpsc::Sender;
 use tower_sanitize_path::SanitizePath;
-use tracing::{debug_span, error, field, trace};
+use tracing::{debug, debug_span, error, field, trace};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::acme::AcmeClient;
@@ -97,10 +100,11 @@ async fn proxy(
     let target_ip = if let Some(ip) = { state.project_cache.get(project_name.as_str()) } {
         ip
     } else {
-        let ip = state
+        let (proj, was_stopped) = state
             .gateway
             .find_or_start_project(&project_name, state.task_sender.clone())
-            .await?
+            .await?;
+        let ip = proj
             .state
             .target_ip()?
             .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotReady))?;
@@ -109,9 +113,33 @@ async fn proxy(
             ip,
             std::time::Duration::from_millis(1000),
         );
+
+        if was_stopped {
+            // wait until service has started and opens its port, give up after 10s
+            span.in_scope(|| {
+                debug!("project waking up, checking service port");
+            });
+            let addr = SocketAddr::new(ip, DEPLOYER_SERVICE_HTTP_PORT);
+            let _ = tokio::time::timeout(Duration::from_secs(10), async move {
+                let mut ms = 5;
+                loop {
+                    if let Ok(socket) = TcpSocket::new_v4() {
+                        if let Ok(_) = socket.connect(addr).await {
+                            break;
+                        }
+                    }
+                    trace!("waiting for service port to open");
+                    // exponential backoff
+                    tokio::time::sleep(Duration::from_millis(ms)).await;
+                    ms *= 2;
+                }
+            })
+            .await;
+        }
+
         ip
     };
-    let target_url = format!("http://{}:{}", target_ip, 8000);
+    let target_url = format!("http://{}:{}", target_ip, DEPLOYER_SERVICE_HTTP_PORT);
 
     let cx = span.context();
     global::get_text_map_propagator(|propagator| {

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -120,11 +120,15 @@ async fn proxy(
                 debug!("project waking up, checking service port");
             });
             let addr = SocketAddr::new(ip, DEPLOYER_SERVICE_HTTP_PORT);
+            let span_clone = span.clone();
             let _ = tokio::time::timeout(Duration::from_secs(10), async move {
                 let mut ms = 5;
                 loop {
                     if let Ok(socket) = TcpSocket::new_v4() {
                         if socket.connect(addr).await.is_ok() {
+                            span_clone.in_scope(|| {
+                                debug!("service port detected open");
+                            });
                             break;
                         }
                     }

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -124,7 +124,7 @@ async fn proxy(
                 let mut ms = 5;
                 loop {
                     if let Ok(socket) = TcpSocket::new_v4() {
-                        if let Ok(_) = socket.connect(addr).await {
+                        if socket.connect(addr).await.is_ok() {
                             break;
                         }
                     }

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -876,10 +876,10 @@ impl GatewayService {
         task_sender: Sender<BoxedTask>,
     ) -> Result<(FindProjectPayload, bool), Error> {
         let mut project = self.find_project(project_name).await?;
-        let mut was_stopped = false;
 
         // Start the project if it is idle
-        if project.state.is_stopped() {
+        let is_stopped = project.state.is_stopped();
+        if is_stopped {
             trace!(shuttle.project.name = %project_name, "starting up idle project");
 
             let handle = self
@@ -894,10 +894,9 @@ impl GatewayService {
             // Wait for project to come up and set new state
             handle.await;
             project = self.find_project(project_name).await?;
-            was_stopped = true;
         }
 
-        Ok((project, was_stopped))
+        Ok((project, is_stopped))
     }
 
     /// Get project id of a project, by name.

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -874,8 +874,9 @@ impl GatewayService {
         self: &Arc<Self>,
         project_name: &ProjectName,
         task_sender: Sender<BoxedTask>,
-    ) -> Result<FindProjectPayload, Error> {
+    ) -> Result<(FindProjectPayload, bool), Error> {
         let mut project = self.find_project(project_name).await?;
+        let mut was_stopped = false;
 
         // Start the project if it is idle
         if project.state.is_stopped() {
@@ -893,9 +894,10 @@ impl GatewayService {
             // Wait for project to come up and set new state
             handle.await;
             project = self.find_project(project_name).await?;
+            was_stopped = true;
         }
 
-        Ok(project)
+        Ok((project, was_stopped))
     }
 
     /// Get project id of a project, by name.


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Fixes (?) the `{"message":"Project returned invalid response","status_code":502}` error on the first hit on an idled project by checking the TCP port of the service before proxying the request.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

An axum project that had a 2s sleep in the main function was deployed. (2s delay between "ready" and `bind`; simulates slow setup logic or other lag in that phase)
The wakeup proxy hits correctly waited and got 200.
