### PR TITLE
cargo-shuttle: add platform version switches

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -42,6 +42,9 @@ pub struct ShuttleArgs {
 
     #[command(subcommand)]
     pub cmd: Command,
+
+    #[arg(long, env = "PLATFORM_VERSION", default_value = "v1")]
+    pub platform_version: String,
 }
 
 // Common args for subcommands that deal with projects.

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1895,13 +1895,6 @@ impl Shuttle {
         let client = self.client.as_ref().unwrap();
         let config = &project::Config { idle_minutes };
 
-        if v2 {
-            // Create project & get project calls should return accordingly with the logic that checks
-            // whether the project was started successfully, and get back with suggestions for how to
-            // verify its state.
-            todo!();
-        }
-
         let p = self.ctx.project_name();
         wait_with_spinner(|i, pb| async move {
             let project = if i == 0 {
@@ -1939,13 +1932,18 @@ impl Shuttle {
         })?;
 
         if idle_minutes > 0 {
-            let idle_msg = format!(
-                "Your project will sleep if it is idle for {} minutes.",
-                idle_minutes
-            );
-            println!("{}", idle_msg.yellow());
-            println!("To change the idle time refer to the docs: {SHUTTLE_IDLE_DOCS_URL}");
-            println!();
+            if v2 {
+                let idle_msg = "The v2 platform ignores the idle_minutes for now.";
+                println!("{}", idle_msg.yellow());
+            } else {
+                let idle_msg = format!(
+                    "Your project will sleep if it is idle for {} minutes.",
+                    idle_minutes
+                );
+                println!("{}", idle_msg.yellow());
+                println!("To change the idle time refer to the docs: {SHUTTLE_IDLE_DOCS_URL}");
+                println!();
+            }
         }
 
         println!("Run `cargo shuttle deploy --allow-dirty` to deploy your Shuttle service.");

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -245,8 +245,8 @@ impl Shuttle {
             Command::Project(ProjectCommand::Restart(ProjectStartArgs {
                 idle_minutes, ..
             })) => self.project_restart_v1(idle_minutes).await,
-            Command::Project(ProjectCommand::Status { follow, .. }) => {
-                self.project_status(follow).await
+            Command::Project(ProjectCommand::Status { follow }) => {
+                self.project_status(follow, is_v2).await
             }
             Command::Project(ProjectCommand::List { page, limit, raw }) => {
                 self.projects_list(page, limit, raw, is_v2).await
@@ -2000,7 +2000,7 @@ impl Shuttle {
         Ok(CommandOutcome::Ok)
     }
 
-    async fn project_status(&self, follow: bool) -> Result<CommandOutcome> {
+    async fn project_status(&self, follow: bool, v2: bool) -> Result<CommandOutcome> {
         let client = self.client.as_ref().unwrap();
         if follow {
             let p = self.ctx.project_name();
@@ -2038,13 +2038,17 @@ impl Shuttle {
                         "getting project status failed repeatedly",
                     )
                 })?;
-            println!(
-                "{project}\nIdle minutes: {}",
-                project
-                    .idle_minutes
-                    .map(|i| i.to_string())
-                    .unwrap_or("<unknown>".to_owned())
-            );
+
+            println!("{project}");
+            if !v2 {
+                println!(
+                    "Idle minutes: {}",
+                    project
+                        .idle_minutes
+                        .map(|i| i.to_string())
+                        .unwrap_or("<unknown>".to_owned())
+                );
+            }
         }
 
         Ok(CommandOutcome::Ok)

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -23,6 +23,7 @@ async fn cargo_shuttle_command(
                 offline: false,
                 debug: false,
                 cmd,
+                platform_version: "v1".to_string(),
             },
             false,
         )

--- a/common-tests/src/cargo_shuttle.rs
+++ b/common-tests/src/cargo_shuttle.rs
@@ -44,6 +44,7 @@ pub async fn cargo_shuttle_run(working_directory: &str, external: bool) -> Strin
             offline: false,
             debug: false,
             cmd: Command::Run(run_args),
+            platform_version: "v1".to_string(),
         },
         false,
     );


### PR DESCRIPTION
## Description of change

Added a `platform_version` cargo-shuttle argument which can be set as environment as well. Up to this point we can use it against the new platform for:
- project start
- project status
- project list
- project delete

## How has this been tested? (if applicable)

Tested locally.

## Notes

`cargo shuttle deploy` is not supported yet, but that will happen in a follow up PR.

