### PR TITLE
fix: runtime panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5568,6 +5568,7 @@ dependencies = [
  "strfmt",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic 0.10.2",
  "tracing-subscriber",
  "uuid",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -22,6 +22,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strfmt = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+tokio-util = "0.7.10"
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -99,7 +99,7 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
     let cloned_token = token.clone();
 
     let router = {
-        let alpha = Alpha::new(loader, runner, token.clone());
+        let alpha = Alpha::new(loader, runner, token);
 
         let svc = RuntimeServer::new(alpha);
         server_builder.add_service(svc)
@@ -108,12 +108,12 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
     tokio::select! {
         res = router.serve(addr) => {
             match res{
-                Ok(_) => panic!("router completed on its own"),
-                Err(e) => panic!("Error while serving address {addr}: {e}")
+                Ok(_) => println!("router completed on its own"),
+                Err(e) => println!("Error while serving address {addr}: {e}")
             }
         }
         _ = cloned_token.cancelled() => {
-            panic!("runtime future was cancelled")
+            println!("runtime future was cancelled")
         }
     }
 }

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -251,7 +251,7 @@ where
             }
         };
 
-        println!("setting state to healthy");
+        println!("setting current state to healthy");
         *self.state.lock().unwrap() = State::Loading;
 
         let state = self.state.clone();
