### PR TITLE
cargo-shuttle: added beta deployment status 

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -167,7 +167,7 @@ pub enum DeploymentCommand {
     /// View status of a deployment
     Status {
         /// ID of deployment to get status for
-        id: Uuid,
+        id: String,
     },
 }
 

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -246,6 +246,16 @@ impl ShuttleApiClient {
         self.get(path).await
     }
 
+    pub async fn deployment_status(
+        &self,
+        project: &str,
+        deployment_id: &str,
+    ) -> Result<deployment::EcsResponse> {
+        let path = format!("/projects/{project}/deployments/{deployment_id}");
+
+        self.get(path).await
+    }
+
     pub async fn get_deployment_details(
         &self,
         project: &str,

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -132,8 +132,7 @@ impl Shuttle {
             }
             if matches!(
                 args.cmd,
-                Command::Deployment(..)
-                    | Command::Resource(..)
+                Command::Resource(..)
                     | Command::Stop
                     | Command::Clean
                     | Command::Status
@@ -221,9 +220,14 @@ impl Shuttle {
             Command::Status => self.status().await,
             Command::Logs(logs_args) => self.logs(logs_args).await,
             Command::Deployment(DeploymentCommand::List { page, limit, raw }) => {
+                if self.beta {
+                    unimplemented!();
+                }
                 self.deployments_list(page, limit, raw).await
             }
-            Command::Deployment(DeploymentCommand::Status { id }) => self.deployment_get(id).await,
+            Command::Deployment(DeploymentCommand::Status { id }) => {
+                self.deployment_get(id.as_str()).await
+            }
             Command::Resource(ResourceCommand::List { raw, show_secrets }) => {
                 self.resources_list(raw, show_secrets).await
             }
@@ -952,14 +956,28 @@ impl Shuttle {
         Ok(CommandOutcome::Ok)
     }
 
-    async fn deployment_get(&self, deployment_id: Uuid) -> Result<CommandOutcome> {
+    async fn deployment_get(&self, deployment_id: &str) -> Result<CommandOutcome> {
         let client = self.client.as_ref().unwrap();
-        let deployment = client
-            .get_deployment_details(self.ctx.project_name(), &deployment_id)
-            .await
-            .map_err(suggestions::deployment::get_deployment_status_failure)?;
 
-        println!("{deployment}");
+        if self.beta {
+            let deployment = client
+                .deployment_status(self.ctx.project_name(), deployment_id)
+                .await
+                .map_err(suggestions::deployment::get_deployment_status_failure)?;
+            deployment.colored_println();
+        } else {
+            let deployment = client
+                .get_deployment_details(
+                    self.ctx.project_name(),
+                    &Uuid::from_str(deployment_id).map_err(|err| {
+                        anyhow!("Provided deployment id is not a valid UUID: {err}")
+                    })?,
+                )
+                .await
+                .map_err(suggestions::deployment::get_deployment_status_failure)?;
+
+            println!("{deployment}");
+        }
 
         Ok(CommandOutcome::Ok)
     }

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -28,6 +28,7 @@ pub enum EcsState {
     #[strum(serialize = "in progress")]
     InProgress,
     Stopped,
+    Failed,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/common/src/deployment.rs
+++ b/common/src/deployment.rs
@@ -28,6 +28,7 @@ pub enum EcsState {
     #[strum(serialize = "in progress")]
     InProgress,
     Stopped,
+    Stopping,
     Failed,
 }
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -124,7 +124,8 @@ impl EcsState {
         match self {
             EcsState::InProgress => "cyan",
             EcsState::Running => "green",
-            EcsState::Stopped => "blue",
+            EcsState::Stopped => "dark_blue",
+            EcsState::Stopping => "blue",
             EcsState::Failed => "red",
         }
     }

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -90,8 +90,12 @@ impl EcsResponse {
         );
 
         let state_with_uri = match self.running_id {
-            None => format!("{latest_state} ({})", self.uri),
-            Some(_) => latest_state,
+            None if EcsState::Running == self.latest_deployment_state
+                || EcsState::InProgress == self.latest_deployment_state =>
+            {
+                format!("{latest_state} ({})", self.uri)
+            }
+            _ => latest_state,
         };
 
         println!(

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -125,6 +125,7 @@ impl EcsState {
             EcsState::InProgress => "cyan",
             EcsState::Running => "green",
             EcsState::Stopped => "blue",
+            EcsState::Failed => "red",
         }
     }
 }


### PR DESCRIPTION
## Description of change

Returns the list of all deployments sorted by `updated_at` column.
No pagination yet.
Will handle the ID for `depl_latest` as a reference to the latest running deployment, if any (it is just a partial replacement for `cargo shuttle status` for now).

## How has this been tested? (if applicable)

Locally.  Example cmd:

```
SHUTTLE_BETA=true cargo run -p cargo-shuttle -- --api-url http://iulian-control-alb-fae7fb2-914574683.eu-west-2.elb.amazonaws.com deployment status --wd examples/custom-resource/pdo/ depl_latest
```

Output:
```
Current deployment: 'depl_01HVM1YNS3VR0V5PKKT60Q3277' - running (http://pdo-yvm4dhkducmt.app.iulian.staging.shuttle.rs)
```



