### PR TITLE
refactor: only use permit to check project permissions

### DIFF
--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -82,39 +82,21 @@ where
 
         let RouterState { service, .. } = RouterState::from_ref(state);
 
-        let has_bypass = user.claim.is_admin() || user.claim.is_deployer();
-
-        let allowed = has_bypass
-            || {
-                let projects: Vec<_> = service.iter_user_projects(&user.id).await?.collect();
-                let internal_allowed = projects.contains(&scope);
-
-                let permit_allowed = service
-                    .permit_client
-                    .allowed(
-                        &user.id,
-                        &service.find_project_by_name(&scope).await?.id,
-                        "develop", // TODO?: make this configurable per endpoint?
-                    )
-                    .await
-                    .map_err(|_| {
-                        error!("failed to check Permit permission");
-                        // Error::from_kind(ErrorKind::Internal)
-                    })
-                    .unwrap_or_default();
-
-                if internal_allowed != permit_allowed {
-                    error!(
-                        "PERMIT: Permissions for user {} project {} did not match internal permissions. Internal: {}, Permit: {}",
-                        user.id,
-                        scope,
-                        internal_allowed,
-                        permit_allowed
-                    );
-                }
-
-                internal_allowed
-            };
+        let allowed = user.claim.is_admin()
+            || user.claim.is_deployer()
+            || service
+                .permit_client
+                .allowed(
+                    &user.id,
+                    &service.find_project_by_name(&scope).await?.id,
+                    "develop", // TODO: make this configurable per endpoint?
+                )
+                .await
+                .map_err(|_| {
+                    error!("failed to check Permit permission");
+                    // Error::from_kind(ErrorKind::Internal)
+                })
+                .unwrap_or_default();
 
         if allowed {
             Ok(Self { user, scope })

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -94,9 +94,8 @@ where
                 .await
                 .map_err(|_| {
                     error!("failed to check Permit permission");
-                    // Error::from_kind(ErrorKind::Internal)
-                })
-                .unwrap_or_default();
+                    Error::from_kind(ErrorKind::Internal)
+                })?;
 
         if allowed {
             Ok(Self { user, scope })


### PR DESCRIPTION
## Description of change
We saw no errors in the last 24 hours nor any results different from our old internal checks. So it is safe to switch fully to permit.



## How has this been tested? (if applicable)
The compiler :grin: 