@@ -262,7 +262,7 @@ where
         tokio::spawn(async move {
             // Note: The timeout is quite low as we are not actually provisioning resources after
             // sending the load response.
-            tokio::time::sleep(Duration::from_secs(30)).await;
+            tokio::time::sleep(Duration::from_secs(180)).await;
             if !matches!(state.lock().unwrap().deref(), State::Running) {
                 println!("the runtime failed to enter the running state before timing out");
 

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -23,7 +23,7 @@ use shuttle_proto::{
 use shuttle_service::{ResourceFactory, Service};
 use tokio::sync::{
     broadcast::{self, Sender},
-    mpsc,
+    mpsc, oneshot,
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{transport::Server, Request, Response, Status};
@@ -106,7 +106,7 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
     tokio::select! {
         res = router.serve(addr) => {
             match res{
-                Ok(_) => panic!("router shut down"),
+                Ok(_) => panic!("router completed on its own"),
                 Err(e) => panic!("Error while serving address {addr}: {e}")
             }
         }
@@ -128,12 +128,13 @@ pub enum State {
 pub struct Alpha<L, R> {
     // Mutexes are for interior mutability
     stopped_tx: Sender<(StopReason, String)>,
+    kill_tx: Mutex<Option<oneshot::Sender<String>>>,
     loader: Mutex<Option<L>>,
     runner: Mutex<Option<R>>,
     /// The current state of the runtime, which is used by the ECS task to determine if the runtime
     /// is healthy.
     state: Arc<Mutex<State>>,
-    runtime_kill_tx: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    runtime_kill_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
 }
 
 impl<L, R> Alpha<L, R> {
@@ -146,7 +147,7 @@ impl<L, R> Alpha<L, R> {
             loader: Mutex::new(Some(loader)),
             runner: Mutex::new(Some(runner)),
             state: Arc::new(Mutex::new(State::Unhealthy)),
-            runtime_kill_tx: Mutex::new(Some(runtime_kill_tx)),
+            runtime_kill_tx: Arc::new(Mutex::new(Some(runtime_kill_tx))),
         }
     }
 }
@@ -250,26 +251,21 @@ where
             }
         };
 
-        println!("setting current state to healthy");
+        println!("setting state to healthy");
         *self.state.lock().unwrap() = State::Loading;
 
         let state = self.state.clone();
+        let runtime_kill_tx = self.runtime_kill_tx.clone();
 
         // Ensure that the runtime is set to unhealthy if it doesn't reach the running state after
         // it has sent a load response, so that the ECS task will fail.
         tokio::spawn(async move {
             // Note: The timeout is quite low as we are not actually provisioning resources after
             // sending the load response.
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_secs(30)).await;
             if !matches!(state.lock().unwrap().deref(), State::Running) {
-                let runtime_kill_tx = self
-                    .runtime_kill_tx
-                    .lock()
-                    .unwrap()
-                    .deref_mut()
-                    .take()
-                    .unwrap();
                 println!("the runtime failed to enter the running state before timing out");
+                let runtime_kill_tx = runtime_kill_tx.lock().unwrap().deref_mut().take().unwrap();
 
                 runtime_kill_tx.send(()).unwrap();
             }
@@ -343,40 +339,61 @@ where
 
         println!("Starting on {service_address}");
 
+        let (kill_tx, kill_rx) = tokio::sync::oneshot::channel();
+        *self.kill_tx.lock().unwrap() = Some(kill_tx);
+
         let handle = tokio::runtime::Handle::current();
 
         // start service as a background task with a kill receiver
         tokio::spawn(async move {
             let mut background = handle.spawn(service.bind(service_address));
 
-            match background.await {
-                Ok(_) => {
-                    println!("service stopped all on its own");
-                    let _ = stopped_tx
-                        .send((StopReason::End, String::new()))
-                        .map_err(|e| println!("{e}"));
-                }
-                Err(error) => {
-                    if error.is_panic() {
-                        let panic = error.into_panic();
-                        let msg = match panic.downcast_ref::<String>() {
-                            Some(msg) => msg.to_string(),
-                            None => match panic.downcast_ref::<&str>() {
-                                Some(msg) => msg.to_string(),
-                                None => "<no panic message>".to_string(),
-                            },
-                        };
+            tokio::select! {
+                res = &mut background => {
+                    match res {
+                        Ok(_) => {
+                            println!("service stopped all on its own");
+                            let _ = stopped_tx
+                                .send((StopReason::End, String::new()))
+                                .map_err(|e| println!("{e}"));
+                        },
+                        Err(error) => {
+                            if error.is_panic() {
+                                let panic = error.into_panic();
+                                let msg = match panic.downcast_ref::<String>() {
+                                    Some(msg) => msg.to_string(),
+                                    None => match panic.downcast_ref::<&str>() {
+                                        Some(msg) => msg.to_string(),
+                                        None => "<no panic message>".to_string(),
+                                    },
+                                };
 
-                        println!("service panicked: {msg}");
-                        let _ = stopped_tx
-                            .send((StopReason::Crash, msg))
-                            .map_err(|e| println!("{e}"));
-                    } else {
-                        println!("service crashed: {error}");
-                        let _ = stopped_tx
-                            .send((StopReason::Crash, error.to_string()))
-                            .map_err(|e| println!("{e}"));
+                                println!("service panicked: {msg}");
+                                let _ = stopped_tx
+                                    .send((StopReason::Crash, msg))
+                                    .map_err(|e| println!("{e}"));
+                            } else {
+                                println!("service crashed: {error}");
+                                let _ = stopped_tx
+                                    .send((StopReason::Crash, error.to_string()))
+                                    .map_err(|e| println!("{e}"));
+                            }
+                        },
                     }
+                },
+                message = kill_rx => {
+                    match message {
+                        Ok(_) => {
+                            let _ = stopped_tx
+                                .send((StopReason::Request, String::new()))
+                                .map_err(|e| println!("{e}"));
+                        }
+                        Err(_) => println!("the kill sender dropped")
+                    };
+
+                    println!("will now abort the service");
+                    background.abort();
+                    background.await.unwrap().expect("to stop service");
                 }
             }
         });

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -26,6 +26,7 @@ use tokio::sync::{
     mpsc, oneshot,
 };
 use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::sync::CancellationToken;
 use tonic::{transport::Server, Request, Response, Status};
 
 use crate::args::args;
@@ -93,11 +94,12 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
         .http2_keepalive_interval(Some(Duration::from_secs(60)))
         .layer(ExtractPropagationLayer);
 
-    // A channel we can use to kill the runtime if it does not become healthy in time.
-    let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    // A cancellation token we can use to kill the runtime if it does not start in time.
+    let token = CancellationToken::new();
+    let cloned_token = token.clone();
 
     let router = {
-        let alpha = Alpha::new(loader, runner, tx);
+        let alpha = Alpha::new(loader, runner, token.clone());
 
         let svc = RuntimeServer::new(alpha);
         server_builder.add_service(svc)
@@ -110,11 +112,8 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
                 Err(e) => panic!("Error while serving address {addr}: {e}")
             }
         }
-        res = rx => {
-            match res{
-                Ok(_) => panic!("Received runtime kill signal"),
-                Err(e) => panic!("Receiver error: {e}")
-            }
+        _ = cloned_token.cancelled() => {
+            panic!("runtime future was cancelled")
         }
     }
 }
@@ -134,11 +133,12 @@ pub struct Alpha<L, R> {
     /// The current state of the runtime, which is used by the ECS task to determine if the runtime
     /// is healthy.
     state: Arc<Mutex<State>>,
-    runtime_kill_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+    // A cancellation token we can use to kill the runtime if it does not start in time.
+    cancellation_token: CancellationToken,
 }
 
 impl<L, R> Alpha<L, R> {
-    pub fn new(loader: L, runner: R, runtime_kill_tx: tokio::sync::oneshot::Sender<()>) -> Self {
+    pub fn new(loader: L, runner: R, cancellation_token: CancellationToken) -> Self {
         let (stopped_tx, _stopped_rx) = broadcast::channel(10);
 
         Self {
@@ -147,7 +147,7 @@ impl<L, R> Alpha<L, R> {
             loader: Mutex::new(Some(loader)),
             runner: Mutex::new(Some(runner)),
             state: Arc::new(Mutex::new(State::Unhealthy)),
-            runtime_kill_tx: Arc::new(Mutex::new(Some(runtime_kill_tx))),
+            cancellation_token,
         }
     }
 }
@@ -255,7 +255,7 @@ where
         *self.state.lock().unwrap() = State::Loading;
 
         let state = self.state.clone();
-        let runtime_kill_tx = self.runtime_kill_tx.clone();
+        let cancellation_token = self.cancellation_token.clone();
 
         // Ensure that the runtime is set to unhealthy if it doesn't reach the running state after
         // it has sent a load response, so that the ECS task will fail.
@@ -265,9 +265,8 @@ where
             tokio::time::sleep(Duration::from_secs(30)).await;
             if !matches!(state.lock().unwrap().deref(), State::Running) {
                 println!("the runtime failed to enter the running state before timing out");
-                let runtime_kill_tx = runtime_kill_tx.lock().unwrap().deref_mut().take().unwrap();
 
-                runtime_kill_tx.send(()).unwrap();
+                cancellation_token.cancel();
             }
         });
 

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -106,7 +106,7 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
     tokio::select! {
         res = router.serve(addr) => {
             match res{
-                Ok(_) => {}
+                Ok(_) => panic!("router shut down"),
                 Err(e) => panic!("Error while serving address {addr}: {e}")
             }
         }

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -109,11 +109,11 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
         res = router.serve(addr) => {
             match res{
                 Ok(_) => println!("router completed on its own"),
-                Err(e) => println!("Error while serving address {addr}: {e}")
+                Err(e) => panic!("Error while serving address {addr}: {e}")
             }
         }
         _ = cloned_token.cancelled() => {
-            println!("runtime future was cancelled")
+            panic!("runtime future was cancelled")
         }
     }
 }

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -254,21 +254,21 @@ where
         *self.state.lock().unwrap() = State::Loading;
 
         let state = self.state.clone();
-        let runtime_kill_tx = self
-            .runtime_kill_tx
-            .lock()
-            .unwrap()
-            .deref_mut()
-            .take()
-            .unwrap();
 
         // Ensure that the runtime is set to unhealthy if it doesn't reach the running state after
         // it has sent a load response, so that the ECS task will fail.
         tokio::spawn(async move {
             // Note: The timeout is quite low as we are not actually provisioning resources after
             // sending the load response.
-            tokio::time::sleep(Duration::from_secs(180)).await;
+            tokio::time::sleep(Duration::from_secs(60)).await;
             if !matches!(state.lock().unwrap().deref(), State::Running) {
+                let runtime_kill_tx = self
+                    .runtime_kill_tx
+                    .lock()
+                    .unwrap()
+                    .deref_mut()
+                    .take()
+                    .unwrap();
                 println!("the runtime failed to enter the running state before timing out");
 
                 runtime_kill_tx.send(()).unwrap();


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

I was taking the kill tx no matter if the condition to kill the runtime was fulfilled, so it was dropped either way when the timeout passed. This could still be done with a oneshot with some changes, but a cancellation token was simpler.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Deployed to my stack, it no longer restarts after the timeout passes.
