### PR TITLE
chore: clean up dev deps

### DIFF
--- a/services/shuttle-actix-web/Cargo.toml
+++ b/services/shuttle-actix-web/Cargo.toml
@@ -9,9 +9,6 @@ keywords = ["shuttle-service", "actix"]
 [workspace]
 
 [dependencies]
-actix-web = { version = "4.3.1" }
-shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
+actix-web = "4.3.1"
 num_cpus = "1.15.0"
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
+shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }

--- a/services/shuttle-axum/Cargo.toml
+++ b/services/shuttle-axum/Cargo.toml
@@ -13,9 +13,6 @@ axum = { version = "0.7.3", optional = true }
 axum-0-6 = { package = "axum", version = "0.6.13", optional = true }
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
 
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }
-
 [features]
 default = ["axum"]
 

--- a/services/shuttle-poem/Cargo.toml
+++ b/services/shuttle-poem/Cargo.toml
@@ -9,8 +9,5 @@ keywords = ["shuttle-service", "poem"]
 [workspace]
 
 [dependencies]
-poem = { version = "2.0.0" }
+poem = "2.0.0"
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-rocket/Cargo.toml
+++ b/services/shuttle-rocket/Cargo.toml
@@ -11,6 +11,3 @@ keywords = ["shuttle-service", "rocket"]
 [dependencies]
 rocket = "0.5.0"
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-salvo/Cargo.toml
+++ b/services/shuttle-salvo/Cargo.toml
@@ -9,8 +9,5 @@ keywords = ["shuttle-service", "salvo"]
 [workspace]
 
 [dependencies]
-salvo = { version = "0.63.0" }
+salvo = "0.63.0"
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-thruster/Cargo.toml
+++ b/services/shuttle-thruster/Cargo.toml
@@ -9,9 +9,8 @@ keywords = ["shuttle-service", "thruster"]
 [workspace]
 
 [dependencies]
-thruster = { version = "1.3.0" }
+thruster = "1.3.0"
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
 
 [dev-dependencies]
 thruster = { version = "1.3.0", features = ["hyper_server"] }
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-tide/Cargo.toml
+++ b/services/shuttle-tide/Cargo.toml
@@ -12,8 +12,5 @@ keywords = ["shuttle-service", "tide"]
 # Tide does not have tokio support. So make sure async-std is compatible with tokio
 # https://github.com/http-rs/tide/issues/791
 async-std = { version = "1.12.0", features = ["tokio1"] }
-tide = { version = "0.16.0" }
+tide = "0.16.0"
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-tower/Cargo.toml
+++ b/services/shuttle-tower/Cargo.toml
@@ -12,6 +12,3 @@ keywords = ["shuttle-service", "tower"]
 hyper = { version = "0.14.23", features = ["server", "tcp", "http1"] }
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
 tower = { version = "0.4.13", features = ["make"] }
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }

--- a/services/shuttle-warp/Cargo.toml
+++ b/services/shuttle-warp/Cargo.toml
@@ -9,8 +9,5 @@ keywords = ["shuttle-service", "warp"]
 [workspace]
 
 [dependencies]
-warp = { version = "0.3.3" }
+warp = "0.3.3"
 shuttle-runtime = { path = "../../runtime", version = "0.43.0", default-features = false }
-
-[dev-dependencies]
-tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Tokio is re-exported by runtime so the doc tests can build without it