### PR TITLE
feat: fall back to finding Secrets.toml in workspace root

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1035,26 +1035,30 @@ impl Shuttle {
         service: &BuiltService,
         idx: u16,
     ) -> Result<Option<(Child, runtime::Client)>> {
-        let secrets_path = run_args.secret_args.secrets.clone().unwrap_or_else(|| {
+        let secrets_file = run_args.secret_args.secrets.clone().or_else(|| {
             let crate_dir = service.crate_directory();
-            if crate_dir.join("Secrets.dev.toml").exists() {
-                crate_dir.join("Secrets.dev.toml")
-            } else {
-                crate_dir.join("Secrets.toml")
-            }
+            // Prioritise crate-local prod secrets over workspace dev secrets (in the rare case that both exist)
+            [
+                crate_dir.join("Secrets.dev.toml"),
+                crate_dir.join("Secrets.toml"),
+                service.workspace_path.join("Secrets.dev.toml"),
+                service.workspace_path.join("Secrets.toml"),
+            ].into_iter().find(|f| {
+                f.exists() && f.is_file()
+            })
         });
-        trace!("Loading secrets from {}", secrets_path.display());
-
-        let secrets: HashMap<String, String> = if let Ok(secrets_str) = read_to_string(secrets_path)
-        {
-            let secrets: HashMap<String, String> =
-                secrets_str.parse::<toml::Value>()?.try_into()?;
-
-            trace!(keys = ?secrets.keys(), "available secrets");
-
-            secrets
+        let secrets = if let Some(secrets_file) = secrets_file {
+            trace!("Loading secrets from {}", secrets_file.display());
+            if let Ok(secrets_str) = read_to_string(secrets_file) {
+                let secrets = toml::from_str::<HashMap<String, String>>(&secrets_str)?;
+                trace!(keys = ?secrets.keys(), "available secrets");
+                secrets
+            } else {
+                trace!("No secrets were loaded");
+                Default::default()
+            }
         } else {
-            trace!("No secrets were loaded");
+            trace!("No secrets file was found");
             Default::default()
         };
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1043,9 +1043,9 @@ impl Shuttle {
                 crate_dir.join("Secrets.toml"),
                 service.workspace_path.join("Secrets.dev.toml"),
                 service.workspace_path.join("Secrets.toml"),
-            ].into_iter().find(|f| {
-                f.exists() && f.is_file()
-            })
+            ]
+            .into_iter()
+            .find(|f| f.exists() && f.is_file())
         });
         let secrets = if let Some(secrets_file) = secrets_file {
             trace!("Loading secrets from {}", secrets_file.display());

--- a/deployer/src/deployment/queue.rs
+++ b/deployer/src/deployment/queue.rs
@@ -200,7 +200,7 @@ impl Queued {
         let built_service = build_deployment(&project_path, tx.clone()).await?;
 
         // Get the Secrets.toml from the shuttle service in the workspace.
-        let secrets = get_secrets(built_service.crate_directory()).await?;
+        let secrets = get_secrets(&built_service).await?;
 
         if self.will_run_tests {
             info!("Running tests before starting up");
@@ -243,16 +243,25 @@ impl fmt::Debug for Queued {
     }
 }
 
-#[instrument(skip(project_path))]
-async fn get_secrets(project_path: &Path) -> Result<HashMap<String, String>> {
-    let secrets_file = project_path.join("Secrets.toml");
+#[instrument(skip(service))]
+async fn get_secrets(service: &BuiltService) -> Result<HashMap<String, String>> {
+    let crate_dir = service.crate_directory();
+    // Prioritise crate-local secrets over workspace secrets
+    let secrets_file = [
+        crate_dir.join("Secrets.toml"),
+        service.workspace_path.join("Secrets.toml"),
+    ]
+    .into_iter()
+    .find(|f| f.exists() && f.is_file());
 
-    if secrets_file.exists() && secrets_file.is_file() {
-        let secrets_str = fs::read_to_string(secrets_file.clone()).await?;
+    if let Some(secrets_file) = secrets_file {
+        info!("Loading secrets from {}", secrets_file.display());
+        let secrets_str = fs::read_to_string(&secrets_file).await?;
 
-        let secrets = secrets_str.parse::<toml::Value>()?.try_into()?;
+        let secrets = toml::from_str::<HashMap<String, String>>(&secrets_str)?;
+        info!(keys = ?secrets.keys(), "available secrets");
 
-        fs::remove_file(secrets_file).await?;
+        fs::remove_file(&secrets_file).await?;
 
         Ok(secrets)
     } else {
@@ -391,7 +400,7 @@ async fn copy_executable(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs::File, io::Write, path::Path};
+    use std::path::Path;
 
     use tempfile::Builder;
     use tokio::fs;
@@ -538,22 +547,5 @@ ff0e55bda1ff01000000000000000000e0079c01ff12a55500280000",
                 .unwrap(),
             "barfoo"
         );
-    }
-
-    #[tokio::test]
-    async fn get_secrets() {
-        let temp = Builder::new().prefix("secrets").tempdir().unwrap();
-        let temp_p = temp.path();
-
-        let secret_p = temp_p.join("Secrets.toml");
-        let mut secret_file = File::create(secret_p.clone()).unwrap();
-        secret_file.write_all(b"KEY = 'value'").unwrap();
-
-        let actual = super::get_secrets(temp_p).await.unwrap();
-        let expected = HashMap::from([("KEY".to_string(), "value".to_string())]);
-
-        assert_eq!(actual, expected);
-
-        assert!(!secret_p.exists(), "the secrets file should be deleted");
     }
 }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

We look for Secret.toml in the *crate* directory, making placing it in the workspace root a common papercut.
This allows you to do both, with the crate dir taking prio.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested with local run and local deployment