### PR TITLE
ci: filter jobs based on if PR is from fork

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -697,16 +697,21 @@ workflows:
               only: main
   unstable:
     jobs:
+      # allow this job on main and other internal branches, but not on PRs from forks
       - approve-deploy-images-unstable:
           type: approval
           filters:
             branches:
-              only: main
+              ignore:
+                - pull/*
+                - production
       - approve-build-and-push-images-unstable:
           type: approval
           filters:
             branches:
-              only: main
+              ignore:
+                - pull/*
+                - production
       - build-and-push:
           name: build-and-push-unstable
           aws-access-key-id: DEV_AWS_ACCESS_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,14 +630,23 @@ workflows:
                 - services/shuttle-warp
       - test-workspace-member:
           name: << matrix.crate >>
+          filters:
+            branches:
+              ignore:
+                - pull/*
           matrix:
             parameters:
               crate:
                 # - shuttle-admin # no tests
                 - shuttle-backends
+                # - shuttle-gateway # TODO: move docker-dependant tests to integration tests and activate this
+      - test-workspace-member:
+          name: << matrix.crate >>
+          matrix:
+            parameters:
+              crate:
                 - shuttle-codegen
                 - shuttle-common
-                # - shuttle-gateway # TODO: move docker-dependant tests to integration tests and activate this
       - test-workspace-member-with-integration:
           name: << matrix.crate >>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -633,7 +633,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - pull/*
+                - /pull\/.*/
           matrix:
             parameters:
               crate:
@@ -712,14 +712,14 @@ workflows:
           filters:
             branches:
               ignore:
-                - pull/*
+                - /pull\/.*/
                 - production
       - approve-build-and-push-images-unstable:
           type: approval
           filters:
             branches:
               ignore:
-                - pull/*
+                - /pull\/.*/
                 - production
       - build-and-push:
           name: build-and-push-unstable


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- Makes all internal branches except prod able to approve unstable deploy
- Skips secret-dependant backend tests for forked branches

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

- internal branch worked for #1697
- testing fork branch here, worked
