### PR TITLE
feat: CORS support on gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       - "--provisioner-host=provisioner"
       - "--proxy-fqdn=${APPS_FQDN}"
       - "--use-tls=${USE_TLS}"
+      - "--cors-origin=https://console.shuttle.rs"
       - "--admin-key=${GATEWAY_ADMIN_KEY}"
       - "--permit-api-uri=https://api.eu-central-1.permit.io"
       - "--permit-pdp-uri=http://permit-pdp:7000"

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -44,7 +44,7 @@ strum = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tower = { workspace = true, features = ["steer"] }
-tower-http = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
 tower-sanitize-path = "0.2.0"
 tracing = { workspace = true, features = ["default"] }
 tracing-opentelemetry = { workspace = true }

--- a/gateway/src/args.rs
+++ b/gateway/src/args.rs
@@ -40,6 +40,9 @@ pub struct StartArgs {
     /// Allows to disable the use of TLS in the user proxy service (DANGEROUS)
     #[arg(long, default_value = "enable")]
     pub use_tls: UseTls,
+    /// The origin to allow CORS requests from
+    #[arg(long, default_value = "https://console.shuttle.rs")]
+    pub cors_origin: String,
     #[command(flatten)]
     pub context: ServiceArgs,
     #[command(flatten)]

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -540,6 +540,7 @@ pub mod tests {
                 user,
                 bouncer,
                 use_tls: UseTls::Disable,
+                cors_origin: "http://localhost:3001".to_string(),
                 context: ServiceArgs {
                     docker_host,
                     image,

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -250,6 +250,7 @@ async fn start(
         .with_default_routes()
         .with_auth_service(args.context.auth_uri, args.context.admin_key)
         .with_default_traces()
+        .with_cors(&args.cors_origin)
         .serve();
 
     let user_handle = user_builder.serve();


### PR DESCRIPTION
## Description of change
Allow the console to call gw directly by adding CORS support to gw and setting the origin as the console.



## How has this been tested? (if applicable)
By starting gw locally and updating a console route to call gw directly


