### PR TITLE
gateway: delete project restarts them first if oudated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5350,6 +5350,7 @@ dependencies = [
  "rmp-serde",
  "rustls",
  "rustls-pemfile",
+ "semver 1.0.22",
  "serde",
  "serde_json",
  "shuttle-common",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -39,6 +39,7 @@ rcgen = "0.11.3"
 reqwest = { workspace = true }
 rustls = "0.21.7"
 rustls-pemfile = "1.0.1"
+semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["sqlite", "json", "migrate"] }

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -302,6 +302,7 @@ async fn delete_project(
             .new_task()
             .project(project_name.clone())
             .and_then(task::restart(project_id))
+            .and_then(task::run_until_done())
             .send(&state.sender)
             .await?;
 


### PR DESCRIPTION
## Description of change

Check the deployer version based on its container inspect response and restart the project before trying to delete it.
We assume it doesn't matter whether the project will be running afterward, or if the deployment will crash, given the
user wants to delete it. What's important is for the deployer to be able to handle the delete request.

## How has this been tested? (if applicable)

N/A


