### PR TITLE
refactor: errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,6 +5438,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-context",
+ "thiserror",
  "tokio",
  "tonic 0.10.2",
  "tower",

--- a/backends/src/client/permit.rs
+++ b/backends/src/client/permit.rs
@@ -32,7 +32,11 @@ use permit_pdp_client_rs::{
     models::{AuthorizationQuery, Resource, User, UserPermissionsQuery, UserPermissionsResult},
 };
 use serde::{Deserialize, Serialize};
-use shuttle_common::{claims::AccountTier, models::organization};
+use shuttle_common::{
+    claims::AccountTier,
+    models::{error::ApiError, organization},
+};
+use tracing::error;
 
 #[async_trait]
 pub trait PermissionsDal {
@@ -913,6 +917,26 @@ impl<T: Debug> From<PermitPDPClientError<T>> for Error {
                 content: e.content,
                 entity: format!("{:?}", e.entity),
             }),
+        }
+    }
+}
+impl From<Error> for ApiError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::ResponseError(value) => ApiError {
+                message: value.content.to_string(),
+                status_code: value.status.into(),
+            },
+            err => {
+                error!(
+                    error = &err as &dyn std::error::Error,
+                    "Internal error while talking to service"
+                );
+                ApiError {
+                    message: "Our server was unable to handle your request. A ticket should be created for us to fix this.".to_string(),
+                    status_code: StatusCode::INTERNAL_SERVER_ERROR.into(),
+                }
+            }
         }
     }
 }

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -63,7 +63,7 @@ impl State {
 }
 
 pub fn get_deployments_table(
-    deployments: &Vec<Response>,
+    deployments: &[Response],
     service_name: &str,
     page: u32,
     raw: bool,

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -9,6 +9,8 @@ use tracing::{error, warn};
 #[cfg(feature = "axum")]
 impl axum::response::IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
+        warn!("{}", self.message);
+
         (self.status(), axum::Json(self)).into_response()
     }
 }
@@ -20,6 +22,27 @@ pub struct ApiError {
 }
 
 impl ApiError {
+    pub fn internal(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            status_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+        }
+    }
+
+    pub fn unavailable(error: impl std::error::Error) -> Self {
+        Self {
+            message: error.to_string(),
+            status_code: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+        }
+    }
+
+    fn bad_request(error: impl std::error::Error) -> Self {
+        Self {
+            message: error.to_string(),
+            status_code: StatusCode::BAD_REQUEST.as_u16(),
+        }
+    }
+
     pub fn status(&self) -> StatusCode {
         StatusCode::from_u16(self.status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
     }
@@ -38,151 +61,9 @@ impl Display for ApiError {
 
 impl std::error::Error for ApiError {}
 
-#[derive(Debug, Clone, PartialEq, Error)]
-pub enum ErrorKind {
-    #[error("Request is missing a key")]
-    KeyMissing,
-    #[error("The 'Host' header is invalid")]
-    BadHost,
-    #[error("Request has an invalid key")]
-    KeyMalformed,
-    #[error("Unauthorized")]
-    Unauthorized,
-    #[error("Forbidden")]
-    Forbidden,
-    #[error("User not found")]
-    UserNotFound,
-    #[error("User already exists")]
-    UserAlreadyExists,
-    #[error("Project '{0}' not found. Make sure you are the owner of this project name. Run `cargo shuttle project start` to create a new project.")]
-    ProjectNotFound(String),
-    #[error("{0:?}")]
-    InvalidProjectName(InvalidProjectName),
-    #[error("A project with the same name already exists")]
-    ProjectAlreadyExists,
-    /// Contains a message describing a running state of the project.
-    /// Used if the project already exists but is owned
-    /// by the caller, which means they can modify the project.
-    #[error("{0}")]
-    OwnProjectAlreadyExists(String),
-    // "not ready" is matched against in cargo-shuttle for giving further instructions on project deletion
-    #[error("Project not ready. Try running `cargo shuttle project restart`.")]
-    ProjectNotReady,
-    #[error("Project returned invalid response")]
-    ProjectUnavailable,
-    #[error("You cannot create more projects. Delete some projects first.")]
-    TooManyProjects,
-    #[error("Could not automatically delete the following resources: {0:?}. Please reach out to Shuttle support for help.")]
-    ProjectHasResources(Vec<String>),
-    #[error("Could not automatically stop the running deployment for the project. Please reach out to Shuttle support for help.")]
-    ProjectHasRunningDeployment,
-    #[error("Project currently has a deployment that is busy building. Use `cargo shuttle deployment list` to see it and wait for it to finish")]
-    ProjectHasBuildingDeployment,
-    #[error("Tried to get project into a ready state for deletion but failed. Please reach out to Shuttle support for help.")]
-    ProjectCorrupted,
-    #[error("Custom domain not found")]
-    CustomDomainNotFound,
-    #[error("Invalid custom domain")]
-    InvalidCustomDomain,
-    #[error("Custom domain already in use")]
-    CustomDomainAlreadyExists,
-    #[error("The requested operation is invalid")]
-    InvalidOperation,
-    #[error("Internal server error")]
-    Internal,
-    #[error("Service not ready")]
-    NotReady,
-    #[error("We're experiencing a high workload right now, please try again in a little bit")]
-    ServiceUnavailable,
-    #[error("Deleting project failed")]
-    DeleteProjectFailed,
-    #[error("Our server is at capacity and cannot serve your request at this time. Please try again in a few minutes.")]
-    CapacityLimit,
-    #[error("{0:?}")]
-    InvalidOrganizationName(InvalidOrganizationName),
-}
-
-impl From<ErrorKind> for ApiError {
-    fn from(kind: ErrorKind) -> Self {
-        let status = match kind {
-            ErrorKind::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorKind::KeyMissing => StatusCode::UNAUTHORIZED,
-            ErrorKind::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
-            ErrorKind::KeyMalformed => StatusCode::BAD_REQUEST,
-            ErrorKind::BadHost => StatusCode::BAD_REQUEST,
-            ErrorKind::UserNotFound => StatusCode::NOT_FOUND,
-            ErrorKind::UserAlreadyExists => StatusCode::BAD_REQUEST,
-            ErrorKind::ProjectNotFound(_) => StatusCode::NOT_FOUND,
-            ErrorKind::ProjectNotReady => StatusCode::SERVICE_UNAVAILABLE,
-            ErrorKind::ProjectUnavailable => StatusCode::BAD_GATEWAY,
-            ErrorKind::TooManyProjects => StatusCode::FORBIDDEN,
-            ErrorKind::ProjectHasRunningDeployment => StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorKind::ProjectHasBuildingDeployment => StatusCode::BAD_REQUEST,
-            ErrorKind::ProjectCorrupted => StatusCode::BAD_REQUEST,
-            ErrorKind::ProjectHasResources(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorKind::InvalidProjectName(_) => StatusCode::BAD_REQUEST,
-            ErrorKind::InvalidOperation => StatusCode::BAD_REQUEST,
-            ErrorKind::ProjectAlreadyExists => StatusCode::BAD_REQUEST,
-            ErrorKind::OwnProjectAlreadyExists(_) => StatusCode::BAD_REQUEST,
-            ErrorKind::InvalidCustomDomain => StatusCode::BAD_REQUEST,
-            ErrorKind::CustomDomainNotFound => StatusCode::NOT_FOUND,
-            ErrorKind::CustomDomainAlreadyExists => StatusCode::BAD_REQUEST,
-            ErrorKind::Unauthorized => StatusCode::UNAUTHORIZED,
-            ErrorKind::Forbidden => StatusCode::FORBIDDEN,
-            ErrorKind::NotReady => StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorKind::DeleteProjectFailed => StatusCode::INTERNAL_SERVER_ERROR,
-            ErrorKind::CapacityLimit => StatusCode::SERVICE_UNAVAILABLE,
-            ErrorKind::InvalidOrganizationName(_) => StatusCode::BAD_REQUEST,
-        };
-        Self {
-            message: kind.to_string(),
-            status_code: status.as_u16(),
-        }
-    }
-}
-
-// Used as a fallback when an API response did not contain a serialized ApiError
-impl From<StatusCode> for ApiError {
-    fn from(code: StatusCode) -> Self {
-        let message = match code {
-            StatusCode::OK | StatusCode::ACCEPTED | StatusCode::FOUND | StatusCode::SWITCHING_PROTOCOLS => {
-                unreachable!("we should not have an API error with a successful status code")
-            }
-            StatusCode::FORBIDDEN => "This request is not allowed",
-            StatusCode::UNAUTHORIZED => {
-                "we were unable to authorize your request. Check that your API key is set correctly. Use `cargo shuttle login` to set it."
-            },
-            StatusCode::INTERNAL_SERVER_ERROR => "Our server was unable to handle your request. A ticket should be created for us to fix this.",
-            StatusCode::SERVICE_UNAVAILABLE => "We're experiencing a high workload right now, please try again in a little bit",
-            StatusCode::BAD_REQUEST => {
-                warn!("responding to a BAD_REQUEST request with an unhelpful message. Use ErrorKind instead");
-                "This request is invalid"
-            },
-            StatusCode::NOT_FOUND => {
-                warn!("responding to a NOT_FOUND request with an unhelpful message. Use ErrorKind instead");
-                "We don't serve this resource"
-            },
-            StatusCode::BAD_GATEWAY => {
-                warn!("got a bad response from the gateway");
-                // Gateway's default response when a request handler panicks is a 502 with some HTML.
-                "Response from gateway is invalid. Please create a ticket to report this"
-            },
-            _ => {
-                error!(%code, "got an unexpected status code");
-                "An unexpected error occurred. Please create a ticket to report this"
-            },
-        };
-
-        Self {
-            message: message.to_string(),
-            status_code: code.as_u16(),
-        }
-    }
-}
-
 // Note: The string "Invalid project name" is used by cargo-shuttle to determine what type of error was returned.
 // Changing it is breaking.
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Error)]
 #[error(
     "Invalid project name. Project names must:
     1. only contain lowercase alphanumeric characters or dashes `-`.
@@ -194,6 +75,89 @@ impl From<StatusCode> for ApiError {
 )]
 pub struct InvalidProjectName;
 
