### PR TITLE
refactor(auth, gateway): use user_id over account_name

### DIFF
--- a/auth/migrations/0004_user_id_not_null.sql
+++ b/auth/migrations/0004_user_id_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ALTER COLUMN user_id SET NOT NULL;

--- a/auth/src/api/builder.rs
+++ b/auth/src/api/builder.rs
@@ -66,12 +66,12 @@ impl ApiBuilder {
             .route("/auth/key", get(convert_key))
             .route("/auth/refresh", post(refresh_token))
             .route("/public-key", get(get_public_key))
-            .route("/users/:account_name", get(get_user))
+            .route("/users/:user_id", get(get_user))
             .route("/users/:account_name/:account_tier", post(post_user))
             .route("/users/reset-api-key", put(put_user_reset_key))
-            .route("/users/:account_name/subscribe", post(post_subscription))
+            .route("/users/:user_id/subscribe", post(post_subscription))
             .route(
-                "/users/:account_name/subscribe/:subscription_id",
+                "/users/:user_id/subscribe/:subscription_id",
                 delete(delete_subscription),
             )
             .route_layer(from_extractor::<Metrics>())
@@ -79,7 +79,7 @@ impl ApiBuilder {
                 TraceLayer::new(|request| {
                     request_span!(
                         request,
-                        request.params.account_name = field::Empty,
+                        request.params.user_id = field::Empty,
                         request.params.account_tier = field::Empty,
                     )
                 })

--- a/auth/src/api/handlers.rs
+++ b/auth/src/api/handlers.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Error,
-    user::{AccountName, Admin, Key},
+    user::{Admin, Key},
 };
 use axum::{
     extract::{Path, State},
@@ -9,7 +9,7 @@ use axum::{
 use http::StatusCode;
 use shuttle_common::{
     claims::{AccountTier, Claim},
-    models::user::{self, SubscriptionRequest},
+    models::user::{self, SubscriptionRequest, UserId},
 };
 use tracing::instrument;
 
@@ -18,24 +18,25 @@ use super::{
     RouterState,
 };
 
-#[instrument(skip_all, fields(account.name = %account_name))]
+#[instrument(skip_all, fields(account.user_id = %user_id))]
 pub(crate) async fn get_user(
     _: Admin,
     State(user_manager): State<UserManagerState>,
-    Path(account_name): Path<AccountName>,
+    Path(user_id): Path<UserId>,
 ) -> Result<Json<user::Response>, Error> {
-    let user = user_manager.get_user(account_name).await?;
+    let user = user_manager.get_user(user_id).await?;
 
     Ok(Json(user.into()))
 }
 
-#[instrument(skip_all, fields(account.name = %account_name, account.tier = %account_tier))]
+#[instrument(skip_all, fields(account.account_name = %account_name, account.tier = %account_tier))]
 pub(crate) async fn post_user(
     _: Admin,
     State(user_manager): State<UserManagerState>,
-    Path((account_name, account_tier)): Path<(AccountName, AccountTier)>,
+    Path((account_name, account_tier)): Path<(String, AccountTier)>,
 ) -> Result<Json<user::Response>, Error> {
     let user = user_manager.create_user(account_name, account_tier).await?;
+    // TODO?: Add `user.id` to span's `account.user_id`?
 
     Ok(Json(user.into()))
 }
@@ -44,24 +45,19 @@ pub(crate) async fn put_user_reset_key(
     State(user_manager): State<UserManagerState>,
     key: Key,
 ) -> Result<(), Error> {
-    let account_name = user_manager.get_user_by_key(key.into()).await?.name;
+    let user_id = user_manager.get_user_by_key(key.into()).await?.id;
 
-    user_manager.reset_key(account_name).await
+    user_manager.reset_key(user_id).await
 }
 
 pub(crate) async fn post_subscription(
     _: Admin,
     State(user_manager): State<UserManagerState>,
-    Path(account_name): Path<AccountName>,
+    Path(user_id): Path<UserId>,
     payload: Json<SubscriptionRequest>,
 ) -> Result<(), Error> {
     user_manager
-        .insert_subscription(
-            &account_name,
-            &payload.id,
-            &payload.r#type,
-            payload.quantity,
-        )
+        .insert_subscription(&user_id, &payload.id, &payload.r#type, payload.quantity)
         .await?;
 
     Ok(())
@@ -70,10 +66,10 @@ pub(crate) async fn post_subscription(
 pub(crate) async fn delete_subscription(
     _: Admin,
     State(user_manager): State<UserManagerState>,
-    Path((account_name, subscription_id)): Path<(AccountName, String)>,
+    Path((user_id, subscription_id)): Path<(UserId, String)>,
 ) -> Result<(), Error> {
     user_manager
-        .delete_subscription(&account_name, &subscription_id)
+        .delete_subscription(&user_id, &subscription_id)
         .await?;
 
     Ok(())
@@ -99,7 +95,7 @@ pub(crate) async fn convert_key(
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
 
     let claim = Claim::new(
-        user.name.to_string(),
+        user.id.clone(),
         user.account_tier.into(),
         user.account_tier,
         user,

--- a/auth/src/args.rs
+++ b/auth/src/args.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use clap::{Parser, Subcommand};
+use shuttle_common::models::user::UserId;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -37,9 +38,9 @@ pub struct StartArgs {
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct InitArgs {
-    /// Name of initial account to create
+    /// User id of account to create
     #[arg(long)]
-    pub name: String,
+    pub user_id: UserId,
     /// Key to assign to initial account
     #[arg(long)]
     pub key: Option<String>,

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -68,21 +68,5 @@ pub async fn pgpool_init(db_uri: &str) -> io::Result<PgPool> {
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-    // Post-migration logic for 0003.
-    // This is done here to skip the need for postgres extensions.
-    let names: Vec<(String,)> =
-        sqlx::query_as("SELECT account_name FROM users WHERE user_id IS NULL")
-            .fetch_all(&pool)
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    for (name,) in names {
-        sqlx::query("UPDATE users SET user_id = $1 WHERE account_name = $2")
-            .bind(User::new_user_id())
-            .bind(name)
-            .execute(&pool)
-            .await
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-    }
-
     Ok(pool)
 }

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -39,17 +39,17 @@ pub async fn init(pool: PgPool, args: InitArgs, tier: AccountTier) -> io::Result
     };
 
     query("INSERT INTO users (account_name, key, account_tier, user_id) VALUES ($1, $2, $3, $4)")
-        .bind(&args.name)
+        .bind("")
         .bind(&key)
         .bind(tier.to_string())
-        .bind(crate::User::new_user_id())
+        .bind(&args.user_id)
         .execute(&pool)
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
     println!(
         "`{}` created as {} with key: {}",
-        args.name,
+        args.user_id,
         tier,
         key.as_ref()
     );

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -38,10 +38,11 @@ pub async fn init(pool: PgPool, args: InitArgs, tier: AccountTier) -> io::Result
         None => ApiKey::generate(),
     };
 
-    query("INSERT INTO users (account_name, key, account_tier) VALUES ($1, $2, $3)")
+    query("INSERT INTO users (account_name, key, account_tier, user_id) VALUES ($1, $2, $3, $4)")
         .bind(&args.name)
         .bind(&key)
         .bind(tier.to_string())
+        .bind(crate::User::new_user_id())
         .execute(&pool)
         .await
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/auth/tests/api/auth.rs
+++ b/auth/tests/api/auth.rs
@@ -44,7 +44,7 @@ mod needs_docker {
         let claim = app.claim_from_response(response).await;
 
         // Verify the claim subject and tier matches the test user we created at the start of the test.
-        assert_eq!(claim.sub, "admin");
+        assert!(claim.sub.starts_with("user_"));
         assert_eq!(claim.tier, AccountTier::Admin);
         assert_eq!(claim.limits.project_limit(), 3);
 
@@ -64,7 +64,7 @@ mod needs_docker {
         let claim = app.claim_from_response(response).await;
 
         // Verify the claim subject and tier matches the test user we created at the start of the test.
-        assert_eq!(claim.sub, "admin");
+        assert!(claim.sub.starts_with("user_"));
         assert_eq!(claim.tier, AccountTier::Admin);
         assert_eq!(claim.limits.project_limit(), 3);
 
@@ -78,7 +78,7 @@ mod needs_docker {
         let claim = app.claim_from_response(response).await;
 
         // Verify the claim subject and tier matches the admin user.
-        assert_eq!(claim.sub, "test-user-basic");
+        assert!(claim.sub.starts_with("user_"));
         assert_eq!(claim.tier, AccountTier::Basic);
         assert_eq!(claim.limits.project_limit(), 3);
     }

--- a/auth/tests/api/helpers.rs
+++ b/auth/tests/api/helpers.rs
@@ -84,9 +84,9 @@ impl TestApp {
         self.send_request(request).await
     }
 
-    pub async fn get_user(&self, name: &str) -> Response {
+    pub async fn get_user(&self, user_id: &str) -> Response {
         let request = Request::builder()
-            .uri(format!("/users/{name}"))
+            .uri(format!("/users/{user_id}"))
             .header(AUTHORIZATION, format!("Bearer {ADMIN_KEY}"))
             .body(Body::empty())
             .unwrap();
@@ -94,8 +94,8 @@ impl TestApp {
         self.send_request(request).await
     }
 
-    pub async fn get_user_typed(&self, name: &str) -> user::Response {
-        let response = self.get_user(name).await;
+    pub async fn get_user_typed(&self, user_id: &str) -> user::Response {
+        let response = self.get_user(user_id).await;
         let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
 
         serde_json::from_slice(&body).unwrap()
@@ -132,13 +132,13 @@ impl TestApp {
 
     pub async fn post_subscription(
         &self,
-        name: &str,
+        user_id: &str,
         subscription_id: &str,
         subscription_type: &str,
         quantity: u32,
     ) -> Response {
         let request = Request::builder()
-            .uri(format!("/users/{name}/subscribe"))
+            .uri(format!("/users/{user_id}/subscribe"))
             .method("POST")
             .header(AUTHORIZATION, format!("Bearer {ADMIN_KEY}"))
             .header(CONTENT_TYPE, "application/json")
@@ -155,9 +155,9 @@ impl TestApp {
         self.send_request(request).await
     }
 
-    pub async fn delete_subscription(&self, name: &str, subscription_id: &str) -> Response {
+    pub async fn delete_subscription(&self, user_id: &str, subscription_id: &str) -> Response {
         let request = Request::builder()
-            .uri(format!("/users/{name}/subscribe/{subscription_id}"))
+            .uri(format!("/users/{user_id}/subscribe/{subscription_id}"))
             .method("DELETE")
             .header(AUTHORIZATION, format!("Bearer {ADMIN_KEY}"))
             .body(Body::empty())
@@ -193,7 +193,7 @@ impl TestApp {
         &self,
         subscription_id: &str,
         response_body: &str,
-        account_name: &str,
+        user_id: &str,
     ) -> Response {
         // This mock will apply until the end of this function scope.
         let _mock_guard = Mock::given(method("GET"))
@@ -206,6 +206,6 @@ impl TestApp {
             .mount_as_scoped(&self.mock_server)
             .await;
 
-        self.get_user(account_name).await
+        self.get_user(user_id).await
     }
 }

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -237,7 +237,7 @@ mod needs_docker {
 
         // Make sure JWT does not allow any RDS instances
         let claim = app.get_claim(basic_user_key).await;
-        assert_eq!(claim.sub, "test-user");
+        assert!(claim.sub.starts_with("user_"));
         assert_eq!(claim.limits.rds_quota(), 0);
 
         // Send a request to insert an RDS subscription for the test user.

--- a/common/src/backends/headers.rs
+++ b/common/src/backends/headers.rs
@@ -33,15 +33,15 @@ impl Header for XShuttleAdminSecret {
     }
 }
 
-pub static X_SHUTTLE_ACCOUNT_NAME: HeaderName = HeaderName::from_static("x-shuttle-account-name");
+pub static X_SHUTTLE_USER_ID: HeaderName = HeaderName::from_static("x-shuttle-user-id");
 
 /// Typed header for sending account names around
 #[derive(Default)]
-pub struct XShuttleAccountName(pub String);
+pub struct XShuttleUserId(pub String);
 
-impl Header for XShuttleAccountName {
+impl Header for XShuttleUserId {
     fn name() -> &'static HeaderName {
-        &X_SHUTTLE_ACCOUNT_NAME
+        &X_SHUTTLE_USER_ID
     }
 
     fn decode<'i, I>(values: &mut I) -> Result<Self, headers::Error>

--- a/common/src/models/admin.rs
+++ b/common/src/models/admin.rs
@@ -4,4 +4,5 @@ use serde::{Deserialize, Serialize};
 pub struct ProjectResponse {
     pub project_name: String,
     pub account_name: String,
+    pub user_id: String,
 }

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString};
 
+pub type UserId = String;
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct Response {
     pub name: String,

--- a/deployer/src/handlers/mod.rs
+++ b/deployer/src/handlers/mod.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 use shuttle_common::{
     backends::{
         auth::{AdminSecretLayer, AuthPublicKey, JwtAuthenticationLayer, ScopedLayer},
-        headers::XShuttleAccountName,
+        headers::XShuttleUserId,
         metrics::{Metrics, TraceLayer},
     },
     claims::{Claim, Scope},
@@ -156,14 +156,14 @@ impl RouterBuilder {
             .route_layer(from_extractor::<Metrics>())
             .layer(
                 TraceLayer::new(|request| {
-                    let account_name = request
+                    let user_id = request
                         .headers()
-                        .typed_get::<XShuttleAccountName>()
+                        .typed_get::<XShuttleUserId>()
                         .unwrap_or_default();
 
                     request_span!(
                         request,
-                        account.name = account_name.0,
+                        account.user_id = user_id.0,
                         request.params.project_name = field::Empty,
                         request.params.service_name = field::Empty,
                         request.params.deployment_id = field::Empty,

--- a/gateway/src/api/project_caller.rs
+++ b/gateway/src/api/project_caller.rs
@@ -5,12 +5,12 @@ use http::{HeaderMap, Method, Request, StatusCode, Uri};
 use hyper::Body;
 use serde::de::DeserializeOwned;
 use shuttle_common::{
-    models::{deployment, error::ErrorKind, project::ProjectName},
+    models::{deployment, error::ErrorKind, project::ProjectName, user::UserId},
     resource,
 };
 use uuid::Uuid;
 
-use crate::{auth::ScopedUser, project::Project, service::GatewayService, AccountName, Error};
+use crate::{auth::ScopedUser, project::Project, service::GatewayService, Error};
 
 use super::latest::RouterState;
 
@@ -18,7 +18,7 @@ use super::latest::RouterState;
 pub(crate) struct ProjectCaller {
     project: Project,
     project_name: ProjectName,
-    account_name: AccountName,
+    user_id: UserId,
     service: Arc<GatewayService>,
     headers: HeaderMap,
 }
@@ -42,7 +42,7 @@ impl ProjectCaller {
         Ok(Self {
             project: project.state,
             project_name,
-            account_name: scoped_user.user.name,
+            user_id: scoped_user.user.id,
             service,
             headers: headers.clone(),
         })
@@ -59,7 +59,7 @@ impl ProjectCaller {
             .unwrap();
 
         self.service
-            .route(&self.project, &self.project_name, &self.account_name, req)
+            .route(&self.project, &self.project_name, &self.user_id, req)
             .await
     }
 

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::str::FromStr;
 
 use axum::extract::{FromRef, FromRequestParts, Path};
 use axum::http::request::Parts;
@@ -7,10 +6,11 @@ use serde::{Deserialize, Serialize};
 use shuttle_common::claims::{Claim, Scope};
 use shuttle_common::models::error::InvalidProjectName;
 use shuttle_common::models::project::ProjectName;
+use shuttle_common::models::user::UserId;
 use tracing::{trace, Span};
 
 use crate::api::latest::RouterState;
-use crate::{AccountName, Error, ErrorKind};
+use crate::{Error, ErrorKind};
 
 /// A wrapper to enrich a token with user details
 ///
@@ -21,7 +21,7 @@ use crate::{AccountName, Error, ErrorKind};
 pub struct User {
     pub projects: Vec<ProjectName>,
     pub claim: Claim,
-    pub name: AccountName,
+    pub id: UserId,
 }
 
 #[async_trait]
@@ -34,18 +34,17 @@ where
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let claim = parts.extensions.get::<Claim>().ok_or(ErrorKind::Internal)?;
-        let name = AccountName::from_str(&claim.sub)
-            .map_err(|err| Error::source(ErrorKind::Internal, err))?;
+        let user_id = claim.sub.clone();
 
         // Record current account name for tracing purposes
-        Span::current().record("account.name", &name.to_string());
+        Span::current().record("account.user_id", &user_id.to_string());
 
         let RouterState { service, .. } = RouterState::from_ref(state);
 
         let user = User {
             claim: claim.clone(),
-            projects: service.iter_user_projects(&name).await?.collect(),
-            name,
+            projects: service.iter_user_projects(&user_id).await?.collect(),
+            id: user_id,
         };
 
         trace!(?user, "got user");

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -23,7 +23,7 @@ use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
-use shuttle_common::backends::headers::{X_SHUTTLE_ACCOUNT_NAME, X_SHUTTLE_ADMIN_SECRET};
+use shuttle_common::backends::headers::{X_SHUTTLE_ADMIN_SECRET, X_SHUTTLE_USER_ID};
 use shuttle_common::constants::{default_idle_minutes, DEFAULT_IDLE_MINUTES};
 use shuttle_common::models::project::ProjectName;
 use shuttle_common::models::service;
@@ -1497,7 +1497,7 @@ impl Service {
                 .method(Method::PUT)
                 .uri(uri)
                 .header(AUTHORIZATION, format!("Bearer {}", jwt))
-                .header(X_SHUTTLE_ACCOUNT_NAME.clone(), "gateway")
+                .header(X_SHUTTLE_USER_ID.clone(), "gateway")
                 .header(X_SHUTTLE_ADMIN_SECRET.clone(), admin_secret)
                 .body(Body::empty())?;
 
@@ -1518,7 +1518,7 @@ impl Service {
         let req = Request::builder()
             .uri(uri)
             .header(AUTHORIZATION, format!("Bearer {}", jwt))
-            .header(X_SHUTTLE_ACCOUNT_NAME.clone(), "gateway")
+            .header(X_SHUTTLE_USER_ID.clone(), "gateway")
             .header(X_SHUTTLE_ADMIN_SECRET.clone(), admin_secret)
             .body(Body::empty())?;
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -21,10 +21,11 @@ use instant_acme::{AccountCredentials, ChallengeType};
 use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
-use shuttle_common::backends::headers::{XShuttleAccountName, XShuttleAdminSecret};
+use shuttle_common::backends::headers::{XShuttleAdminSecret, XShuttleUserId};
 use shuttle_common::claims::AccountTier;
 use shuttle_common::constants::SHUTTLE_IDLE_DOCS_URL;
 use shuttle_common::models::project::{ProjectName, State};
+use shuttle_common::models::user::UserId;
 use sqlx::error::DatabaseError;
 use sqlx::migrate::Migrator;
 use sqlx::sqlite::SqlitePool;
@@ -45,7 +46,7 @@ use crate::task::{self, BoxedTask, TaskBuilder};
 use crate::tls::ChainAndPrivateKey;
 use crate::worker::TaskRouter;
 use crate::{
-    AccountName, DockerContext, DockerStatsSource, Error, ErrorKind, ProjectDetails, AUTH_CLIENT,
+    DockerContext, DockerStatsSource, Error, ErrorKind, ProjectDetails, AUTH_CLIENT,
     DOCKER_STATS_PATH_CGROUP_V1, DOCKER_STATS_PATH_CGROUP_V2,
 };
 
@@ -285,7 +286,7 @@ impl GatewayService {
         &self,
         project: &Project,
         project_name: &ProjectName,
-        account_name: &AccountName,
+        user_id: &UserId,
         mut req: Request<Body>,
     ) -> Result<Response<Body>, Error> {
         let target_ip = project
@@ -299,7 +300,7 @@ impl GatewayService {
         let control_key = self.control_key_from_project_name(project_name).await?;
 
         let headers = req.headers_mut();
-        headers.typed_insert(XShuttleAccountName(account_name.to_string()));
+        headers.typed_insert(XShuttleUserId(user_id.to_string()));
         headers.typed_insert(XShuttleAdminSecret(control_key));
 
         let cx = Span::current().context();
@@ -317,24 +318,24 @@ impl GatewayService {
 
     pub async fn iter_projects(
         &self,
-    ) -> Result<impl ExactSizeIterator<Item = (ProjectName, AccountName)>, Error> {
-        let iter = query("SELECT project_name, account_name FROM projects")
+    ) -> Result<impl ExactSizeIterator<Item = (ProjectName, UserId)>, Error> {
+        let iter = query("SELECT project_name, user_id FROM projects")
             .fetch_all(&self.db)
             .await?
             .into_iter()
-            .map(|row| (row.get("project_name"), row.get("account_name")));
+            .map(|row| (row.get("project_name"), row.get("user_id")));
         Ok(iter)
     }
 
     /// Only get an iterator for the projects that are ready
     pub async fn iter_projects_ready(
         &self,
-    ) -> Result<impl ExactSizeIterator<Item = (ProjectName, AccountName)>, Error> {
-        let iter = query("SELECT project_name, account_name FROM projects, JSON_EACH(project_state) WHERE key = 'ready'")
+    ) -> Result<impl ExactSizeIterator<Item = (ProjectName, UserId)>, Error> {
+        let iter = query("SELECT project_name, user_id FROM projects, JSON_EACH(project_state) WHERE key = 'ready'")
             .fetch_all(&self.db)
             .await?
             .into_iter()
-            .map(|row| (row.get("project_name"), row.get("account_name")));
+            .map(|row| (row.get("project_name"), row.get("user_id")));
         Ok(iter)
     }
 
@@ -409,16 +410,16 @@ impl GatewayService {
 
     pub async fn iter_user_projects_detailed(
         &self,
-        account_name: &AccountName,
+        user_id: &UserId,
         offset: u32,
         limit: u32,
     ) -> Result<impl Iterator<Item = (String, ProjectName, Project)>, Error> {
         let mut query = QueryBuilder::new(
-            "SELECT project_id, project_name, project_state FROM projects WHERE account_name = ",
+            "SELECT project_id, project_name, project_state FROM projects WHERE user_id = ",
         );
 
         query
-            .push_bind(account_name)
+            .push_bind(user_id)
             .push(" ORDER BY project_id DESC, project_name LIMIT ")
             .push_bind(limit);
 
@@ -472,15 +473,12 @@ impl GatewayService {
         Ok(())
     }
 
-    pub async fn account_name_from_project(
-        &self,
-        project_name: &ProjectName,
-    ) -> Result<AccountName, Error> {
-        query("SELECT account_name FROM projects WHERE project_name = ?1")
+    pub async fn user_id_from_project(&self, project_name: &ProjectName) -> Result<UserId, Error> {
+        query("SELECT user_id FROM projects WHERE project_name = ?1")
             .bind(project_name)
             .fetch_optional(&self.db)
             .await?
-            .map(|row| row.get("account_name"))
+            .map(|row| row.get("user_id"))
             .ok_or_else(|| Error::from(ErrorKind::ProjectNotFound(project_name.to_string())))
     }
 
@@ -499,10 +497,10 @@ impl GatewayService {
 
     pub async fn iter_user_projects(
         &self,
-        AccountName(account_name): &AccountName,
+        user_id: &UserId,
     ) -> Result<impl Iterator<Item = ProjectName>, Error> {
-        let iter = query("SELECT project_name FROM projects WHERE account_name = ?1")
-            .bind(account_name)
+        let iter = query("SELECT project_name FROM projects WHERE user_id = ?1")
+            .bind(user_id)
             .fetch_all(&self.db)
             .await?
             .into_iter()
@@ -513,21 +511,20 @@ impl GatewayService {
     pub async fn create_project(
         &self,
         project_name: ProjectName,
-        account_name: AccountName,
+        user_id: UserId,
         is_admin: bool,
         can_create_project: bool,
         idle_minutes: u64,
     ) -> Result<FindProjectPayload, Error> {
         if let Some(row) = query(
             r#"
-        SELECT project_name, project_id, account_name, initial_key, project_state
-        FROM projects
-        WHERE (project_name = ?1)
-        AND (account_name = ?2 OR ?3)
-        "#,
+            SELECT project_id, project_state
+            FROM projects
+            WHERE (project_name = ?1) AND (user_id = ?2 OR ?3)
+            "#,
         )
         .bind(&project_name)
-        .bind(&account_name)
+        .bind(&user_id)
         .bind(is_admin)
         .fetch_optional(&self.db)
         .await?
@@ -605,20 +602,19 @@ impl GatewayService {
             // Attempt to create a new one. This will fail
             // outright if the project already exists (this happens if
             // it belongs to another account).
-            self.insert_project(project_name, Ulid::new(), account_name, idle_minutes)
+            self.insert_project(project_name, Ulid::new(), user_id, idle_minutes)
                 .await
         } else {
             Err(Error::from_kind(ErrorKind::TooManyProjects))
         }
     }
 
-    pub async fn get_project_count(&self, account_name: &AccountName) -> Result<u32, Error> {
-        let proj_count: u32 =
-            query("SELECT COUNT(project_name) FROM projects WHERE account_name = ?1")
-                .bind(account_name)
-                .fetch_one(&self.db)
-                .await?
-                .get::<_, usize>(0);
+    pub async fn get_project_count(&self, user_id: &UserId) -> Result<u32, Error> {
+        let proj_count: u32 = query("SELECT COUNT(project_name) FROM projects WHERE user_id = ?1")
+            .bind(user_id)
+            .fetch_one(&self.db)
+            .await?
+            .get::<_, usize>(0);
 
         Ok(proj_count)
     }
@@ -627,7 +623,7 @@ impl GatewayService {
         &self,
         project_name: ProjectName,
         project_id: Ulid,
-        account_name: AccountName,
+        user_id: UserId,
         idle_minutes: u64,
     ) -> Result<FindProjectPayload, Error> {
         let project = SqlxJson(Project::Creating(
@@ -638,10 +634,11 @@ impl GatewayService {
             ),
         ));
 
-        query("INSERT INTO projects (project_id, project_name, account_name, initial_key, project_state) VALUES (?1, ?2, ?3, ?4, ?5)")
+        query("INSERT INTO projects (project_id, project_name, account_name, user_id, initial_key, project_state) VALUES (?1, ?2, ?3, ?4, ?5, ?6)")
             .bind(&project_id.to_string())
             .bind(&project_name)
-            .bind(&account_name)
+            .bind("")
+            .bind(&user_id)
             .bind(project.initial_key().unwrap())
             .bind(&project)
             .execute(&self.db)
@@ -772,13 +769,14 @@ impl GatewayService {
     pub async fn iter_projects_detailed(
         &self,
     ) -> Result<impl Iterator<Item = ProjectDetails>, Error> {
-        let iter = query("SELECT project_name, account_name FROM projects")
+        let iter = query("SELECT project_name, account_name, user_id FROM projects")
             .fetch_all(&self.db)
             .await?
             .into_iter()
             .map(|row| ProjectDetails {
                 project_name: row.try_get("project_name").unwrap(),
                 account_name: row.try_get("account_name").unwrap(),
+                user_id: row.try_get("user_id").unwrap(),
             });
         Ok(iter)
     }
@@ -1151,11 +1149,11 @@ pub mod tests {
         let world = World::new().await;
         let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await?);
 
-        let neo: AccountName = "neo".parse().unwrap();
-        let trinity: AccountName = "trinity".parse().unwrap();
+        let neo: UserId = "neo".to_owned();
+        let trinity: UserId = "trinity".to_owned();
         let matrix: ProjectName = "matrix".parse().unwrap();
 
-        let admin: AccountName = "admin".parse().unwrap();
+        let admin: UserId = "admin".to_owned();
 
         let creating_same_project_name = |project: &Project, project_name: &ProjectName| {
             matches!(
@@ -1183,7 +1181,8 @@ pub mod tests {
                 .expect("to get one project with its user"),
             ProjectDetails {
                 project_name: matrix.clone(),
-                account_name: neo.clone(),
+                account_name: Some("".to_owned()),
+                user_id: neo.clone(),
             }
         );
         assert_eq!(
@@ -1366,7 +1365,7 @@ pub mod tests {
         let world = World::new().await;
         let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await?);
 
-        let neo: AccountName = "neo".parse().unwrap();
+        let neo: UserId = "neo".to_owned();
         let matrix: ProjectName = "matrix".parse().unwrap();
 
         svc.create_project(matrix.clone(), neo.clone(), false, true, 0)
@@ -1418,7 +1417,7 @@ pub mod tests {
         let world = World::new().await;
         let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await?);
 
-        let account: AccountName = "neo".parse().unwrap();
+        let account: UserId = "neo".to_owned();
         let project_name: ProjectName = "matrix".parse().unwrap();
         let domain: FQDN = "neo.the.matrix".parse().unwrap();
         let certificate = "dummy certificate";
@@ -1472,7 +1471,7 @@ pub mod tests {
         let world = World::new().await;
         let svc = Arc::new(GatewayService::init(world.args(), world.pool(), "".into()).await?);
 
-        let account: AccountName = "neo".parse().unwrap();
+        let account: UserId = "neo".to_owned();
         let project_name: ProjectName = "matrix".parse().unwrap();
         let domain: FQDN = "neo.the.matrix".parse().unwrap();
         let certificate = "dummy certificate";

--- a/scripts/local-admin.sh
+++ b/scripts/local-admin.sh
@@ -9,4 +9,4 @@ export SHUTTLE_API_KEY=$key
 export SHUTTLE_API="http://localhost:8001"
 export PS1="(shuttle: local admin key) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"
 
-docker compose --file docker-compose.rendered.yml --project-name shuttle-dev exec auth /usr/local/bin/shuttle-auth --db-connection-uri=postgres://postgres:postgres@control-db init-admin --name admin --key $key
+docker compose --file docker-compose.rendered.yml --project-name shuttle-dev exec auth /usr/local/bin/shuttle-auth --db-connection-uri=postgres://postgres:postgres@control-db init-admin --user-id admin --key $key


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- Rename AccountName -> UserId but use a type alias instead of a newtype with no parsing logic (IMO user_id should not be stricly parsed to allow more flexibility)
- Rename header XShuttleAccountName -> XShuttleUserId
- Posting a user still uses account name (the only endpoint that takes it in), returns struct with a user id
- Admin call to gw still includes account_name
- Admin command logic not updated
- Auth's create user CLI command inserts user with blank name and the provided string as user_id
- New projects in gw get a blank account_name

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


