### PR TITLE
feat: auth sync users with permit

### DIFF
--- a/auth/src/args.rs
+++ b/auth/src/args.rs
@@ -19,6 +19,7 @@ pub enum Commands {
     Start(StartArgs),
     InitAdmin(InitArgs),
     InitDeployer(InitArgs),
+    Sync(SyncArgs),
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -36,6 +37,28 @@ pub struct StartArgs {
     #[arg(long, default_value = "")]
     pub jwt_signing_private_key: String,
 
+    #[command(flatten)]
+    pub permit: PermitArgs,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct InitArgs {
+    /// User id of account to create
+    #[arg(long)]
+    pub user_id: UserId,
+    /// Key to assign to initial account
+    #[arg(long)]
+    pub key: Option<String>,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct SyncArgs {
+    #[command(flatten)]
+    pub permit: PermitArgs,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct PermitArgs {
     /// Address to reach the permit.io API at
     #[arg(long, default_value = "https://api.eu-central-1.permit.io")]
     pub permit_api_uri: Uri,
@@ -48,14 +71,4 @@ pub struct StartArgs {
     /// Permit API key
     #[arg(long, default_value = "permit_")]
     pub permit_api_key: String,
-}
-
-#[derive(clap::Args, Debug, Clone)]
-pub struct InitArgs {
-    /// User id of account to create
-    #[arg(long)]
-    pub user_id: UserId,
-    /// Key to assign to initial account
-    #[arg(long)]
-    pub key: Option<String>,
 }

--- a/auth/src/main.rs
+++ b/auth/src/main.rs
@@ -6,7 +6,7 @@ use shuttle_common::{claims::AccountTier, log::Backend};
 use sqlx::migrate::Migrator;
 use tracing::trace;
 
-use shuttle_auth::{init, pgpool_init, start, Args, Commands};
+use shuttle_auth::{init, pgpool_init, start, sync, Args, Commands};
 
 pub static MIGRATIONS: Migrator = sqlx::migrate!("./migrations");
 
@@ -26,5 +26,6 @@ async fn main() -> io::Result<()> {
         Commands::Start(args) => start(pool, args).await,
         Commands::InitAdmin(args) => init(pool, args, AccountTier::Admin).await,
         Commands::InitDeployer(args) => init(pool, args, AccountTier::Deployer).await,
+        Commands::Sync(args) => sync(pool, args).await,
     }
 }


### PR DESCRIPTION
## Description of change
Adds a command to auth to allow manual syncing with permit

## How has this been tested? (if applicable)
Tested against Permit testing environment