-#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+impl From<InvalidProjectName> for ApiError {
+    fn from(err: InvalidProjectName) -> Self {
+        Self::bad_request(err)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Error)]
 #[error("Invalid organization name. Must not be more than 30 characters long.")]
 pub struct InvalidOrganizationName;
+
+impl From<InvalidOrganizationName> for ApiError {
+    fn from(err: InvalidOrganizationName) -> Self {
+        Self::bad_request(err)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Project is not ready. Try to restart it")]
+pub struct ProjectNotReady;
+
+#[derive(Debug, Error)]
+#[error("Project is running but is not responding correctly. Try to restart it")]
+pub struct ProjectUnavailable;
+
+#[derive(Debug, Error)]
+#[error("Project '{0}' not found. Make sure you are the owner of this project name. Run `cargo shuttle project start` to create a new project.")]
+pub struct ProjectNotFound(pub String);
+
+impl From<ProjectNotFound> for ApiError {
+    fn from(err: ProjectNotFound) -> Self {
+        Self {
+            message: err.to_string(),
+            status_code: StatusCode::NOT_FOUND.as_u16(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Could not automatically delete the following resources: {0:?}. Please reach out to Shuttle support for help.")]
+pub struct ProjectHasResources(pub Vec<String>);
+
+impl From<ProjectHasResources> for ApiError {
+    fn from(err: ProjectHasResources) -> Self {
+        Self::bad_request(err)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Could not automatically stop the running deployment for the project. Please reach out to Shuttle support for help.")]
+pub struct ProjectHasRunningDeployment;
+
+impl From<ProjectHasRunningDeployment> for ApiError {
+    fn from(err: ProjectHasRunningDeployment) -> Self {
+        Self::bad_request(err)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Project currently has a deployment that is busy building. Use `cargo shuttle deployment list` to see it and wait for it to finish")]
+pub struct ProjectHasBuildingDeployment;
+
+impl From<ProjectHasBuildingDeployment> for ApiError {
+    fn from(err: ProjectHasBuildingDeployment) -> Self {
+        Self::bad_request(err)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Tried to get project into a ready state for deletion but failed. Please reach out to Shuttle support for help.")]
+pub struct ProjectCorrupted;
+
+impl From<ProjectCorrupted> for ApiError {
+    fn from(err: ProjectCorrupted) -> Self {
+        Self::bad_request(err)
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Invalid custom domain")]
+pub struct InvalidCustomDomain;
+
+impl From<InvalidCustomDomain> for ApiError {
+    fn from(err: InvalidCustomDomain) -> Self {
+        Self::bad_request(err)
+    }
+}

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -41,8 +41,10 @@ impl ToJson for reqwest::Response {
             let res: error::ApiError = match serde_json::from_slice(&full) {
                 Ok(res) => res,
                 _ => {
-                    trace!("getting error from status code");
-                    status_code.into()
+                    error::ApiError {
+                        message: "Did not understand the response from the server. Please log a ticket for this".to_string(),
+                        status_code: status_code.as_u16(),
+                    }
                 }
             };
 

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -164,12 +164,7 @@ pub struct Config {
     pub idle_minutes: u64,
 }
 
-pub fn get_projects_table(
-    projects: &Vec<Response>,
-    page: u32,
-    raw: bool,
-    page_hint: bool,
-) -> String {
+pub fn get_projects_table(projects: &[Response], page: u32, raw: bool, page_hint: bool) -> String {
     if projects.is_empty() {
         // The page starts at 1 in the CLI.
         let mut s = if page <= 1 {

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 pub fn get_resource_tables(
-    resources: &Vec<Response>,
+    resources: &[Response],
     service_name: &str,
     raw: bool,
     show_secrets: bool,

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -41,6 +41,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["sqlite", "json", "migrate"] }
 strum = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true }
 tower = { workspace = true, features = ["steer"] }

--- a/gateway/src/acme.rs
+++ b/gateway/src/acme.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use fqdn::FQDN;
+use http::StatusCode;
 use instant_acme::{
     Account, AccountCredentials, Authorization, AuthorizationStatus, Challenge, ChallengeType,
     Identifier, KeyAuthorization, LetsEncrypt, NewAccount, NewOrder, Order, OrderStatus,
 };
 use rcgen::{Certificate, CertificateParams, DistinguishedName};
 use shuttle_backends::project_name::ProjectName;
+use shuttle_common::models::error::ApiError;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 use tracing::{error, trace, warn};
@@ -361,3 +363,12 @@ pub enum AcmeClientError {
 }
 
 impl std::error::Error for AcmeClientError {}
+
+impl From<AcmeClientError> for ApiError {
+    fn from(value: AcmeClientError) -> Self {
+        Self {
+            message: value.to_string(),
+            status_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+        }
+    }
+}

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -27,7 +27,10 @@ use shuttle_backends::project_name::ProjectName;
 use shuttle_backends::request_span;
 use shuttle_backends::ClaimExt;
 use shuttle_common::claims::{Claim, Scope, EXP_MINUTES};
-use shuttle_common::models::error::{ErrorKind, InvalidOrganizationName};
+use shuttle_common::models::error::{
+    ApiError, InvalidCustomDomain, InvalidOrganizationName, ProjectCorrupted,
+    ProjectHasBuildingDeployment, ProjectHasResources, ProjectHasRunningDeployment,
+};
 use shuttle_common::models::{admin::ProjectResponse, project, stats};
 use shuttle_common::models::{organization, service};
 use shuttle_common::{deployment, VersionInfo};
@@ -53,7 +56,7 @@ use crate::service::{ContainerSettings, GatewayService};
 use crate::task::{self, BoxedTask};
 use crate::tls::{GatewayCertResolver, RENEWAL_VALIDITY_THRESHOLD_IN_DAYS};
 use crate::worker::WORKER_QUEUE_SIZE;
-use crate::{DockerContext, Error, AUTH_CLIENT};
+use crate::{DockerContext, AUTH_CLIENT};
 
 use super::auth_layer::ShuttleAuthLayer;
 use super::project_caller::ProjectCaller;
@@ -106,7 +109,7 @@ impl StatusResponse {
 async fn get_project(
     State(RouterState { service, .. }): State<RouterState>,
     ScopedUser { scope, .. }: ScopedUser,
-) -> Result<AxumJson<project::Response>, Error> {
+) -> Result<AxumJson<project::Response>, ApiError> {
     let project = service.find_project_by_name(&scope).await?;
     let idle_minutes = project.state.idle_minutes();
 
@@ -124,23 +127,17 @@ async fn get_project(
 async fn check_project_name(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath(project_name): CustomErrorPath<ProjectName>,
-) -> Result<AxumJson<bool>, Error> {
-    service
-        .project_name_exists(&project_name)
-        .await
-        .map(AxumJson)
+) -> Result<AxumJson<bool>, ApiError> {
+    let res = service.project_name_exists(&project_name).await?;
+
+    Ok(AxumJson(res))
 }
 async fn get_projects_list(
     State(RouterState { service, .. }): State<RouterState>,
     Claim { sub, .. }: Claim,
-) -> Result<AxumJson<Vec<project::Response>>, Error> {
+) -> Result<AxumJson<Vec<project::Response>>, ApiError> {
     let mut projects = vec![];
-    for p in service
-        .permit_client
-        .get_user_projects(&sub)
-        .await
-        .map_err(|_| Error::from(ErrorKind::Internal))?
-    {
+    for p in service.permit_client.get_user_projects(&sub).await? {
         let proj_id = p.resource.expect("project resource").key;
         let project = service.find_project_by_id(&proj_id).await?;
         let idle_minutes = project.state.idle_minutes();
@@ -167,7 +164,7 @@ async fn create_project(
     claim: Claim,
     CustomErrorPath(project_name): CustomErrorPath<ProjectName>,
     AxumJson(config): AxumJson<project::Config>,
-) -> Result<AxumJson<project::Response>, Error> {
+) -> Result<AxumJson<project::Response>, ApiError> {
     let is_cch_project = project_name.is_cch_project();
 
     // Check that the user is within their project limits.
@@ -224,7 +221,7 @@ async fn destroy_project(
         scope: project_name,
         ..
     }: ScopedUser,
-) -> Result<AxumJson<project::Response>, Error> {
+) -> Result<AxumJson<project::Response>, ApiError> {
     let project = service.find_project_by_name(&project_name).await?;
     let idle_minutes = project.state.idle_minutes();
 
@@ -266,7 +263,7 @@ async fn delete_project(
     scoped_user: ScopedUser,
     Query(DeleteProjectParams { dry_run }): Query<DeleteProjectParams>,
     req: Request<Body>,
-) -> Result<AxumJson<String>, Error> {
+) -> Result<AxumJson<String>, ApiError> {
     // Don't do the dry run that might come from older CLIs
     if dry_run.is_some_and(|d| d) {
         return Ok(AxumJson("dry run is no longer supported".to_owned()));
@@ -318,7 +315,7 @@ async fn delete_project(
         let new_state = state.service.find_project_by_name(&project_name).await?;
 
         if !new_state.state.is_ready() {
-            return Err(Error::from_kind(ErrorKind::ProjectCorrupted));
+            return Err(ProjectCorrupted.into());
         }
     }
 
@@ -344,7 +341,7 @@ async fn delete_project(
     });
 
     if has_bad_state {
-        return Err(Error::from_kind(ErrorKind::ProjectHasBuildingDeployment));
+        return Err(ProjectHasBuildingDeployment.into());
     }
 
     let running_deployments = deployments
@@ -357,7 +354,7 @@ async fn delete_project(
             .await?;
 
         if res.status() != StatusCode::OK {
-            return Err(Error::from_kind(ErrorKind::ProjectHasRunningDeployment));
+            return Err(ProjectHasRunningDeployment.into());
         }
     }
 
@@ -375,9 +372,7 @@ async fn delete_project(
     }
 
     if !delete_fails.is_empty() {
-        return Err(Error::from_kind(ErrorKind::ProjectHasResources(
-            delete_fails,
-        )));
+        return Err(ProjectHasResources(delete_fails).into());
     }
 
     let task = service
@@ -398,7 +393,7 @@ async fn override_create_service(
     state: State<RouterState>,
     scoped_user: ScopedUser,
     req: Request<Body>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<Body>, ApiError> {
     let user_id = scoped_user.claim.sub.clone();
     let posthog_client = state.posthog_client.clone();
     tokio::spawn(async move {
@@ -420,7 +415,7 @@ async fn override_get_delete_service(
     state: State<RouterState>,
     scoped_user: ScopedUser,
     req: Request<Body>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<Body>, ApiError> {
     let project_name = scoped_user.scope.to_string();
     let service = state.service.clone();
     let ctx = state.service.context().clone();
@@ -457,7 +452,7 @@ async fn route_project(
     }): State<RouterState>,
     scoped_user: ScopedUser,
     req: Request<Body>,
-) -> Result<Response<Body>, Error> {
+) -> Result<Response<Body>, ApiError> {
     let project_name = scoped_user.scope;
     let is_cch_project = project_name.is_cch_project();
 
@@ -471,16 +466,19 @@ async fn route_project(
         .find_or_start_project(&project_name, sender)
         .await?
         .0;
-    service
+
+    let res = service
         .route(&project.state, &project_name, &scoped_user.claim.sub, req)
-        .await
+        .await?;
+
+    Ok(res)
 }
 
 #[instrument(skip_all)]
 async fn get_organizations(
     State(RouterState { service, .. }): State<RouterState>,
     Claim { sub, .. }: Claim,
-) -> Result<AxumJson<Vec<organization::Response>>, Error> {
+) -> Result<AxumJson<Vec<organization::Response>>, ApiError> {
     let orgs = service.permit_client.get_organizations(&sub).await?;
 
     Ok(AxumJson(orgs))
@@ -491,11 +489,9 @@ async fn create_organization(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath(organization_name): CustomErrorPath<String>,
     Claim { sub, .. }: Claim,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     if organization_name.chars().count() > 30 {
-        return Err(Error::from_kind(ErrorKind::InvalidOrganizationName(
-            InvalidOrganizationName,
-        )));
+        return Err(InvalidOrganizationName.into());
     }
 
     let org = Organization {
@@ -518,7 +514,7 @@ async fn get_organization_projects(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath(organization_id): CustomErrorPath<String>,
     Claim { sub, .. }: Claim,
-) -> Result<AxumJson<Vec<project::Response>>, Error> {
+) -> Result<AxumJson<Vec<project::Response>>, ApiError> {
     let project_ids = service
         .permit_client
         .get_organization_projects(&sub, &organization_id)
@@ -546,7 +542,7 @@ async fn delete_organization(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath(organization_id): CustomErrorPath<String>,
     Claim { sub, .. }: Claim,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     service
         .permit_client
         .delete_organization(&sub, &organization_id)
@@ -560,7 +556,7 @@ async fn transfer_project_to_organization(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath((organization_id, project_id)): CustomErrorPath<(String, String)>,
     Claim { sub, .. }: Claim,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     service
         .permit_client
         .transfer_project_to_org(&sub, &project_id, &organization_id)
@@ -574,7 +570,7 @@ async fn transfer_project_from_organization(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath((organization_id, project_id)): CustomErrorPath<(String, String)>,
     Claim { sub, .. }: Claim,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     service
         .permit_client
         .transfer_project_from_org(&sub, &project_id, &organization_id)
@@ -588,7 +584,7 @@ async fn get_organization_members(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath(organization_id): CustomErrorPath<String>,
     Claim { sub, .. }: Claim,
-) -> Result<AxumJson<Vec<organization::MemberResponse>>, Error> {
+) -> Result<AxumJson<Vec<organization::MemberResponse>>, ApiError> {
     let members = service
         .permit_client
         .get_organization_members(&sub, &organization_id)
@@ -602,7 +598,7 @@ async fn add_member_to_organization(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath((organization_id, user_id)): CustomErrorPath<(String, String)>,
     Claim { sub, .. }: Claim,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     service
         .permit_client
         .add_organization_member(&sub, &organization_id, &user_id)
@@ -616,7 +612,7 @@ async fn remove_member_from_organization(
     State(RouterState { service, .. }): State<RouterState>,
     CustomErrorPath((organization_id, user_id)): CustomErrorPath<(String, String)>,
     Claim { sub, .. }: Claim,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     service
         .permit_client
         .remove_organization_member(&sub, &organization_id, &user_id)
@@ -676,7 +672,7 @@ async fn get_status(
 async fn post_load(
     State(RouterState { running_builds, .. }): State<RouterState>,
     AxumJson(build): AxumJson<stats::LoadRequest>,
-) -> Result<AxumJson<stats::LoadResponse>, Error> {
+) -> Result<AxumJson<stats::LoadResponse>, ApiError> {
     let mut running_builds = running_builds.lock().await;
 
     trace!(id = %build.id, "checking build queue");
@@ -698,7 +694,7 @@ async fn post_load(
 async fn delete_load(
     State(RouterState { running_builds, .. }): State<RouterState>,
     AxumJson(build): AxumJson<stats::LoadRequest>,
-) -> Result<AxumJson<stats::LoadResponse>, Error> {
+) -> Result<AxumJson<stats::LoadResponse>, ApiError> {
     let mut running_builds = running_builds.lock().await;
     running_builds.remove(&build.id);
 
@@ -711,7 +707,7 @@ async fn delete_load(
 #[instrument(skip_all)]
 async fn get_load_admin(
     State(RouterState { running_builds, .. }): State<RouterState>,
-) -> Result<AxumJson<stats::LoadResponse>, Error> {
+) -> Result<AxumJson<stats::LoadResponse>, ApiError> {
     let mut running_builds = running_builds.lock().await;
 
     let load = calculate_capacity(&mut running_builds);
@@ -722,7 +718,7 @@ async fn get_load_admin(
 #[instrument(skip_all)]
 async fn delete_load_admin(
     State(RouterState { running_builds, .. }): State<RouterState>,
-) -> Result<AxumJson<stats::LoadResponse>, Error> {
+) -> Result<AxumJson<stats::LoadResponse>, ApiError> {
     let mut running_builds = running_builds.lock().await;
     running_builds.clear();
 
@@ -747,10 +743,10 @@ async fn revive_projects(
     State(RouterState {
         service, sender, ..
     }): State<RouterState>,
-) -> Result<(), Error> {
-    crate::project::exec::revive(service, sender)
-        .await
-        .map_err(|_| Error::from_kind(ErrorKind::Internal))
+) -> Result<(), ApiError> {
+    crate::project::exec::revive(service, sender).await?;
+
+    Ok(())
 }
 
 #[instrument(skip_all)]
@@ -758,10 +754,10 @@ async fn idle_cch_projects(
     State(RouterState {
         service, sender, ..
     }): State<RouterState>,
-) -> Result<(), Error> {
-    crate::project::exec::idle_cch(service, sender)
-        .await
-        .map_err(|_| Error::from_kind(ErrorKind::Internal))
+) -> Result<(), ApiError> {
+    crate::project::exec::idle_cch(service, sender).await?;
+
+    Ok(())
 }
 
 #[instrument(skip_all)]
@@ -769,10 +765,10 @@ async fn destroy_projects(
     State(RouterState {
         service, sender, ..
     }): State<RouterState>,
-) -> Result<(), Error> {
-    crate::project::exec::destroy(service, sender)
-        .await
-        .map_err(|_| Error::from_kind(ErrorKind::Internal))
+) -> Result<(), ApiError> {
+    crate::project::exec::destroy(service, sender).await?;
+
+    Ok(())
 }
 
 #[instrument(skip_all, fields(%email, ?acme_server))]
@@ -780,7 +776,7 @@ async fn create_acme_account(
     Extension(acme_client): Extension<AcmeClient>,
     Path(email): Path<String>,
     AxumJson(acme_server): AxumJson<Option<String>>,
-) -> Result<AxumJson<serde_json::Value>, Error> {
+) -> Result<AxumJson<serde_json::Value>, ApiError> {
     let res = acme_client.create_account(&email, acme_server).await?;
 
     Ok(AxumJson(res))
@@ -793,10 +789,8 @@ async fn request_custom_domain_acme_certificate(
     Extension(resolver): Extension<Arc<GatewayCertResolver>>,
     CustomErrorPath((project_name, fqdn)): CustomErrorPath<(ProjectName, String)>,
     AxumJson(credentials): AxumJson<AccountCredentials<'_>>,
-) -> Result<String, Error> {
-    let fqdn: FQDN = fqdn
-        .parse()
-        .map_err(|_err| Error::from(ErrorKind::InvalidCustomDomain))?;
+) -> Result<String, ApiError> {
+    let fqdn: FQDN = fqdn.parse().map_err(|_| InvalidCustomDomain)?;
 
     let (certs, private_key) = service
         .create_custom_domain_certificate(&fqdn, &acme_client, &project_name, credentials)
@@ -821,10 +815,8 @@ async fn renew_custom_domain_acme_certificate(
     Extension(resolver): Extension<Arc<GatewayCertResolver>>,
     CustomErrorPath((project_name, fqdn)): CustomErrorPath<(ProjectName, String)>,
     AxumJson(credentials): AxumJson<AccountCredentials<'_>>,
-) -> Result<String, Error> {
-    let fqdn: FQDN = fqdn
-        .parse()
-        .map_err(|_err| Error::from(ErrorKind::InvalidCustomDomain))?;
+) -> Result<String, ApiError> {
+    let fqdn: FQDN = fqdn.parse().map_err(|_| InvalidCustomDomain)?;
     // Try retrieve the current certificate if any.
     match service.project_details_for_custom_domain(&fqdn).await {
         Ok(CustomDomain {
@@ -836,20 +828,16 @@ async fn renew_custom_domain_acme_certificate(
             certificate.push('\n');
             certificate.push_str(private_key.as_str());
             let (_, pem) = parse_x509_pem(certificate.as_bytes()).map_err(|err| {
-                Error::custom(
-                    ErrorKind::Internal,
-                    format!("Error while parsing the pem certificate for {project_name}: {err}"),
-                )
+                ApiError::internal(&format!(
+                    "Error while parsing the pem certificate for {project_name}: {err}"
+                ))
             })?;
 
             let (_, x509_cert_chain) =
                 parse_x509_certificate(pem.contents.as_bytes()).map_err(|err| {
-                    Error::custom(
-                        ErrorKind::Internal,
-                        format!(
-                            "Error while parsing the certificate chain for {project_name}: {err}"
-                        ),
-                    )
+                    ApiError::internal(&format!(
+                        "Error while parsing the certificate chain for {project_name}: {err}"
+                    ))
                 })?;
 
             let diff = x509_cert_chain
@@ -891,7 +879,7 @@ async fn renew_custom_domain_acme_certificate(
                 ))
             }
         }
-        Err(err) => Err(err),
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -901,7 +889,7 @@ async fn renew_gateway_acme_certificate(
     Extension(acme_client): Extension<AcmeClient>,
     Extension(resolver): Extension<Arc<GatewayCertResolver>>,
     AxumJson(credentials): AxumJson<AccountCredentials<'_>>,
-) -> Result<String, Error> {
+) -> Result<String, ApiError> {
     let account = AccountWrapper::from(credentials).0;
     let certs = service
         .fetch_certificate(&acme_client, account.credentials())
@@ -948,7 +936,7 @@ async fn renew_gateway_acme_certificate(
 
 async fn get_projects(
     State(RouterState { service, .. }): State<RouterState>,
-) -> Result<AxumJson<Vec<ProjectResponse>>, Error> {
+) -> Result<AxumJson<Vec<ProjectResponse>>, ApiError> {
     let projects = service
         .iter_projects_detailed()
         .await?
@@ -961,7 +949,7 @@ async fn get_projects(
 async fn change_project_owner(
     State(RouterState { service, .. }): State<RouterState>,
     Path((project_name, new_user_id)): Path<(String, String)>,
-) -> Result<(), Error> {
+) -> Result<(), ApiError> {
     service
         .update_project_owner(&project_name, &new_user_id)
         .await?;

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -1,13 +1,58 @@
 use axum::extract::{FromRef, FromRequestParts, Path};
 use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use http::StatusCode;
+use shuttle_backends::client::permit;
 use shuttle_backends::project_name::ProjectName;
 use shuttle_backends::ClaimExt;
 use shuttle_common::claims::Claim;
-use shuttle_common::models::error::InvalidProjectName;
+use shuttle_common::models::error::{ApiError, InvalidProjectName, ProjectNotFound};
+use thiserror::Error;
 use tracing::error;
 
 use crate::api::latest::RouterState;
-use crate::{Error, ErrorKind};
+use crate::service;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("could not serve your request")]
+    StatusCode(StatusCode),
+
+    #[error(transparent)]
+    InvalidProjectName(#[from] InvalidProjectName),
+
+    #[error(transparent)]
+    ProjcetNotFound(#[from] ProjectNotFound),
+
+    #[error(transparent)]
+    Permission(#[from] permit::Error),
+
+    #[error(transparent)]
+    Service(#[from] service::Error),
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        let api_error: ApiError = self.into();
+
+        api_error.into_response()
+    }
+}
+
+impl From<Error> for ApiError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::StatusCode(e) => Self {
+                message: e.to_string(),
+                status_code: e.as_u16(),
+            },
+            Error::InvalidProjectName(e) => e.into(),
+            Error::ProjcetNotFound(e) => e.into(),
+            Error::Permission(e) => e.into(),
+            Error::Service(e) => e.into(),
+        }
+    }
+}
 
 /// A wrapper for a guard that validates a user's API token *and*
 /// scopes the request to a project they own.
@@ -31,14 +76,14 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let claim = Claim::from_request_parts(parts, state)
             .await
-            .map_err(|_| ErrorKind::Unauthorized)?;
+            .map_err(Error::StatusCode)?;
 
         let scope = match Path::<ProjectName>::from_request_parts(parts, state).await {
             Ok(Path(p)) => p,
             Err(_) => Path::<(ProjectName, String)>::from_request_parts(parts, state)
                 .await
                 .map(|Path((p, _))| p)
-                .map_err(|_| Error::from(ErrorKind::InvalidProjectName(InvalidProjectName)))?,
+                .map_err(|_| InvalidProjectName)?,
         };
 
         let RouterState { service, .. } = RouterState::from_ref(state);
@@ -52,16 +97,12 @@ where
                     &service.find_project_by_name(&scope).await?.id,
                     "develop", // TODO: make this configurable per endpoint?
                 )
-                .await
-                .map_err(|_| {
-                    error!("failed to check Permit permission");
-                    Error::from_kind(ErrorKind::Internal)
-                })?;
+                .await?;
 
         if allowed {
             Ok(Self { claim, scope })
         } else {
-            Err(Error::from(ErrorKind::ProjectNotFound(scope.to_string())))
+            Err(ProjectNotFound(scope.to_string()).into())
         }
     }
 }

--- a/gateway/src/auth.rs
+++ b/gateway/src/auth.rs
@@ -22,7 +22,7 @@ pub enum Error {
     InvalidProjectName(#[from] InvalidProjectName),
 
     #[error(transparent)]
-    ProjcetNotFound(#[from] ProjectNotFound),
+    ProjectNotFound(#[from] ProjectNotFound),
 
     #[error(transparent)]
     Permission(#[from] permit::Error),
@@ -47,7 +47,7 @@ impl From<Error> for ApiError {
                 status_code: e.as_u16(),
             },
             Error::InvalidProjectName(e) => e.into(),
-            Error::ProjcetNotFound(e) => e.into(),
+            Error::ProjectNotFound(e) => e.into(),
             Error::Permission(e) => e.into(),
             Error::Service(e) => e.into(),
         }

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -3,13 +3,7 @@ extern crate async_trait;
 
 use std::convert::Infallible;
 use std::error::Error as StdError;
-use std::fmt::Formatter;
-use std::io;
 use std::pin::Pin;
-
-use acme::AcmeClientError;
-
-use axum::response::{IntoResponse, Response};
 
 use bollard::Docker;
 use futures::prelude::*;
@@ -18,10 +12,8 @@ use hyper::Client;
 use once_cell::sync::Lazy;
 use service::ContainerSettings;
 use shuttle_backends::project_name::ProjectName;
-use shuttle_common::models::error::{ApiError, ErrorKind};
 use shuttle_common::models::user::UserId;
 use strum::Display;
-use tokio::sync::mpsc::error::SendError;
 
 pub mod acme;
 pub mod api;
@@ -44,107 +36,6 @@ pub enum DockerStatsSource {
     Bollard,
 }
 static AUTH_CLIENT: Lazy<Client<HttpConnector>> = Lazy::new(Client::new);
-
-/// Server-side errors that do not have to do with the user runtime
-/// should be [`Error`]s.
-///
-/// All [`Error`] have an [`ErrorKind`] and an (optional) source.
-
-/// [`Error] is safe to be used as error variants to axum endpoints
-/// return types as their [`IntoResponse`] implementation does not
-/// leak any sensitive information.
-#[derive(Debug)]
-pub struct Error {
-    kind: ErrorKind,
-    source: Option<Box<dyn StdError + Sync + Send + 'static>>,
-}
-
-impl Error {
-    pub fn source<E: StdError + Sync + Send + 'static>(kind: ErrorKind, err: E) -> Self {
-        Self {
-            kind,
-            source: Some(Box::new(err)),
-        }
-    }
-
-    pub fn custom<S: AsRef<str>>(kind: ErrorKind, message: S) -> Self {
-        Self {
-            kind,
-            source: Some(Box::new(io::Error::new(
-                io::ErrorKind::Other,
-                message.as_ref().to_string(),
-            ))),
-        }
-    }
-
-    pub fn from_kind(kind: ErrorKind) -> Self {
-        Self { kind, source: None }
-    }
-
-    pub fn kind(&self) -> ErrorKind {
-        self.kind.clone()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Self {
-        Self::from_kind(kind)
-    }
-}
-
-impl<T> From<SendError<T>> for Error {
-    fn from(_: SendError<T>) -> Self {
-        Self::from(ErrorKind::ServiceUnavailable)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(_: io::Error) -> Self {
-        Self::from(ErrorKind::Internal)
-    }
-}
-
-impl From<AcmeClientError> for Error {
-    fn from(error: AcmeClientError) -> Self {
-        Self::source(ErrorKind::Internal, error)
-    }
-}
-
-impl From<Error> for ApiError {
-    fn from(error: Error) -> Self {
-        let error: ApiError = error.kind.into();
-
-        if error.status_code >= 500 {
-            tracing::error!(
-                error = &error as &dyn std::error::Error,
-                "control plane request error"
-            );
-        }
-
-        error
-    }
-}
-
-impl IntoResponse for Error {
-    fn into_response(self) -> Response {
-        let error: ApiError = self.into();
-
-        error.into_response()
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.kind)?;
-        if let Some(source) = self.source.as_ref() {
-            write!(f, ": ")?;
-            source.fmt(f)?;
-        }
-        Ok(())
-    }
-}
-
-impl StdError for Error {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectDetails {
@@ -169,7 +60,7 @@ pub trait DockerContext: Send + Sync {
 
     fn container_settings(&self) -> &ContainerSettings;
 
-    async fn get_stats(&self, container_id: &str) -> Result<u64, Error>;
+    async fn get_stats(&self, container_id: &str) -> Result<u64, String>;
 }
 
 /// A generic state which can, when provided with a [`Context`], do
@@ -296,7 +187,7 @@ pub mod tests {
     use crate::service::{ContainerSettings, GatewayService, MIGRATIONS};
     use crate::task::BoxedTask;
     use crate::worker::Worker;
-    use crate::{DockerContext, Error};
+    use crate::DockerContext;
 
     macro_rules! value_block_helper {
         ($next:ident, $block:block) => {
@@ -367,18 +258,6 @@ pub mod tests {
         }}
     }
 
-    macro_rules! assert_err_kind {
-        {
-            $left:expr, ErrorKind::$right:ident
-        } => {{
-            let left: Result<_, crate::Error> = $left;
-            assert_eq!(
-                left.map_err(|err| err.kind()),
-                Err(crate::ErrorKind::$right)
-            );
-        }};
-    }
-
     macro_rules! timed_loop {
         (wait: $wait:literal$(, max: $max:literal)?, $block:block) => {{
             #[allow(unused_mut)]
@@ -395,7 +274,7 @@ pub mod tests {
         }};
     }
 
-    pub(crate) use {assert_err_kind, assert_matches, assert_stream_matches, value_block_helper};
+    pub(crate) use {assert_matches, assert_stream_matches, value_block_helper};
 
     mod request_builder_ext {
         pub trait Sealed {}
@@ -692,7 +571,7 @@ pub mod tests {
             });
 
             let _worker = tokio::spawn(async move {
-                worker.start().await.unwrap();
+                worker.start().await;
             });
 
             // Allow the spawns to start
@@ -735,7 +614,7 @@ pub mod tests {
             &self.container_settings
         }
 
-        async fn get_stats(&self, _container_id: &str) -> Result<u64, Error> {
+        async fn get_stats(&self, _container_id: &str) -> Result<u64, String> {
             Ok(0)
         }
     }

--- a/gateway/src/main.rs
+++ b/gateway/src/main.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use async_posthog::ClientOptions;
 use clap::Parser;
-use futures::prelude::*;
 use shuttle_backends::client::{permit, PermissionsDal};
 use shuttle_backends::trace::setup_tracing;
 use shuttle_common::log::Backend;
@@ -136,12 +135,7 @@ async fn start(
 
     let sender = worker.sender();
 
-    let worker_handle = tokio::spawn(
-        worker
-            .start()
-            .map_ok(|_| info!("worker terminated successfully"))
-            .map_err(|err| error!("worker error: {}", err)),
-    );
+    let worker_handle = tokio::spawn(worker.start());
 
     // Every 60 secs go over all `::Ready` projects and check their health.
     // Also syncs the state of all projects on startup

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use axum::extract::{ConnectInfo, Path, State};
 use axum::headers::{HeaderMapExt, Host};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::any;
 use axum_server::accept::DefaultAcceptor;
 use axum_server::tls_rustls::RustlsAcceptor;
@@ -26,7 +26,10 @@ use shuttle_backends::cache::{CacheManagement, CacheManager};
 use shuttle_backends::headers::XShuttleProject;
 use shuttle_backends::project_name::ProjectName;
 use shuttle_common::constants::DEPLOYER_SERVICE_HTTP_PORT;
-use shuttle_common::models::error::InvalidProjectName;
+use shuttle_common::models::error::{
+    ApiError, InvalidProjectName, ProjectNotReady, ProjectUnavailable,
+};
+use thiserror::Error;
 use tokio::net::TcpSocket;
 use tokio::sync::mpsc::Sender;
 use tower_sanitize_path::SanitizePath;
@@ -34,13 +37,50 @@ use tracing::{debug, debug_span, error, field, trace, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::acme::AcmeClient;
-use crate::service::GatewayService;
+use crate::service::{self, GatewayService};
 use crate::task::BoxedTask;
-use crate::{Error, ErrorKind};
 
 static PROXY_CLIENT: Lazy<ReverseProxy<HttpConnector<GaiResolver>>> =
     Lazy::new(|| ReverseProxy::new(Client::new()));
 static SERVER_HEADER: Lazy<HeaderValue> = Lazy::new(|| "shuttle.rs".parse().unwrap());
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error("The 'Host' header is invalid")]
+    BadHost,
+
+    #[error(transparent)]
+    InvalidProjectName(#[from] InvalidProjectName),
+
+    #[error(transparent)]
+    ProjectNotReady(#[from] ProjectNotReady),
+
+    #[error(transparent)]
+    ProjectUnavailable(#[from] ProjectUnavailable),
+
+    #[error(transparent)]
+    Service(#[from] service::Error),
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        // Make the exposed error safe first
+        let message = match self {
+            Error::BadHost => self.to_string(),
+            Error::InvalidProjectName(e) => e.to_string(),
+            Error::ProjectNotReady(e) => e.to_string(),
+            Error::ProjectUnavailable(e) => e.to_string(),
+            Error::Service(e) => {
+                let error: ApiError = e.into();
+
+                error.message
+            }
+        };
+
+        // Use a custom 600 status code to distinguish between proxy errors and project errors
+        (StatusCode::from_u16(600).unwrap(), message).into_response()
+    }
+}
 
 pub struct ProxyState {
     gateway: Arc<GatewayService>,
@@ -62,7 +102,7 @@ async fn proxy(
         .headers()
         .typed_get::<Host>()
         .map(|host| fqdn!(host.hostname()))
-        .ok_or_else(|| Error::from_kind(ErrorKind::BadHost))?;
+        .ok_or_else(|| Error::BadHost)?;
 
     span.record("http.host", fqdn.to_string());
 
@@ -73,7 +113,7 @@ async fn proxy(
                 .unwrap()
                 .to_owned()
                 .parse()
-                .map_err(|_| Error::from_kind(ErrorKind::InvalidProjectName(InvalidProjectName)))?
+                .map_err(|_| InvalidProjectName)?
         } else if let Some(project) = { state.domain_cache.get(fqdn.to_string().as_str()) } {
             project
         } else {
@@ -104,10 +144,7 @@ async fn proxy(
             .gateway
             .find_or_start_project(&project_name, state.task_sender.clone())
             .await?;
-        let ip = proj
-            .state
-            .target_ip()?
-            .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotReady))?;
+        let ip = proj.state.target_ip().ok_or_else(|| ProjectNotReady)?;
         state.project_cache.insert(
             project_name.as_str(),
             ip,
@@ -152,7 +189,7 @@ async fn proxy(
         .await
         .map_err(|err| {
             error!(error = ?err, "gateway proxy client error");
-            Error::from_kind(ErrorKind::ProjectUnavailable)
+            ProjectUnavailable
         })?;
 
     res.headers_mut().insert(SERVER, SERVER_HEADER.clone());

--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -144,7 +144,7 @@ async fn proxy(
             .gateway
             .find_or_start_project(&project_name, state.task_sender.clone())
             .await?;
-        let ip = proj.state.target_ip().ok_or_else(|| ProjectNotReady)?;
+        let ip = proj.state.target_ip().ok_or(ProjectNotReady)?;
         state.project_cache.insert(
             project_name.as_str(),
             ip,

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -71,7 +71,7 @@ pub enum Error {
     #[error(transparent)]
     ProjectUnavailable(#[from] ProjectUnavailable),
 
-    #[error("Project '{0}' not found. Make sure you are the owner of this project name. Run `cargo shuttle project start` to create a new project.")]
+    #[error(transparent)]
     ProjectNotFound(#[from] ProjectNotFound),
 
     /// Contains a message describing a running state of the project.
@@ -116,7 +116,7 @@ impl From<Error> for ApiError {
             }
             Error::ProjectNotReady(_) => StatusCode::SERVICE_UNAVAILABLE,
             Error::ProjectUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
-            Error::ProjectNotFound(_) => StatusCode::NOT_FOUND,
+            Error::ProjectNotFound(e) => return e.into(),
             Error::OwnProjectAlreadyExists(_) => StatusCode::CONFLICT,
             Error::TooManyProjects => StatusCode::PAYMENT_REQUIRED,
             Error::ProjectAlreadyExists => StatusCode::CONFLICT,

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -12,7 +12,7 @@ use axum::response::Response;
 use bollard::container::StatsOptions;
 use bollard::{Docker, API_DEFAULT_VERSION};
 use fqdn::{Fqdn, FQDN};
-use http::Uri;
+use http::{StatusCode, Uri};
 use hyper::client::connect::dns::GaiResolver;
 use hyper::client::HttpConnector;
 use hyper::Client;
@@ -21,11 +21,14 @@ use instant_acme::{AccountCredentials, ChallengeType};
 use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
-use shuttle_backends::client::PermissionsDal;
+use shuttle_backends::client::{permit, PermissionsDal};
 use shuttle_backends::headers::XShuttleAdminSecret;
 use shuttle_backends::project_name::ProjectName;
 use shuttle_common::claims::AccountTier;
 use shuttle_common::constants::SHUTTLE_IDLE_DOCS_URL;
+use shuttle_common::models::error::{
+    ApiError, ProjectNotFound, ProjectNotReady, ProjectUnavailable,
+};
 use shuttle_common::models::project::State;
 use shuttle_common::models::user::UserId;
 use sqlx::error::DatabaseError;
@@ -33,6 +36,7 @@ use sqlx::migrate::Migrator;
 use sqlx::sqlite::SqlitePool;
 use sqlx::types::Json as SqlxJson;
 use sqlx::{query, query_as, Error as SqlxError, QueryBuilder, Row};
+use thiserror::Error;
 use tokio::sync::mpsc::Sender;
 use tokio::time::timeout;
 use tonic::codegen::tokio_stream::StreamExt;
@@ -41,25 +45,99 @@ use tracing::{debug, error, info, instrument, trace, warn, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use ulid::Ulid;
 
-use crate::acme::{AcmeClient, CustomDomain};
+use crate::acme::{AcmeClient, AcmeClientError, CustomDomain};
 use crate::args::ServiceArgs;
 use crate::project::{Project, ProjectCreating, ProjectError, IS_HEALTHY_TIMEOUT};
 use crate::task::{self, BoxedTask, TaskBuilder};
 use crate::tls::ChainAndPrivateKey;
 use crate::worker::TaskRouter;
 use crate::{
-    DockerContext, DockerStatsSource, Error, ErrorKind, ProjectDetails, AUTH_CLIENT,
-    DOCKER_STATS_PATH_CGROUP_V1, DOCKER_STATS_PATH_CGROUP_V2,
+    DockerContext, DockerStatsSource, ProjectDetails, AUTH_CLIENT, DOCKER_STATS_PATH_CGROUP_V1,
+    DOCKER_STATS_PATH_CGROUP_V2,
 };
 
 pub static MIGRATIONS: Migrator = sqlx::migrate!("./migrations");
 static PROXY_CLIENT: Lazy<ReverseProxy<HttpConnector<GaiResolver>>> =
     Lazy::new(|| ReverseProxy::new(Client::new()));
 
-impl From<SqlxError> for Error {
-    fn from(err: SqlxError) -> Self {
-        debug!("internal SQLx error: {err}");
-        Self::source(ErrorKind::Internal, err)
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Sql(#[from] SqlxError),
+
+    #[error(transparent)]
+    ProjectNotReady(#[from] ProjectNotReady),
+
+    #[error(transparent)]
+    ProjectUnavailable(#[from] ProjectUnavailable),
+
+    #[error("Project '{0}' not found. Make sure you are the owner of this project name. Run `cargo shuttle project start` to create a new project.")]
+    ProjectNotFound(#[from] ProjectNotFound),
+
+    /// Contains a message describing a running state of the project.
+    /// Used if the project already exists but is owned
+    /// by the caller, which means they can modify the project.
+    #[error("{0}")]
+    OwnProjectAlreadyExists(String),
+
+    #[error("You cannot create more projects. Delete some projects first.")]
+    TooManyProjects,
+
+    #[error("A project with the same name already exists. Try using a different name.")]
+    ProjectAlreadyExists,
+
+    #[error(transparent)]
+    Permissions(#[from] permit::Error),
+
+    // Errors that are safe to expose to the user
+    #[error("{0}")]
+    InternalSafe(String),
+
+    #[error("Custom domain not found")]
+    CustomDomainNotFound,
+
+    #[error(transparent)]
+    AcmeClient(#[from] AcmeClientError),
+
+    #[error("Our server is at capacity and cannot serve your request at this time. Please try again in a few minutes.")]
+    CapacityLimit,
+}
+
+impl From<Error> for ApiError {
+    fn from(error: Error) -> Self {
+        let status_code = match error {
+            Error::Sql(error) => {
+                error!(
+                    error = &error as &dyn std::error::Error,
+                    "internal SQLx error"
+                );
+
+                return Self::internal("Internal server error");
+            }
+            Error::ProjectNotReady(_) => StatusCode::SERVICE_UNAVAILABLE,
+            Error::ProjectUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
+            Error::ProjectNotFound(_) => StatusCode::NOT_FOUND,
+            Error::OwnProjectAlreadyExists(_) => StatusCode::CONFLICT,
+            Error::TooManyProjects => StatusCode::PAYMENT_REQUIRED,
+            Error::ProjectAlreadyExists => StatusCode::CONFLICT,
+            Error::Permissions(error) => {
+                error!(
+                    error = &error as &dyn std::error::Error,
+                    "Failed to check permissions"
+                );
+
+                return Self::internal("Internal server error");
+            }
+            Error::InternalSafe(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::CustomDomainNotFound => StatusCode::NOT_FOUND,
+            Error::AcmeClient(e) => return e.into(),
+            Error::CapacityLimit => StatusCode::SERVICE_UNAVAILABLE,
+        };
+
+        Self {
+            message: error.to_string(),
+            status_code: status_code.as_u16(),
+        }
     }
 }
 
@@ -280,9 +358,7 @@ impl GatewayService {
         user_id: &UserId,
         mut req: Request<Body>,
     ) -> Result<Response<Body>, Error> {
-        let target_ip = project
-            .target_ip()?
-            .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotReady))?;
+        let target_ip = project.target_ip().ok_or_else(|| ProjectNotReady)?;
 
         let target_url = format!("http://{target_ip}:8001");
 
@@ -303,7 +379,7 @@ impl GatewayService {
         let resp = PROXY_CLIENT
             .call(Ipv4Addr::LOCALHOST.into(), &target_url, req)
             .await
-            .map_err(|_| Error::from_kind(ErrorKind::ProjectUnavailable))?;
+            .map_err(|_| ProjectUnavailable)?;
 
         Ok(resp)
     }
@@ -390,7 +466,7 @@ impl GatewayService {
                     ))
                 }),
         })
-        .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound(project_name.to_string())))
+        .ok_or_else(|| ProjectNotFound(project_name.to_string()).into())
     }
 
     pub async fn find_project_by_id(&self, project_id: &str) -> Result<FindProjectPayload, Error> {
@@ -414,7 +490,7 @@ impl GatewayService {
                         ))
                     }),
             })
-            .ok_or_else(|| Error::from_kind(ErrorKind::ProjectNotFound(project_id.to_string())))
+            .ok_or_else(|| ProjectNotFound(project_id.to_string()).into())
     }
 
     pub async fn project_name_exists(&self, project_name: &ProjectName) -> Result<bool, Error> {
@@ -525,7 +601,7 @@ impl GatewayService {
             .fetch_optional(&self.db)
             .await?
             .map(|row| row.get("user_id"))
-            .ok_or_else(|| Error::from(ErrorKind::ProjectNotFound(project_name.to_string())))
+            .ok_or_else(|| ProjectNotFound(project_name.to_string()).into())
     }
 
     pub async fn control_key_from_project_name(
@@ -537,7 +613,7 @@ impl GatewayService {
             .fetch_optional(&self.db)
             .await?
             .map(|row| row.try_get("initial_key").unwrap())
-            .ok_or_else(|| Error::from(ErrorKind::ProjectNotFound(project_name.to_string())))?;
+            .ok_or_else(|| ProjectNotFound(project_name.to_string()))?;
         Ok(control_key)
     }
 
@@ -594,10 +670,9 @@ impl GatewayService {
                 let creating = ProjectCreating::new_with_random_initial_key(
                     project_name.clone(),
                     Ulid::from_string(project_id.as_str()).map_err(|err| {
-                        Error::custom(
-                            ErrorKind::Internal,
-                            format!("The project id of the destroyed project is not a valid ULID: {err}"),
-                        )
+                        Error::InternalSafe(format!(
+                            "The project id of the destroyed project is not a valid ULID: {err}"
+                        ))
                     })?,
                     idle_minutes,
                 );
@@ -641,9 +716,7 @@ impl GatewayService {
                         "deleted project should not never remain in gateway. please report this."
                     ),
                 };
-                Err(Error::from_kind(ErrorKind::OwnProjectAlreadyExists(
-                    message,
-                )))
+                Err(Error::OwnProjectAlreadyExists(message))
             }
         } else if can_create_project {
             // Attempt to create a new one. This will fail
@@ -652,7 +725,7 @@ impl GatewayService {
             self.insert_project(project_name, Ulid::new(), user_id, idle_minutes)
                 .await
         } else {
-            Err(Error::from_kind(ErrorKind::TooManyProjects))
+            Err(Error::TooManyProjects)
         }
     }
 
@@ -696,7 +769,7 @@ impl GatewayService {
                 // project name clash
                 if let Some(db_err_code) = err.as_database_error().and_then(DatabaseError::code) {
                     if db_err_code == "2067" {  // SQLITE_CONSTRAINT_UNIQUE
-                        return Error::from_kind(ErrorKind::ProjectAlreadyExists)
+                        return Error::ProjectAlreadyExists
                     }
                 }
                 // Otherwise this is internal
@@ -780,7 +853,7 @@ impl GatewayService {
                     private_key: row.get("private_key"),
                 })
             })
-            .map_err(|_| Error::from_kind(ErrorKind::Internal))
+            .map_err(Error::from)
     }
 
     pub async fn find_custom_domain_for_project(
@@ -819,7 +892,7 @@ impl GatewayService {
             certificate: row.get("certificate"),
             private_key: row.get("private_key"),
         })
-        .ok_or_else(|| Error::from(ErrorKind::CustomDomainNotFound))?;
+        .ok_or_else(|| Error::CustomDomainNotFound)?;
         Ok(custom_domain)
     }
 
@@ -854,7 +927,7 @@ impl GatewayService {
                 private_key,
                 ..
             }) => Ok((certificate, private_key)),
-            Err(err) if err.kind() == ErrorKind::CustomDomainNotFound => {
+            Err(Error::CustomDomainNotFound) => {
                 let (certs, private_key) = acme_client
                     .create_certificate(&fqdn.to_string(), ChallengeType::Http01, creds)
                     .await?;
@@ -944,7 +1017,8 @@ impl GatewayService {
                 .and_then(task::run_until_done())
                 .and_then(task::start_idle_deploys())
                 .send(&task_sender)
-                .await?;
+                .await
+                .map_err(|task_error| Error::InternalSafe(task_error.to_string()))?;
 
             // Wait for project to come up and set new state
             handle.await;
@@ -1009,7 +1083,7 @@ impl GatewayService {
             && (std::fs::metadata(CCH_CONTROL_FILE).is_ok()
                 || self.count_ready_cch_projects().await? >= CCH_CONCURRENT_LIMIT)
         {
-            return Err(Error::from_kind(ErrorKind::CapacityLimit));
+            return Err(Error::CapacityLimit);
         }
 
         let current_container_count = self.count_ready_projects().await?;
@@ -1026,7 +1100,7 @@ impl GatewayService {
         if has_capacity {
             Ok(())
         } else {
-            Err(Error::from_kind(ErrorKind::CapacityLimit))
+            Err(Error::CapacityLimit)
         }
     }
 }
@@ -1052,7 +1126,7 @@ impl DockerContext for GatewayContext {
     }
 
     #[instrument(name = "get container stats", skip_all, fields(docker_stats_source = %self.docker_stats_source, shuttle.container.id = container_id))]
-    async fn get_stats(&self, container_id: &str) -> Result<u64, Error> {
+    async fn get_stats(&self, container_id: &str) -> Result<u64, String> {
         match self.docker_stats_source {
             DockerStatsSource::CgroupV1 => {
                 let cpu_usage: u64 = tokio::fs::read_to_string(format!(
@@ -1065,7 +1139,7 @@ impl DockerContext for GatewayContext {
                         shuttle.container.id = container_id,
                         "failed to read docker stats file for container"
                     );
-                    ProjectError::internal("failed to read docker stats file for container")
+                    "failed to read docker stats file for container".to_string()
                 })?
                 .trim()
                 .parse()
@@ -1076,7 +1150,7 @@ impl DockerContext for GatewayContext {
                         "failed to parse cpu usage stat"
                     );
 
-                    ProjectError::internal("failed to parse cpu usage to u64")
+                    "failed to parse cpu usage to u64".to_string()
                 })?;
                 Ok(cpu_usage)
             }
@@ -1092,30 +1166,22 @@ impl DockerContext for GatewayContext {
                         shuttle.container.id = container_id,
                         "failed to read docker stats file for container"
                     );
-                    ProjectError::internal("failed to read docker stats file for container")
+                    "failed to read docker stats file for container".to_string()
                 })?
                 .lines()
                 .next()
                 .ok_or_else(|| {
-                    let err = ProjectError::internal(
-                        "failed to read first line of docker stats file for container",
-                    );
-                    error!(
-                        shuttle.container.id = container_id,
-                        error = &err as &dyn std::error::Error,
-                    );
+                    let err =
+                        "failed to read first line of docker stats file for container".to_string();
+                    error!(shuttle.container.id = container_id, error = &err);
 
                     err
                 })?
                 .split(' ')
                 .nth(1)
                 .ok_or_else(|| {
-                    let err =
-                        ProjectError::internal("failed to split docker stats line for container");
-                    error!(
-                        shuttle.container.id = container_id,
-                        error = &err as &dyn std::error::Error,
-                    );
+                    let err = "failed to split docker stats line for container".to_string();
+                    error!(shuttle.container.id = container_id, error = &err);
 
                     err
                 })?
@@ -1126,7 +1192,7 @@ impl DockerContext for GatewayContext {
                         shuttle.container.id = container_id,
                         "failed to parse cpu usage stat"
                     );
-                    ProjectError::internal("failed to parse cpu usage to u64")
+                    "failed to parse cpu usage to u64".to_string()
                 })?;
                 Ok(cpu_usage * 1_000)
             }
@@ -1142,7 +1208,21 @@ impl DockerContext for GatewayContext {
                     )
                     .next()
                     .await
-                    .unwrap()?;
+                    .ok_or_else(|| {
+                        error!(
+                            shuttle.container.id = container_id,
+                            "there was no stats for the container"
+                        );
+                        "there was no stats for the container".to_string()
+                    })?
+                    .map_err(|error| {
+                        error!(
+                            shuttle.container.id = container_id,
+                            error = %error,
+                            "failed to get container stats from bollard"
+                        );
+                        "failed to get stats for container".to_string()
+                    })?;
 
                 Ok(new_stat.cpu_stats.cpu_usage.total_usage)
             }
@@ -1200,8 +1280,7 @@ pub mod tests {
     use super::*;
 
     use crate::task::{self, TaskResult};
-    use crate::tests::{assert_err_kind, World};
-    use crate::{Error, ErrorKind};
+    use crate::tests::World;
 
     #[tokio::test]
     async fn service_create_find_stop_delete_project() {
@@ -1270,14 +1349,13 @@ pub mod tests {
         }
 
         // Creating a project with can_create_project set to false should fail.
-        assert_eq!(
+        assert!(matches!(
             svc.create_project("final-one".parse().unwrap(), &admin, false, false, 0)
                 .await
                 .err()
-                .unwrap()
-                .kind(),
-            ErrorKind::TooManyProjects
-        );
+                .unwrap(),
+            Error::TooManyProjects
+        ));
 
         // We need to fetch all of them from the DB since they are ordered by created_at (in the id) and project_name,
         // and created_at will be the same for some of them.
@@ -1337,10 +1415,7 @@ pub mod tests {
         assert!(matches!(
             svc.create_project(matrix.clone(), &trinity, false, true, 0)
                 .await,
-            Err(Error {
-                kind: ErrorKind::ProjectAlreadyExists,
-                ..
-            })
+            Err(Error::ProjectAlreadyExists)
         ));
 
         // If recreated by the same user
@@ -1356,10 +1431,7 @@ pub mod tests {
         assert!(matches!(
             svc.create_project(matrix.clone(), &neo, false, true, 0)
                 .await,
-            Err(Error {
-                kind: ErrorKind::OwnProjectAlreadyExists(_),
-                ..
-            })
+            Err(Error::OwnProjectAlreadyExists(_))
         ));
 
         let mut work = svc
@@ -1390,10 +1462,7 @@ pub mod tests {
         assert!(matches!(
             svc.create_project(matrix.clone(), &admin, true, true, 0)
                 .await,
-            Err(Error {
-                kind: ErrorKind::OwnProjectAlreadyExists(_),
-                ..
-            })
+            Err(Error::OwnProjectAlreadyExists(_))
         ));
 
         // We can delete a project
@@ -1402,10 +1471,7 @@ pub mod tests {
         // Project is gone
         assert!(matches!(
             svc.find_project_by_name(&matrix).await,
-            Err(Error {
-                kind: ErrorKind::ProjectNotFound(_),
-                ..
-            })
+            Err(Error::ProjectNotFound(_))
         ));
 
         // It can be re-created by anyone, with the same project name
@@ -1497,10 +1563,12 @@ pub mod tests {
         let certificate = "dummy certificate";
         let private_key = "dummy private key";
 
-        assert_err_kind!(
-            svc.project_details_for_custom_domain(&domain).await,
-            ErrorKind::CustomDomainNotFound
-        );
+        assert!(matches!(
+            svc.project_details_for_custom_domain(&domain)
+                .await
+                .unwrap_err(),
+            Error::CustomDomainNotFound
+        ));
 
         let _ = svc
             .create_project(project_name.clone(), &account, false, true, 0)
@@ -1558,10 +1626,12 @@ pub mod tests {
         let certificate = "dummy certificate";
         let private_key = "dummy private key";
 
-        assert_err_kind!(
-            svc.project_details_for_custom_domain(&domain).await,
-            ErrorKind::CustomDomainNotFound
-        );
+        assert!(matches!(
+            svc.project_details_for_custom_domain(&domain)
+                .await
+                .unwrap_err(),
+            Error::CustomDomainNotFound
+        ));
 
         let _ = svc
             .create_project(project_name.clone(), &account, false, true, 0)

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -358,7 +358,7 @@ impl GatewayService {
         user_id: &UserId,
         mut req: Request<Body>,
     ) -> Result<Response<Body>, Error> {
-        let target_ip = project.target_ip().ok_or_else(|| ProjectNotReady)?;
+        let target_ip = project.target_ip().ok_or(ProjectNotReady)?;
 
         let target_url = format!("http://{target_ip}:8001");
 

--- a/gateway/src/tls.rs
+++ b/gateway/src/tls.rs
@@ -7,16 +7,40 @@ use std::sync::Arc;
 use axum_server::accept::DefaultAcceptor;
 use axum_server::tls_rustls::{RustlsAcceptor, RustlsConfig};
 use futures::executor::block_on;
+use http::StatusCode;
 use pem::Pem;
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::{self, CertifiedKey};
 use rustls::{Certificate, PrivateKey, ServerConfig};
 use rustls_pemfile::Item;
-use shuttle_common::models::error::ErrorKind;
+use shuttle_common::models::error::ApiError;
+use thiserror::Error;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock;
 
-use crate::Error;
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Tls(#[from] rustls::Error),
+
+    #[error("Got an unknown certificate")]
+    UnknownType,
+
+    #[error("read failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("failed to get signing key: {0}")]
+    SigningKey(#[from] sign::SignError),
+}
+
+impl From<Error> for ApiError {
+    fn from(err: Error) -> Self {
+        Self {
+            message: err.to_string(),
+            status_code: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+        }
+    }
+}
 
 /// LetsEncrypt recommends to renew a certificate when its close to 30 days validity window.
 pub const RENEWAL_VALIDITY_THRESHOLD_IN_DAYS: i64 = 30;
@@ -32,15 +56,13 @@ impl ChainAndPrivateKey {
         let mut private_key = None;
         let mut chain = Vec::new();
 
-        for item in rustls_pemfile::read_all(&mut BufReader::new(rd))
-            .map_err(|_| Error::from_kind(ErrorKind::Internal))?
-        {
+        for item in rustls_pemfile::read_all(&mut BufReader::new(rd))? {
             match item {
                 Item::X509Certificate(cert) => chain.push(Certificate(cert)),
                 Item::ECKey(key) | Item::PKCS8Key(key) | Item::RSAKey(key) => {
                     private_key = Some(PrivateKey(key))
                 }
-                _ => return Err(Error::from_kind(ErrorKind::Internal)),
+                _ => return Err(Error::UnknownType),
             }
         }
 
@@ -73,8 +95,7 @@ impl ChainAndPrivateKey {
     }
 
     pub fn into_certified_key(self) -> Result<CertifiedKey, Error> {
-        let signing_key = sign::any_supported_type(&self.private_key)
-            .map_err(|_| Error::from_kind(ErrorKind::Internal))?;
+        let signing_key = sign::any_supported_type(&self.private_key)?;
         Ok(CertifiedKey::new(self.chain, signing_key))
     }
 

--- a/gateway/src/tls.rs
+++ b/gateway/src/tls.rs
@@ -121,7 +121,7 @@ impl GatewayCertResolver {
     /// Get the loaded [CertifiedKey] associated with the given
     /// domain.
     pub async fn get(&self, sni: &str) -> Option<Arc<CertifiedKey>> {
-        self.keys.read().await.get(sni).map(Arc::clone)
+        self.keys.read().await.get(sni).cloned()
     }
 
     pub async fn serve_default_der(&self, certs: ChainAndPrivateKey) -> Result<(), Error> {

--- a/gateway/src/worker.rs
+++ b/gateway/src/worker.rs
@@ -8,7 +8,6 @@ use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
 use crate::task::{BoxedTask, TaskResult};
-use crate::Error;
 
 pub const WORKER_QUEUE_SIZE: usize = 2048;
 
@@ -46,7 +45,7 @@ impl Worker {
     ///
     /// # Panics
     /// If this worker has already started.
-    pub async fn start(mut self) -> Result<Self, Error> {
+    pub async fn start(mut self) -> Self {
         // Drop the self-sender owned by this worker to prevent a
         // deadlock if all the other senders have already been dropped
         // at this point.
@@ -66,7 +65,7 @@ impl Worker {
             }
         }
 
-        Ok(self)
+        self
     }
 }
 


### PR DESCRIPTION
## Description of change
We used to have code that went from `ApiError` -> `ErrorKind` -> `ApiError`. During this conversion to `ErrorKind` we would remove friendly errors which would have been helpful to our end users. So this removes the `ErrorKind` enum.

Instead, each module has its own `Error` know and knows has to convert it to `ApiError` to be as friendly as possible while not exposing sensitive information to users.

With this it is also easier to isolate the proxy errors so they now return a custom `600` error code if the proxy fails

## How has this been tested? (if applicable)
Starting the local stack


