### PR TITLE
feat: get project owners and only personal projects

### DIFF
--- a/backends/src/client/gateway.rs
+++ b/backends/src/client/gateway.rs
@@ -107,13 +107,17 @@ mod tests {
                     id: "00000000000000000000000001".to_string(),
                     name: "user-1-project-1".to_string(),
                     state: State::Stopped,
-                    idle_minutes: Some(30)
+                    idle_minutes: Some(30),
+                    owner: shuttle_common::models::project::Owner::User("user-1".to_string()),
+                    is_admin: true,
                 },
                 Response {
                     id: "00000000000000000000000002".to_string(),
                     name: "user-1-project-2".to_string(),
                     state: State::Ready,
-                    idle_minutes: Some(30)
+                    idle_minutes: Some(30),
+                    owner: shuttle_common::models::project::Owner::User("user-1".to_string()),
+                    is_admin: true,
                 }
             ]
         )

--- a/backends/src/client/permit.rs
+++ b/backends/src/client/permit.rs
@@ -29,10 +29,14 @@ use permit_pdp_client_rs::{
         policy_updater_api::trigger_policy_update_policy_updater_trigger_post,
         Error as PermitPDPClientError,
     },
-    models::{AuthorizationQuery, Resource, User, UserPermissionsQuery, UserPermissionsResult},
+    models::{AuthorizationQuery, Resource, User, UserPermissionsQuery},
 };
 use serde::{Deserialize, Serialize};
