### PR TITLE
feat: add services client constructor for default headers

### DIFF
--- a/backends/src/client/mod.rs
+++ b/backends/src/client/mod.rs
@@ -60,6 +60,13 @@ impl ServicesApiClient {
         }
     }
 
+    pub fn new_with_default_headers(base: Uri, headers: HeaderMap) -> Self {
+        Self {
+            client: Self::builder().default_headers(headers).build().unwrap(),
+            base,
+        }
+    }
+
     pub async fn get<T: DeserializeOwned>(
         &self,
         path: &str,


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Add a new method to the ServicesApiClient, which is useful in places where we want to set some headers on all requests. The `new_with_bearer` method is similar, but it's specific for bearer auth and it only takes the token. On the new architecture, we want to pass a secret on all requests to the new provisioner, and this new method makes it simpler.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested on new platform, CI.
