### PR TITLE
Feat: added --quiet flag to silent local run 

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -287,6 +287,9 @@ pub struct RunArgs {
 
     #[command(flatten)]
     pub secret_args: SecretsArgs,
+
+    #[arg(long)]
+    pub quiet: bool,
 }
 
 #[derive(Parser, Debug, Default)]

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1034,6 +1034,13 @@ impl Shuttle {
         service: &BuiltService,
         idx: u16,
     ) -> Result<Option<(Child, runtime::Client)>> {
+        macro_rules! println {
+            ($($rest:tt)*) => {
+                if !std::env::args().any(|arg| arg == "--quiet") {
+                    std::println!($($rest)*);
+                }
+            }
+        }
         let secrets_file = run_args.secret_args.secrets.clone().or_else(|| {
             let crate_dir = service.crate_directory();
             // Prioritise crate-local prod secrets over workspace dev secrets (in the rare case that both exist)


### PR DESCRIPTION
## Description of change
On running a Shuttle project, it generates a lot of logs during the runtime and build time, so the `--quiet` flag can be used to avoid printing all of those.
<!-- Be sure to reference any related issues by adding `Closes #`. -->
Issue #1602 


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
Manually

