### PR TITLE
misc(deployer): improve get_logs out_of_range error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -731,14 +731,14 @@ workflows:
     jobs:
       - approve-deploy-images-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - approve-build-and-push-images-unstable:
           type: approval
-          filters:
-            branches:
-              only: main
+          # filters:
+          #   branches:
+          #     only: main
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## Description of change

If users' deployments accumulate too many logs that will be fetched in one request our logger/deployer channel will not be able to send/receive all of them at once. This is a current limitation that will be solved by #1629 , by providing the ability to
fetch a partial amount of logs.

## How has this been tested? (if applicable)

Tested on staging.


