### PR TITLE
feat(cargo-shuttle): remove retry client, add version header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,8 +992,6 @@ dependencies = [
  "portpicker",
  "regex",
  "reqwest",
- "reqwest-middleware",
- "reqwest-retry",
  "rexpect",
  "rmp-serde",
  "semver 1.0.22",
@@ -1322,7 +1320,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1338,7 +1336,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio",
- "parking_lot 0.12.1",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1699,7 +1697,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "windows-sys 0.52.0",
 ]
 
@@ -1807,7 +1805,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1973,7 +1971,7 @@ dependencies = [
  "gix-worktree",
  "gix-worktree-state",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "reqwest",
  "smallvec",
  "thiserror",
@@ -2218,7 +2216,7 @@ checksum = "feb61880816d7ec4f0b20606b498147d480860ddd9133ba542628df2f548d3ca"
 dependencies = [
  "gix-hash",
  "hashbrown 0.14.3",
- "parking_lot 0.12.1",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2327,7 +2325,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
- "parking_lot 0.12.1",
+ "parking_lot",
  "tempfile",
  "thiserror",
 ]
@@ -2347,7 +2345,7 @@ dependencies = [
  "gix-path",
  "gix-tempfile",
  "memmap2 0.7.1",
- "parking_lot 0.12.1",
+ "parking_lot",
  "smallvec",
  "thiserror",
 ]
@@ -2410,7 +2408,7 @@ checksum = "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678"
 dependencies = [
  "gix-command",
  "gix-config-value",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rustix",
  "thiserror",
 ]
@@ -2546,7 +2544,7 @@ dependencies = [
  "gix-fs",
  "libc",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "tempfile",
 ]
 
@@ -3166,9 +3164,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3352,7 +3347,7 @@ checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3510,16 +3505,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -3959,37 +3944,12 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4000,7 +3960,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -4439,15 +4399,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -4530,7 +4481,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4554,44 +4504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest-middleware"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 0.2.12",
- "reqwest",
- "serde",
- "task-local-extensions",
- "thiserror",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af20b65c2ee9746cc575acb6bd28a05ffc0d15e25c992a8f4462d8686aacb4f"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "futures",
- "getrandom 0.2.12",
- "http 0.2.12",
- "hyper 0.14.28",
- "parking_lot 0.11.2",
- "reqwest",
- "reqwest-middleware",
- "retry-policies",
- "task-local-extensions",
- "tokio",
- "tracing",
- "wasm-timer",
-]
-
-[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4599,17 +4511,6 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
-]
-
-[[package]]
-name = "retry-policies"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17dd00bff1d737c40dbcd47d4375281bf4c17933f9eef0a185fc7bacca23ecbd"
-dependencies = [
- "anyhow",
- "chrono",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -6043,15 +5944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6209,7 +6101,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.6",
@@ -6666,7 +6558,7 @@ dependencies = [
  "lazy_static",
  "log",
  "lru-cache",
- "parking_lot 0.12.1",
+ "parking_lot",
  "resolv-conf",
  "smallvec",
  "thiserror",
@@ -6685,7 +6577,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot 0.12.1",
+ "parking_lot",
  "rand 0.8.5",
  "resolv-conf",
  "smallvec",
@@ -6779,15 +6671,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -7044,21 +6927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7117,7 +6985,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "wasite",
 ]
 

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -41,8 +41,6 @@ percent-encoding = { workspace = true }
 portpicker = { workspace = true }
 regex = "1.9.5"
 reqwest = { workspace = true, features = ["json"] }
-reqwest-middleware = "0.2.0"
-reqwest-retry = "0.3.0"
 rmp-serde = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -1,9 +1,14 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use headers::{Authorization, HeaderMapExt};
 use percent_encoding::utf8_percent_encode;
+use reqwest::header::HeaderMap;
 use reqwest::RequestBuilder;
 use reqwest::Response;
 use serde::{Deserialize, Serialize};
+use shuttle_common::constants::headers::X_CARGO_SHUTTLE_VERSION;
 use shuttle_common::models::deployment::DeploymentRequest;
 use shuttle_common::models::{deployment, project, service, ToJson};
 use shuttle_common::secrets::Secret;
@@ -26,7 +31,17 @@ impl Client {
         Self {
             api_url,
             api_key: None,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .default_headers(
+                    HeaderMap::try_from(&HashMap::from([(
+                        X_CARGO_SHUTTLE_VERSION,
+                        crate::VERSION.to_owned(),
+                    )]))
+                    .unwrap(),
+                )
+                .timeout(Duration::from_secs(60))
+                .build()
+                .unwrap(),
         }
     }
 

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -34,7 +34,7 @@ impl Client {
             client: reqwest::Client::builder()
                 .default_headers(
                     HeaderMap::try_from(&HashMap::from([(
-                        X_CARGO_SHUTTLE_VERSION,
+                        X_CARGO_SHUTTLE_VERSION.clone(),
                         crate::VERSION.to_owned(),
                     )]))
                     .unwrap(),

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -1,10 +1,8 @@
 use anyhow::{Context, Result};
 use headers::{Authorization, HeaderMapExt};
 use percent_encoding::utf8_percent_encode;
+use reqwest::RequestBuilder;
 use reqwest::Response;
-use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, RequestBuilder};
-use reqwest_retry::policies::ExponentialBackoff;
-use reqwest_retry::RetryTransientMiddleware;
 use serde::{Deserialize, Serialize};
 use shuttle_common::models::deployment::DeploymentRequest;
 use shuttle_common::models::{deployment, project, service, ToJson};
@@ -21,22 +19,14 @@ pub struct Client {
     api_url: ApiUrl,
     api_key: Option<Secret<ApiKey>>,
     client: reqwest::Client,
-    retry_client: ClientWithMiddleware,
 }
 
 impl Client {
     pub fn new(api_url: ApiUrl) -> Self {
-        let client = reqwest::Client::new();
-        let retry_client = ClientBuilder::new(client.clone())
-            .with(RetryTransientMiddleware::new_with_policy(
-                ExponentialBackoff::builder().build_with_max_retries(3),
-            ))
-            .build();
         Self {
             api_url,
             api_key: None,
-            client,
-            retry_client,
+            client: reqwest::Client::new(),
         }
     }
 
@@ -79,7 +69,7 @@ impl Client {
             .context("serialize DeploymentRequest as a MessagePack byte vector")?;
 
         let url = format!("{}{}", self.api_url, path);
-        let mut builder = self.retry_client.post(url);
+        let mut builder = self.client.post(url);
         builder = self.set_builder_auth(builder);
 
         builder
@@ -246,7 +236,7 @@ impl Client {
     {
         let url = format!("{}{}", self.api_url, path);
 
-        let mut builder = self.retry_client.get(url);
+        let mut builder = self.client.get(url);
 
         builder = self.set_builder_auth(builder);
 
@@ -261,7 +251,7 @@ impl Client {
     async fn post<T: Serialize>(&self, path: String, body: Option<T>) -> Result<Response> {
         let url = format!("{}{}", self.api_url, path);
 
-        let mut builder = self.retry_client.post(url);
+        let mut builder = self.client.post(url);
 
         builder = self.set_builder_auth(builder);
 
@@ -277,7 +267,7 @@ impl Client {
     async fn put<T: Serialize>(&self, path: String, body: Option<T>) -> Result<Response> {
         let url = format!("{}{}", self.api_url, path);
 
-        let mut builder = self.retry_client.put(url);
+        let mut builder = self.client.put(url);
 
         builder = self.set_builder_auth(builder);
 
@@ -296,7 +286,7 @@ impl Client {
     {
         let url = format!("{}{}", self.api_url, path);
 
-        let mut builder = self.retry_client.delete(url);
+        let mut builder = self.client.delete(url);
 
         builder = self.set_builder_auth(builder);
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,7 +17,7 @@ chrono = { workspace = true }
 comfy-table = { workspace = true, optional = true }
 crossterm = { workspace = true, optional = true }
 headers = { workspace = true, optional = true }
-http = { workspace = true, optional = true }
+http = { workspace = true }
 http-body = { workspace = true, optional = true }
 hyper = { workspace = true, optional = true }
 jsonwebtoken = { workspace = true, optional = true }
@@ -76,7 +76,6 @@ claims = [
     "bytes",
     "chrono/clock",
     "headers",
-    "http",
     "http-body",
     "jsonwebtoken",
     "opentelemetry",
@@ -88,14 +87,13 @@ claims = [
 ]
 display = ["chrono/clock", "comfy-table", "crossterm"]
 extract_propagation = [
-    "http",
     "opentelemetry",
     "opentelemetry-http",
     "pin-project",
     "tower",
     "tracing-opentelemetry",
 ]
-models = ["async-trait", "http", "reqwest", "service", "thiserror"]
+models = ["async-trait", "reqwest", "service", "thiserror"]
 persist = ["sqlx", "rand"]
 sqlx = ["dep:sqlx", "sqlx/sqlite"]
 service = ["chrono/serde", "display", "tracing", "tracing-subscriber", "uuid"]

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -48,3 +48,10 @@ pub mod limits {
     pub const MAX_PROJECTS_DEFAULT: u32 = 3;
     pub const MAX_PROJECTS_EXTRA: u32 = 15;
 }
+
+pub mod headers {
+    use http::HeaderName;
+
+    pub const X_CARGO_SHUTTLE_VERSION: HeaderName =
+        HeaderName::from_static("x-cargo-shuttle-version");
+}

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -52,6 +52,6 @@ pub mod limits {
 pub mod headers {
     use http::HeaderName;
 
-    pub const X_CARGO_SHUTTLE_VERSION: HeaderName =
+    pub static X_CARGO_SHUTTLE_VERSION: HeaderName =
         HeaderName::from_static("x-cargo-shuttle-version");
 }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Our APIs should be stable enough where the retry logic is no longer relevant.
Adds a version header that can be used for better version checking later on.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

against netcat