-use shuttle_common::{claims::AccountTier, models::organization};
+use shuttle_common::{
+    claims::AccountTier,
+    models::{error::ApiError, organization, project},
+};
+use tracing::error;
 
 #[async_trait]
 pub trait PermissionsDal {
@@ -56,6 +60,9 @@ pub trait PermissionsDal {
     /// Deletes a Project resource
     async fn delete_project(&self, project_id: &str) -> Result<()>;
 
+    /// Get list of all projects the user has direct permissions for
+    async fn get_personal_projects(&self, user_id: &str) -> Result<Vec<String>>;
+
     // Organization management
 
     /// Creates an Organization resource and assigns the user as admin for the organization
@@ -63,6 +70,10 @@ pub trait PermissionsDal {
 
     /// Deletes an Organization resource
     async fn delete_organization(&self, user_id: &str, org_id: &str) -> Result<()>;
+
+    /// Get the details of an organization
+    async fn get_organization(&self, user_id: &str, org_id: &str)
+        -> Result<organization::Response>;
 
     /// Get a list of all the organizations a user has access to
     async fn get_organizations(&self, user_id: &str) -> Result<Vec<organization::Response>>;
@@ -119,10 +130,11 @@ pub trait PermissionsDal {
 
     // Permissions queries
 
-    /// Get list of all projects user has permissions for
-    async fn get_user_projects(&self, user_id: &str) -> Result<Vec<UserPermissionsResult>>;
     /// Check if user can perform action on this project
     async fn allowed(&self, user_id: &str, project_id: &str, action: &str) -> Result<bool>;
+
+    /// Get the owner of a project
+    async fn get_project_owner(&self, user_id: &str, project_id: &str) -> Result<Owner>;
 }
 
 /// Simple details of an organization to create
@@ -145,6 +157,21 @@ impl OrganizationAttributes {
     fn new(org: &Organization) -> Self {
         Self {
             display_name: org.display_name.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Owner {
+    User(String),
+    Organization(String),
+}
+
+impl From<Owner> for project::Owner {
+    fn from(owner: Owner) -> Self {
+        match owner {
+            Owner::User(id) => project::Owner::User(id),
+            Owner::Organization(id) => project::Owner::Organization(id),
         }
     }
 }
@@ -276,24 +303,31 @@ impl PermissionsDal for Client {
         .await?)
     }
 
-    async fn get_user_projects(&self, user_id: &str) -> Result<Vec<UserPermissionsResult>> {
-        let perms = get_user_permissions_user_permissions_post(
-            &self.pdp,
-            UserPermissionsQuery {
-                user: Box::new(User {
-                    key: user_id.to_owned(),
-                    ..Default::default()
-                }),
-                resource_types: Some(vec!["Project".to_owned()]),
-                tenants: Some(vec!["default".to_owned()]),
-                ..Default::default()
-            },
+    async fn get_personal_projects(&self, user_id: &str) -> Result<Vec<String>> {
+        let projects = list_role_assignments(
+            &self.api,
+            &self.proj_id,
+            &self.env_id,
+            Some(user_id),
+            Some("admin"),
+            Some("default"),
+            Some("Project"),
+            None,
+            None,
             None,
             None,
         )
-        .await?;
+        .await?
+        .into_iter()
+        .map(|ra| ra.resource_instance.expect("to have resource instance"))
+        .map(|ri| {
+            ri.strip_prefix("Project:")
+                .expect("ID to start with the 'Project:' prefix")
+                .to_string()
+        })
+        .collect();
 
-        Ok(perms.into_values().collect())
+        Ok(projects)
     }
 
     async fn allowed(&self, user_id: &str, project_id: &str, action: &str) -> Result<bool> {
@@ -430,6 +464,52 @@ impl PermissionsDal for Client {
             .collect();
 
         Ok(projects)
+    }
+
+    async fn get_organization(
+        &self,
+        user_id: &str,
+        org_id: &str,
+    ) -> Result<organization::Response> {
+        let mut perms = get_user_permissions_user_permissions_post(
+            &self.pdp,
+            UserPermissionsQuery {
+                user: Box::new(User {
+                    key: user_id.to_owned(),
+                    ..Default::default()
+                }),
+                resources: Some(vec![format!("Organization:{org_id}")]),
+                tenants: Some(vec!["default".to_owned()]),
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .await?;
+
+        let Some(org) = perms.remove(&format!("Organization:{org_id}")) else {
+            return Err(Error::ResponseError(ResponseContent {
+                status: StatusCode::FORBIDDEN,
+                content: "User does not have permission to view the organization".to_owned(),
+                entity: "Organization".to_owned(),
+            }));
+        };
+
+        let res = if let Some(resource) = org.resource {
+            let attributes = resource.attributes.unwrap_or_default();
+            let org_attrs = serde_json::from_value::<OrganizationAttributes>(attributes)
+                .expect("to read organization attributes");
+
+            organization::Response {
+                id: resource.key,
+                display_name: org_attrs.display_name,
+                is_admin: org.roles.unwrap_or_default().contains(&"admin".to_string()),
+            }
+        } else {
+            unreachable!("the permission will always have a resource")
+        };
+
+        Ok(res)
     }
 
     async fn get_organizations(&self, user_id: &str) -> Result<Vec<organization::Response>> {
@@ -639,6 +719,40 @@ impl PermissionsDal for Client {
             .collect();
 
         Ok(members)
+    }
+
+    async fn get_project_owner(&self, user_id: &str, project_id: &str) -> Result<Owner> {
+        if !self.allowed(user_id, project_id, "view").await? {
+            return Err(Error::ResponseError(ResponseContent {
+                status: StatusCode::FORBIDDEN,
+                content: "User does not have permission to view the project".to_owned(),
+                entity: "Project".to_owned(),
+            }));
+        }
+
+        let relationships = list_relationship_tuples(
+            &self.api,
+            &self.proj_id,
+            &self.env_id,
+            Some(true),
+            None,
+            None,
+            Some("default"),
+            None,
+            Some("parent"),
+            Some(&format!("Project:{project_id}")),
+            None,
+            Some("Organization"),
+        )
+        .await?;
+
+        if let Some(rel) = relationships.into_iter().next() {
+            let org_id = rel.subject_details.expect("to have subject details").key;
+            Ok(Owner::Organization(org_id))
+        } else {
+            // If a user is able to view a project while the project has no parent org, then this user must be the project owner
+            Ok(Owner::User(user_id.to_owned()))
+        }
     }
 }
 

--- a/backends/src/client/permit.rs
+++ b/backends/src/client/permit.rs
@@ -34,9 +34,8 @@ use permit_pdp_client_rs::{
 use serde::{Deserialize, Serialize};
 use shuttle_common::{
     claims::AccountTier,
-    models::{error::ApiError, organization, project},
+    models::{organization, project},
 };
-use tracing::error;
 
 #[async_trait]
 pub trait PermissionsDal {

--- a/backends/src/test_utils/gateway.rs
+++ b/backends/src/test_utils/gateway.rs
@@ -22,24 +22,30 @@ pub async fn get_mocked_gateway_server() -> MockServer {
     let projects = vec![
         Project {
             id: "00000000000000000000000001",
-            account_id: "user-1",
+            owner_id: "user-1",
             name: "user-1-project-1",
             state: "stopped",
             idle_minutes: 30,
+            is_admin: true,
+            owner_type: "user",
         },
         Project {
             id: "00000000000000000000000002",
-            account_id: "user-1",
+            owner_id: "user-1",
             name: "user-1-project-2",
             state: "ready",
             idle_minutes: 30,
+            is_admin: true,
+            owner_type: "user",
         },
         Project {
             id: "00000000000000000000000003",
-            account_id: "user-2",
+            owner_id: "user-2",
             name: "user-2-project-1",
             state: "ready",
             idle_minutes: 30,
+            is_admin: true,
+            owner_type: "user",
         },
     ];
 
@@ -53,7 +59,7 @@ pub async fn get_mocked_gateway_server() -> MockServer {
 
             let user = bearer.to_str().unwrap().split_whitespace().nth(1).unwrap();
 
-            let body: Vec<_> = p.iter().filter(|p| p.account_id == user).collect();
+            let body: Vec<_> = p.iter().filter(|p| p.owner_id == user).collect();
 
             ResponseTemplate::new(200).set_body_json(body)
         })
@@ -71,7 +77,7 @@ pub async fn get_mocked_gateway_server() -> MockServer {
 
             let user = bearer.to_str().unwrap().split_whitespace().nth(1).unwrap();
 
-            if p.iter().any(|p| p.account_id == user && p.name == project) {
+            if p.iter().any(|p| p.owner_id == user && p.name == project) {
                 ResponseTemplate::new(200)
             } else {
                 ResponseTemplate::new(401)
@@ -87,10 +93,12 @@ pub async fn get_mocked_gateway_server() -> MockServer {
 #[derive(Debug, Clone, Serialize)]
 struct Project<'a> {
     id: &'a str,
-    account_id: &'a str,
     name: &'a str,
     state: &'a str,
     idle_minutes: u64,
+    is_admin: bool,
+    owner_type: &'a str,
+    owner_id: &'a str,
 }
 
 #[derive(Clone, Default)]

--- a/backends/src/test_utils/gateway.rs
+++ b/backends/src/test_utils/gateway.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use permit_client_rs::models::UserRead;
-use permit_pdp_client_rs::models::UserPermissionsResult;
 use serde::Serialize;
 use shuttle_common::models::organization;
 use tokio::sync::Mutex;
@@ -13,7 +12,7 @@ use wiremock::{
 };
 
 use crate::client::{
-    permit::{Organization, Result},
+    permit::{Organization, Owner, Result},
     PermissionsDal,
 };
 
@@ -148,11 +147,11 @@ impl PermissionsDal for PermissionsMock {
         Ok(())
     }
 
-    async fn get_user_projects(&self, user_id: &str) -> Result<Vec<UserPermissionsResult>> {
+    async fn get_personal_projects(&self, user_id: &str) -> Result<Vec<String>> {
         self.calls
             .lock()
             .await
-            .push(format!("get_user_projects {user_id}"));
+            .push(format!("get_personal_projects {user_id}"));
         Ok(vec![])
     }
 
@@ -178,6 +177,18 @@ impl PermissionsDal for PermissionsMock {
             .await
             .push(format!("delete_organization {user_id} {org_id}"));
         Ok(())
+    }
+
+    async fn get_organization(
+        &self,
+        user_id: &str,
+        org_id: &str,
+    ) -> Result<organization::Response> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("get_organization {user_id} {org_id}"));
+        Ok(Default::default())
     }
 
     async fn get_organization_projects(&self, user_id: &str, org_id: &str) -> Result<Vec<String>> {
@@ -267,5 +278,13 @@ impl PermissionsDal for PermissionsMock {
             .await
             .push(format!("get_organization_members {user_id} {org_id}"));
         Ok(Default::default())
+    }
+
+    async fn get_project_owner(&self, user_id: &str, project_id: &str) -> Result<Owner> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("get_project_owner {user_id} {project_id}"));
+        Ok(Owner::User(user_id.to_string()))
     }
 }

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -10,6 +10,7 @@ use reqwest::Response;
 use serde::{Deserialize, Serialize};
 use shuttle_common::constants::headers::X_CARGO_SHUTTLE_VERSION;
 use shuttle_common::models::deployment::DeploymentRequest;
+use shuttle_common::models::organization;
 use shuttle_common::models::{deployment, project, service, ToJson};
 use shuttle_common::secrets::Secret;
 use shuttle_common::{resource, ApiKey, ApiUrl, LogItem, VersionInfo};
@@ -177,6 +178,19 @@ impl Client {
         let path = format!("/projects/{project}/delete");
 
         self.delete(path).await
+    }
+
+    pub async fn get_organizations_list(&self) -> Result<Vec<organization::Response>> {
+        self.get("/organizations".to_string()).await
+    }
+
+    pub async fn get_organization_projects_list(
+        &self,
+        org_id: &str,
+    ) -> Result<Vec<project::Response>> {
+        let path = format!("/organizations/{org_id}/projects");
+
+        self.get(path).await
     }
 
     pub async fn get_logs(&self, project: &str, deployment_id: &Uuid) -> Result<Vec<LogItem>> {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1970,7 +1970,35 @@ impl Shuttle {
         };
         let projects_table = project::get_projects_table(&projects, page, raw, page_hint);
 
+        println!("{}", "Personal Projects".bold());
         println!("{projects_table}");
+
+        let orgs = client.get_organizations_list().await?;
+
+        for org in orgs {
+            let mut org_projects = client
+                .get_organization_projects_list(&org.id)
+                .await
+                .map_err(|err| {
+                    suggestions::project::project_request_failure(
+                        err,
+                        "Getting organization projects list failed",
+                        false,
+                        "getting the organization projects list fails repeatedly",
+                    )
+                })?;
+            let page_hint = if org_projects.len() == limit as usize {
+                org_projects.pop();
+                true
+            } else {
+                false
+            };
+            let org_projects_table =
+                project::get_projects_table(&org_projects, page, raw, page_hint);
+
+            println!("{}", format!("{}'s Projects", org.display_name).bold());
+            println!("{org_projects_table}");
+        }
 
         Ok(CommandOutcome::Ok)
     }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -17,6 +17,9 @@ pub struct Response {
     pub name: String,
     pub state: State,
     pub idle_minutes: Option<u64>,
+    #[serde(flatten)]
+    pub owner: Owner,
+    pub is_admin: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, EnumString)]
@@ -162,6 +165,13 @@ impl State {
 #[derive(Deserialize, Serialize)]
 pub struct Config {
     pub idle_minutes: u64,
+}
+
+#[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
+#[serde(tag = "owner_type", content = "owner_id", rename_all = "lowercase")]
+pub enum Owner {
+    User(String),
+    Organization(String),
 }
 
 pub fn get_projects_table(

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -71,7 +71,29 @@ services:
       - "--permit-api-uri=https://api.eu-central-1.permit.io"
       - "--permit-pdp-uri=http://permit-pdp:7000"
       - "--permit-env=${SHUTTLE_ENV}"
-      - "--permit-api-key=${PERMIT_API_KEY}"
+      - "--permit-api-key=${PERMIT_DEV_API_KEY}"
+  gateway:
+    command:
+      - "--state=/var/lib/shuttle"
+      - "start"
+      - "--control=0.0.0.0:8001"
+      - "--user=0.0.0.0:8000"
+      - "--bouncer=0.0.0.0:7999"
+      - "--image=${CONTAINER_REGISTRY}/deployer:${DEPLOYER_TAG}"
+      - "--prefix=shuttle_"
+      - "--network-name=${STACK}_user-net"
+      - "--docker-host=/var/run/docker.sock"
+      - "--auth-uri=http://auth:8000"
+      - "--deploys-api-key=${DEPLOYS_API_KEY}"
+      - "--provisioner-host=provisioner"
+      - "--proxy-fqdn=${APPS_FQDN}"
+      - "--use-tls=${USE_TLS}"
+      - "--cors-origin=http://localhost:3001"
+      - "--admin-key=${GATEWAY_ADMIN_KEY}"
+      - "--permit-api-uri=https://api.eu-central-1.permit.io"
+      - "--permit-pdp-uri=http://permit-pdp:7000"
+      - "--permit-env=${SHUTTLE_ENV}"
+      - "--permit-api-key=${PERMIT_DEV_API_KEY}"
   otel-collector:
     ports:
       - 4317:4317
@@ -123,3 +145,4 @@ services:
   permit-pdp:
     environment:
       - PDP_DEBUG=True
+      - PDP_API_KEY=${PERMIT_DEV_API_KEY}

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -105,8 +105,8 @@ impl StatusResponse {
 #[instrument(skip(service))]
 async fn get_project(
     State(RouterState { service, .. }): State<RouterState>,
+    ScopedUser { scope, claim }: ScopedUser,
 ) -> Result<AxumJson<project::Response>, Error> {
-    ScopedUser { scope, claim, .. }: ScopedUser,
     let project = service.find_project_by_name(&scope).await?;
     let idle_minutes = project.state.idle_minutes();
     let owner = service

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -105,16 +105,27 @@ impl StatusResponse {
 #[instrument(skip(service))]
 async fn get_project(
     State(RouterState { service, .. }): State<RouterState>,
-    ScopedUser { scope, .. }: ScopedUser,
 ) -> Result<AxumJson<project::Response>, Error> {
+    ScopedUser { scope, claim, .. }: ScopedUser,
     let project = service.find_project_by_name(&scope).await?;
     let idle_minutes = project.state.idle_minutes();
+    let owner = service
+        .permit_client
+        .get_project_owner(&claim.sub, &project.id)
+        .await?
+        .into();
+    let is_admin = service
+        .permit_client
+        .allowed(&claim.sub, &project.id, "manage")
+        .await?;
 
     let response = project::Response {
         id: project.id.to_uppercase(),
         name: scope.to_string(),
         state: project.state.into(),
         idle_minutes,
+        owner,
+        is_admin,
     };
 
     Ok(AxumJson(response))
@@ -135,21 +146,31 @@ async fn get_projects_list(
     Claim { sub, .. }: Claim,
 ) -> Result<AxumJson<Vec<project::Response>>, Error> {
     let mut projects = vec![];
-    for p in service
+    for proj_id in service
         .permit_client
-        .get_user_projects(&sub)
+        .get_personal_projects(&sub)
         .await
         .map_err(|_| Error::from(ErrorKind::Internal))?
     {
-        let proj_id = p.resource.expect("project resource").key;
         let project = service.find_project_by_id(&proj_id).await?;
         let idle_minutes = project.state.idle_minutes();
+        let owner = service
+            .permit_client
+            .get_project_owner(&sub, &proj_id)
+            .await?
+            .into();
+        let is_admin = service
+            .permit_client
+            .allowed(&sub, &proj_id, "manage")
+            .await?;
 
         let response = project::Response {
             id: project.id,
             name: project.name,
             state: project.state.into(),
             idle_minutes,
+            owner,
+            is_admin,
         };
         projects.push(response);
     }
@@ -210,6 +231,8 @@ async fn create_project(
         name: project_name.to_string(),
         state: project.state.into(),
         idle_minutes,
+        owner: project::Owner::User(claim.sub),
+        is_admin: true,
     };
 
     Ok(AxumJson(response))
@@ -222,17 +245,29 @@ async fn destroy_project(
     }): State<RouterState>,
     ScopedUser {
         scope: project_name,
+        claim,
         ..
     }: ScopedUser,
 ) -> Result<AxumJson<project::Response>, Error> {
     let project = service.find_project_by_name(&project_name).await?;
     let idle_minutes = project.state.idle_minutes();
+    let owner = service
+        .permit_client
+        .get_project_owner(&claim.sub, &project.id)
+        .await?
+        .into();
+    let is_admin = service
+        .permit_client
+        .allowed(&claim.sub, &project.id, "manage")
+        .await?;
 
     let mut response = project::Response {
         id: project.id.to_uppercase(),
         name: project_name.to_string(),
         state: project.state.into(),
         idle_minutes,
+        owner,
+        is_admin,
     };
 
     if response.state == shuttle_common::models::project::State::Destroyed {
@@ -486,6 +521,20 @@ async fn get_organizations(
     Ok(AxumJson(orgs))
 }
 
+#[instrument(skip_all)]
+async fn get_organization(
+    State(RouterState { service, .. }): State<RouterState>,
+    CustomErrorPath(organization_id): CustomErrorPath<String>,
+    Claim { sub, .. }: Claim,
+) -> Result<AxumJson<organization::Response>, Error> {
+    let org = service
+        .permit_client
+        .get_organization(&sub, &organization_id)
+        .await?;
+
+    Ok(AxumJson(org))
+}
+
 #[instrument(skip_all, fields(shuttle.organization.name = %organization_name, shuttle.organization.id = field::Empty))]
 async fn create_organization(
     State(RouterState { service, .. }): State<RouterState>,
@@ -529,12 +578,23 @@ async fn get_organization_projects(
     for project_id in project_ids {
         let project = service.find_project_by_id(&project_id).await?;
         let idle_minutes = project.state.idle_minutes();
+        let owner = service
+            .permit_client
+            .get_project_owner(&sub, &project_id)
+            .await?
+            .into();
+        let is_admin = service
+            .permit_client
+            .allowed(&sub, &project_id, "manage")
+            .await?;
 
         projects.push(project::Response {
             id: project.id,
             name: project.name,
             state: project.state.into(),
             idle_minutes,
+            owner,
+            is_admin,
         });
     }
 
@@ -1100,7 +1160,10 @@ impl ApiBuilder {
         let organization_routes = Router::new()
             .route("/", get(get_organizations))
             .route("/name/:organization_name", post(create_organization))
-            .route("/:organization_id", delete(delete_organization))
+            .route(
+                "/:organization_id",
+                get(get_organization).delete(delete_organization),
+            )
             .route("/:organization_id/projects", get(get_organization_projects))
             .route(
                 "/:organization_id/projects/:project_id",

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -88,13 +88,10 @@ async fn sync_permit_projects(db: SqlitePool, args: SyncArgs) {
 
     for (uid, pids) in projects_by_user {
         println!("syncing {uid} projects");
-        match client.get_user_projects(&uid).await {
+        match client.get_personal_projects(&uid).await {
             Ok(projs) => {
                 for pid in pids {
-                    if !projs
-                        .iter()
-                        .any(|p| p.resource.as_ref().unwrap().key == pid)
-                    {
+                    if !projs.iter().any(|p| *p == pid) {
                         println!("creating project link {uid} <-> {pid}");
                         client.create_project(&uid, &pid).await.unwrap();
                     } else {


### PR DESCRIPTION
## Description of change
Add more details to projects to know who their owners are
Allow get the details of a single org
And allow only getting projects the user is the direct owner of

## How has this been tested? (if applicable)
Added more tests and started the local stack


