### PR TITLE
refactor: rename organizations to teams

### DIFF
--- a/backends/src/client/permit.rs
+++ b/backends/src/client/permit.rs
@@ -34,7 +34,7 @@ use permit_pdp_client_rs::{
 use serde::{Deserialize, Serialize};
 use shuttle_common::{
     claims::AccountTier,
-    models::{error::ApiError, organization, project},
+    models::{error::ApiError, project, team},
 };
 use tracing::error;
 
@@ -63,23 +63,22 @@ pub trait PermissionsDal {
     /// Get list of all projects the user has direct permissions for
     async fn get_personal_projects(&self, user_id: &str) -> Result<Vec<String>>;
 
-    // Organization management
+    // Team management
 
-    /// Creates an Organization resource and assigns the user as admin for the organization
-    async fn create_organization(&self, user_id: &str, org: &Organization) -> Result<()>;
+    /// Creates a Team resource and assigns the user as admin for the team
+    async fn create_team(&self, user_id: &str, team: &Team) -> Result<()>;
 
-    /// Deletes an Organization resource
-    async fn delete_organization(&self, user_id: &str, org_id: &str) -> Result<()>;
+    /// Deletes a Team resource
+    async fn delete_team(&self, user_id: &str, team_id: &str) -> Result<()>;
 
-    /// Get the details of an organization
-    async fn get_organization(&self, user_id: &str, org_id: &str)
-        -> Result<organization::Response>;
+    /// Get the details of a team
+    async fn get_team(&self, user_id: &str, team_id: &str) -> Result<team::Response>;
 
-    /// Get a list of all the organizations a user has access to
-    async fn get_organizations(&self, user_id: &str) -> Result<Vec<organization::Response>>;
+    /// Get a list of all the teams a user has access to
+    async fn get_teams(&self, user_id: &str) -> Result<Vec<team::Response>>;
 
-    /// Get a list of all project IDs that belong to an organization
-    async fn get_organization_projects(&self, user_id: &str, org_id: &str) -> Result<Vec<String>>;
+    /// Get a list of all project IDs that belong to a team
+    async fn get_team_projects(&self, user_id: &str, team_id: &str) -> Result<Vec<String>>;
 
     /// Transfers a project from a user to another user
     async fn transfer_project_to_user(
@@ -89,44 +88,39 @@ pub trait PermissionsDal {
         new_user_id: &str,
     ) -> Result<()>;
 
-    /// Transfers a project from a user to an organization
-    async fn transfer_project_to_org(
+    /// Transfers a project from a user to a team
+    async fn transfer_project_to_team(
         &self,
         user_id: &str,
         project_id: &str,
-        org_id: &str,
+        team_id: &str,
     ) -> Result<()>;
 
-    /// Transfers a project from an organization to a user
-    async fn transfer_project_from_org(
+    /// Transfers a project from a team to a user
+    async fn transfer_project_from_team(
         &self,
         user_id: &str,
         project_id: &str,
-        org_id: &str,
+        team_id: &str,
     ) -> Result<()>;
 
-    /// Add a user as a normal member to an organization
-    async fn add_organization_member(
+    /// Add a user as a normal member to a team
+    async fn add_team_member(&self, admin_user: &str, team_id: &str, user_id: &str) -> Result<()>;
+
+    /// Remove a user from a team
+    async fn remove_team_member(
         &self,
         admin_user: &str,
-        org_id: &str,
+        team_id: &str,
         user_id: &str,
     ) -> Result<()>;
 
-    /// Remove a user from an organization
-    async fn remove_organization_member(
-        &self,
-        admin_user: &str,
-        org_id: &str,
-        user_id: &str,
-    ) -> Result<()>;
-
-    /// Get a list of all the members of an organization
-    async fn get_organization_members(
+    /// Get a list of all the members of a team
+    async fn get_team_members(
         &self,
         user_id: &str,
-        org_id: &str,
-    ) -> Result<Vec<organization::MemberResponse>>;
+        team_id: &str,
+    ) -> Result<Vec<team::MemberResponse>>;
 
     // Permissions queries
 
@@ -137,26 +131,26 @@ pub trait PermissionsDal {
     async fn get_project_owner(&self, user_id: &str, project_id: &str) -> Result<Owner>;
 }
 
-/// Simple details of an organization to create
+/// Simple details of a team to create
 #[derive(Debug, PartialEq)]
-pub struct Organization {
-    /// Unique identifier for the organization. Should be `org_{ulid}`
+pub struct Team {
+    /// Unique identifier for the team. Should be `team_{ulid}`
     pub id: String,
 
-    /// The name used to display the organization in the UI
+    /// The name used to display the team in the UI
     pub display_name: String,
 }
 
 #[derive(Deserialize, Serialize)]
-/// The attributes stored with each organization resource
-struct OrganizationAttributes {
+/// The attributes stored with each team resource
+struct TeamAttributes {
     display_name: String,
 }
 
-impl OrganizationAttributes {
-    fn new(org: &Organization) -> Self {
+impl TeamAttributes {
+    fn new(team: &Team) -> Self {
         Self {
-            display_name: org.display_name.to_string(),
+            display_name: team.display_name.to_string(),
         }
     }
 }
@@ -164,14 +158,14 @@ impl OrganizationAttributes {
 #[derive(Debug, PartialEq)]
 pub enum Owner {
     User(String),
-    Organization(String),
+    Team(String),
 }
 
 impl From<Owner> for project::Owner {
     fn from(owner: Owner) -> Self {
         match owner {
             Owner::User(id) => project::Owner::User(id),
-            Owner::Organization(id) => project::Owner::Organization(id),
+            Owner::Team(id) => project::Owner::Team(id),
         }
     }
 }
@@ -356,22 +350,21 @@ impl PermissionsDal for Client {
         Ok(res.allow.unwrap_or_default())
     }
 
-    async fn create_organization(&self, user_id: &str, org: &Organization) -> Result<()> {
-        if !self.allowed_org(user_id, &org.id, "create").await? {
+    async fn create_team(&self, user_id: &str, team: &Team) -> Result<()> {
+        if !self.allowed_team(user_id, &team.id, "create").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content:
-                    "User does not have permission to create organization. Are you a pro user?"
-                        .to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to create a team. Are you a pro user?"
+                    .to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
-        if !self.get_organizations(user_id).await?.is_empty() {
+        if !self.get_teams(user_id).await?.is_empty() {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::BAD_REQUEST,
-                content: "User already has an organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User already has a team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -380,10 +373,10 @@ impl PermissionsDal for Client {
             &self.proj_id,
             &self.env_id,
             ResourceInstanceCreate {
-                key: org.id.to_owned(),
+                key: team.id.to_owned(),
                 tenant: "default".to_owned(),
-                resource: "Organization".to_owned(),
-                attributes: serde_json::to_value(OrganizationAttributes::new(org)).ok(),
+                resource: "Team".to_owned(),
+                attributes: serde_json::to_value(TeamAttributes::new(team)).ok(),
             },
         )
         .await
@@ -399,28 +392,28 @@ impl PermissionsDal for Client {
             }
         }
 
-        self.assign_resource_role(user_id, format!("Organization:{}", org.id), "admin")
+        self.assign_resource_role(user_id, format!("Team:{}", team.id), "admin")
             .await?;
 
         Ok(())
     }
 
-    async fn delete_organization(&self, user_id: &str, org_id: &str) -> Result<()> {
-        if !self.allowed_org(user_id, org_id, "manage").await? {
+    async fn delete_team(&self, user_id: &str, team_id: &str) -> Result<()> {
+        if !self.allowed_team(user_id, team_id, "manage").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to delete the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to delete the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
-        let projects = self.get_organization_projects(user_id, org_id).await?;
+        let projects = self.get_team_projects(user_id, team_id).await?;
 
         if !projects.is_empty() {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::BAD_REQUEST,
-                content: "Organization still has projects".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "Team still has projects".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -428,17 +421,17 @@ impl PermissionsDal for Client {
             &self.api,
             &self.proj_id,
             &self.env_id,
-            format!("Organization:{org_id}").as_str(),
+            format!("Team:{team_id}").as_str(),
         )
         .await?)
     }
 
-    async fn get_organization_projects(&self, user_id: &str, org_id: &str) -> Result<Vec<String>> {
-        if !self.allowed_org(user_id, org_id, "view").await? {
+    async fn get_team_projects(&self, user_id: &str, team_id: &str) -> Result<Vec<String>> {
+        if !self.allowed_team(user_id, team_id, "view").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to view the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to view the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -450,7 +443,7 @@ impl PermissionsDal for Client {
             None,
             None,
             Some("default"),
-            Some(&format!("Organization:{org_id}")),
+            Some(&format!("Team:{team_id}")),
             Some("parent"),
             None,
             Some("Project"),
@@ -466,11 +459,7 @@ impl PermissionsDal for Client {
         Ok(projects)
     }
 
-    async fn get_organization(
-        &self,
-        user_id: &str,
-        org_id: &str,
-    ) -> Result<organization::Response> {
+    async fn get_team(&self, user_id: &str, team_id: &str) -> Result<team::Response> {
         let mut perms = get_user_permissions_user_permissions_post(
             &self.pdp,
             UserPermissionsQuery {
@@ -478,7 +467,7 @@ impl PermissionsDal for Client {
                     key: user_id.to_owned(),
                     ..Default::default()
                 }),
-                resources: Some(vec![format!("Organization:{org_id}")]),
+                resources: Some(vec![format!("Team:{team_id}")]),
                 tenants: Some(vec!["default".to_owned()]),
                 ..Default::default()
             },
@@ -487,23 +476,26 @@ impl PermissionsDal for Client {
         )
         .await?;
 
-        let Some(org) = perms.remove(&format!("Organization:{org_id}")) else {
+        let Some(team) = perms.remove(&format!("Team:{team_id}")) else {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to view the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to view the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         };
 
-        let res = if let Some(resource) = org.resource {
+        let res = if let Some(resource) = team.resource {
             let attributes = resource.attributes.unwrap_or_default();
-            let org_attrs = serde_json::from_value::<OrganizationAttributes>(attributes)
-                .expect("to read organization attributes");
+            let team_attrs = serde_json::from_value::<TeamAttributes>(attributes)
+                .expect("to read team attributes");
 
-            organization::Response {
+            team::Response {
                 id: resource.key,
-                display_name: org_attrs.display_name,
-                is_admin: org.roles.unwrap_or_default().contains(&"admin".to_string()),
+                display_name: team_attrs.display_name,
+                is_admin: team
+                    .roles
+                    .unwrap_or_default()
+                    .contains(&"admin".to_string()),
             }
         } else {
             unreachable!("the permission will always have a resource")
@@ -512,7 +504,7 @@ impl PermissionsDal for Client {
         Ok(res)
     }
 
-    async fn get_organizations(&self, user_id: &str) -> Result<Vec<organization::Response>> {
+    async fn get_teams(&self, user_id: &str) -> Result<Vec<team::Response>> {
         let perms = get_user_permissions_user_permissions_post(
             &self.pdp,
             UserPermissionsQuery {
@@ -520,7 +512,7 @@ impl PermissionsDal for Client {
                     key: user_id.to_owned(),
                     ..Default::default()
                 }),
-                resource_types: Some(vec!["Organization".to_owned()]),
+                resource_types: Some(vec!["Team".to_owned()]),
                 tenants: Some(vec!["default".to_owned()]),
                 ..Default::default()
             },
@@ -534,12 +526,12 @@ impl PermissionsDal for Client {
         for perm in perms.into_values() {
             if let Some(resource) = perm.resource {
                 let attributes = resource.attributes.unwrap_or_default();
-                let org = serde_json::from_value::<OrganizationAttributes>(attributes)
-                    .expect("to read organization attributes");
+                let team = serde_json::from_value::<TeamAttributes>(attributes)
+                    .expect("to read team attributes");
 
-                res.push(organization::Response {
+                res.push(team::Response {
                     id: resource.key,
-                    display_name: org.display_name,
+                    display_name: team.display_name,
                     is_admin: perm
                         .roles
                         .unwrap_or_default()
@@ -566,17 +558,17 @@ impl PermissionsDal for Client {
         Ok(())
     }
 
-    async fn transfer_project_to_org(
+    async fn transfer_project_to_team(
         &self,
         user_id: &str,
         project_id: &str,
-        org_id: &str,
+        team_id: &str,
     ) -> Result<()> {
-        if !self.allowed_org(user_id, org_id, "manage").await? {
+        if !self.allowed_team(user_id, team_id, "manage").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to modify the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to modify the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -584,7 +576,7 @@ impl PermissionsDal for Client {
             .await?;
 
         self.assign_relationship(
-            format!("Organization:{org_id}"),
+            format!("Team:{team_id}"),
             "parent",
             format!("Project:{project_id}"),
         )
@@ -593,17 +585,17 @@ impl PermissionsDal for Client {
         Ok(())
     }
 
-    async fn transfer_project_from_org(
+    async fn transfer_project_from_team(
         &self,
         user_id: &str,
         project_id: &str,
-        org_id: &str,
+        team_id: &str,
     ) -> Result<()> {
-        if !self.allowed_org(user_id, org_id, "manage").await? {
+        if !self.allowed_team(user_id, team_id, "manage").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to modify the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to modify the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -611,7 +603,7 @@ impl PermissionsDal for Client {
             .await?;
 
         self.unassign_relationship(
-            format!("Organization:{org_id}"),
+            format!("Team:{team_id}"),
             "parent",
             format!("Project:{project_id}"),
         )
@@ -620,17 +612,12 @@ impl PermissionsDal for Client {
         Ok(())
     }
 
-    async fn add_organization_member(
-        &self,
-        admin_user: &str,
-        org_id: &str,
-        user_id: &str,
-    ) -> Result<()> {
-        if !self.allowed_org(admin_user, org_id, "manage").await? {
+    async fn add_team_member(&self, admin_user: &str, team_id: &str, user_id: &str) -> Result<()> {
+        if !self.allowed_team(admin_user, team_id, "manage").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to modify the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to modify the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -642,55 +629,55 @@ impl PermissionsDal for Client {
         {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::BAD_REQUEST,
-                content: "Only Pro users can be added to an organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "Only Pro users can be added to a team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
-        self.assign_resource_role(user_id, format!("Organization:{org_id}"), "member")
+        self.assign_resource_role(user_id, format!("Team:{team_id}"), "member")
             .await?;
 
         Ok(())
     }
 
-    async fn remove_organization_member(
+    async fn remove_team_member(
         &self,
         admin_user: &str,
-        org_id: &str,
+        team_id: &str,
         user_id: &str,
     ) -> Result<()> {
         if admin_user == user_id {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::BAD_REQUEST,
-                content: "Cannot remove yourself from an organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "Cannot remove yourself from a team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
-        if !self.allowed_org(admin_user, org_id, "manage").await? {
+        if !self.allowed_team(admin_user, team_id, "manage").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to modify the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to modify the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
-        self.unassign_resource_role(user_id, format!("Organization:{org_id}"), "member")
+        self.unassign_resource_role(user_id, format!("Team:{team_id}"), "member")
             .await?;
 
         Ok(())
     }
 
-    async fn get_organization_members(
+    async fn get_team_members(
         &self,
         user_id: &str,
-        org_id: &str,
-    ) -> Result<Vec<organization::MemberResponse>> {
-        if !self.allowed_org(user_id, org_id, "view").await? {
+        team_id: &str,
+    ) -> Result<Vec<team::MemberResponse>> {
+        if !self.allowed_team(user_id, team_id, "view").await? {
             return Err(Error::ResponseError(ResponseContent {
                 status: StatusCode::FORBIDDEN,
-                content: "User does not have permission to view the organization".to_owned(),
-                entity: "Organization".to_owned(),
+                content: "User does not have permission to view the team".to_owned(),
+                entity: "Team".to_owned(),
             }));
         }
 
@@ -702,7 +689,7 @@ impl PermissionsDal for Client {
             None,
             Some("default"),
             None,
-            Some(&format!("Organization:{org_id}")),
+            Some(&format!("Team:{team_id}")),
             None,
             None,
             None,
@@ -711,10 +698,10 @@ impl PermissionsDal for Client {
 
         let members = assignments
             .into_iter()
-            .map(|assignment| organization::MemberResponse {
+            .map(|assignment| team::MemberResponse {
                 id: assignment.user,
-                role: organization::MemberRole::from_str(&assignment.role)
-                    .unwrap_or(organization::MemberRole::Member),
+                role: team::MemberRole::from_str(&assignment.role)
+                    .unwrap_or(team::MemberRole::Member),
             })
             .collect();
 
@@ -742,15 +729,15 @@ impl PermissionsDal for Client {
             Some("parent"),
             Some(&format!("Project:{project_id}")),
             None,
-            Some("Organization"),
+            Some("Team"),
         )
         .await?;
 
         if let Some(rel) = relationships.into_iter().next() {
-            let org_id = rel.subject_details.expect("to have subject details").key;
-            Ok(Owner::Organization(org_id))
+            let team_id = rel.subject_details.expect("to have subject details").key;
+            Ok(Owner::Team(team_id))
         } else {
-            // If a user is able to view a project while the project has no parent org, then this user must be the project owner
+            // If a user is able to view a project while the project has no parent team, then this user must be the project owner
             Ok(Owner::User(user_id.to_owned()))
         }
     }
@@ -849,7 +836,7 @@ impl Client {
         Ok(())
     }
 
-    async fn allowed_org(&self, user_id: &str, org_id: &str, action: &str) -> Result<bool> {
+    async fn allowed_team(&self, user_id: &str, team_id: &str, action: &str) -> Result<bool> {
         // NOTE: This API function was modified in upstream to use AuthorizationQuery
         let res = is_allowed_allowed_post(
             &self.pdp,
@@ -860,8 +847,8 @@ impl Client {
                 }),
                 action: action.to_owned(),
                 resource: Box::new(Resource {
-                    r#type: "Organization".to_string(),
-                    key: Some(org_id.to_owned()),
+                    r#type: "Team".to_string(),
+                    key: Some(team_id.to_owned()),
                     tenant: Some("default".to_owned()),
                     ..Default::default()
                 }),

--- a/backends/src/test_utils/gateway.rs
+++ b/backends/src/test_utils/gateway.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use permit_client_rs::models::UserRead;
 use serde::Serialize;
-use shuttle_common::models::organization;
+use shuttle_common::models::team;
 use tokio::sync::Mutex;
 use wiremock::{
     http,
@@ -12,7 +12,7 @@ use wiremock::{
 };
 
 use crate::client::{
-    permit::{Organization, Owner, Result},
+    permit::{Owner, Result, Team},
     PermissionsDal,
 };
 
@@ -171,47 +171,40 @@ impl PermissionsDal for PermissionsMock {
         Ok(true)
     }
 
-    async fn create_organization(&self, user_id: &str, org: &Organization) -> Result<()> {
+    async fn create_team(&self, user_id: &str, team: &Team) -> Result<()> {
         self.calls.lock().await.push(format!(
-            "create_organization {user_id} {} {}",
-            org.id, org.display_name
+            "create_team {user_id} {} {}",
+            team.id, team.display_name
         ));
         Ok(())
     }
 
-    async fn delete_organization(&self, user_id: &str, org_id: &str) -> Result<()> {
+    async fn delete_team(&self, user_id: &str, team_id: &str) -> Result<()> {
         self.calls
             .lock()
             .await
-            .push(format!("delete_organization {user_id} {org_id}"));
+            .push(format!("delete_team {user_id} {team_id}"));
         Ok(())
     }
 
-    async fn get_organization(
-        &self,
-        user_id: &str,
-        org_id: &str,
-    ) -> Result<organization::Response> {
+    async fn get_team(&self, user_id: &str, team_id: &str) -> Result<team::Response> {
         self.calls
             .lock()
             .await
-            .push(format!("get_organization {user_id} {org_id}"));
+            .push(format!("get_team {user_id} {team_id}"));
         Ok(Default::default())
     }
 
-    async fn get_organization_projects(&self, user_id: &str, org_id: &str) -> Result<Vec<String>> {
+    async fn get_team_projects(&self, user_id: &str, team_id: &str) -> Result<Vec<String>> {
         self.calls
             .lock()
             .await
-            .push(format!("get_organization_projects {user_id} {org_id}"));
+            .push(format!("get_team_projects {user_id} {team_id}"));
         Ok(Default::default())
     }
 
-    async fn get_organizations(&self, user_id: &str) -> Result<Vec<organization::Response>> {
-        self.calls
-            .lock()
-            .await
-            .push(format!("get_organizations {user_id}"));
+    async fn get_teams(&self, user_id: &str) -> Result<Vec<team::Response>> {
+        self.calls.lock().await.push(format!("get_teams {user_id}"));
         Ok(Default::default())
     }
 
@@ -228,63 +221,59 @@ impl PermissionsDal for PermissionsMock {
         Ok(())
     }
 
-    async fn transfer_project_to_org(
+    async fn transfer_project_to_team(
         &self,
         user_id: &str,
         project_id: &str,
-        org_id: &str,
+        team_id: &str,
     ) -> Result<()> {
         self.calls.lock().await.push(format!(
-            "transfer_project_to_org {user_id} {project_id} {org_id}"
+            "transfer_project_to_team {user_id} {project_id} {team_id}"
         ));
         Ok(())
     }
 
-    async fn transfer_project_from_org(
+    async fn transfer_project_from_team(
         &self,
         user_id: &str,
         project_id: &str,
-        org_id: &str,
+        team_id: &str,
     ) -> Result<()> {
         self.calls.lock().await.push(format!(
-            "transfer_project_from_org {user_id} {project_id} {org_id}"
+            "transfer_project_from_team {user_id} {project_id} {team_id}"
         ));
         Ok(())
     }
 
-    async fn add_organization_member(
-        &self,
-        admin_user: &str,
-        org_id: &str,
-        user_id: &str,
-    ) -> Result<()> {
-        self.calls.lock().await.push(format!(
-            "add_organization_member {admin_user} {org_id} {user_id}"
-        ));
-        Ok(())
-    }
-
-    async fn remove_organization_member(
-        &self,
-        admin_user: &str,
-        org_id: &str,
-        user_id: &str,
-    ) -> Result<()> {
-        self.calls.lock().await.push(format!(
-            "remove_organization_member {admin_user} {org_id} {user_id}"
-        ));
-        Ok(())
-    }
-
-    async fn get_organization_members(
-        &self,
-        user_id: &str,
-        org_id: &str,
-    ) -> Result<Vec<organization::MemberResponse>> {
+    async fn add_team_member(&self, admin_user: &str, team_id: &str, user_id: &str) -> Result<()> {
         self.calls
             .lock()
             .await
-            .push(format!("get_organization_members {user_id} {org_id}"));
+            .push(format!("add_team_member {admin_user} {team_id} {user_id}"));
+        Ok(())
+    }
+
+    async fn remove_team_member(
+        &self,
+        admin_user: &str,
+        team_id: &str,
+        user_id: &str,
+    ) -> Result<()> {
+        self.calls.lock().await.push(format!(
+            "remove_team_member {admin_user} {team_id} {user_id}"
+        ));
+        Ok(())
+    }
+
+    async fn get_team_members(
+        &self,
+        user_id: &str,
+        team_id: &str,
+    ) -> Result<Vec<team::MemberResponse>> {
+        self.calls
+            .lock()
+            .await
+            .push(format!("get_team_members {user_id} {team_id}"));
         Ok(Default::default())
     }
 

--- a/backends/tests/integration/permit_tests.rs
+++ b/backends/tests/integration/permit_tests.rs
@@ -8,10 +8,10 @@ mod needs_docker {
     };
     use serial_test::serial;
     use shuttle_backends::client::{
-        permit::{Client, Error, Organization, Owner, ResponseContent},
+        permit::{Client, Error, Owner, ResponseContent, Team},
         PermissionsDal,
     };
-    use shuttle_common::{claims::AccountTier, models::organization};
+    use shuttle_common::{claims::AccountTier, models::team};
     use shuttle_common_tests::permit_pdp::DockerInstance;
     use test_context::{test_context, AsyncTestContext};
     use uuid::Uuid;
@@ -203,7 +203,7 @@ mod needs_docker {
     #[test_context(Wrap)]
     #[tokio::test]
     #[serial]
-    async fn test_organizations(Wrap(client): &mut Wrap) {
+    async fn test_teams(Wrap(client): &mut Wrap) {
         let u1 = "user-o-1";
         let u2 = "user-o-2";
         client.new_user(u1).await.unwrap();
@@ -213,57 +213,57 @@ mod needs_docker {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        let org = Organization {
-            id: "org_123".to_string(),
-            display_name: "Test organization".to_string(),
+        let team = Team {
+            id: "team_123".to_string(),
+            display_name: "Test team".to_string(),
         };
 
-        let err = client.create_organization(u1, &org).await.unwrap_err();
+        let err = client.create_team(u1, &team).await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Only Pro users can create organizations"
+            "Only Pro users can create teams"
         );
 
         client.make_pro(u1).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        client.create_organization(u1, &org).await.unwrap();
+        client.create_team(u1, &team).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
-        let o1 = client.get_organizations(u1).await.unwrap();
+        let o1 = client.get_teams(u1).await.unwrap();
 
         assert_eq!(
             o1,
-            vec![organization::Response {
-                id: "org_123".to_string(),
-                display_name: "Test organization".to_string(),
+            vec![team::Response {
+                id: "team_123".to_string(),
+                display_name: "Test team".to_string(),
                 is_admin: true,
             }]
         );
 
-        let o = client.get_organization(u1, "org_123").await.unwrap();
+        let o = client.get_team(u1, "team_123").await.unwrap();
 
         assert_eq!(
             o,
-            organization::Response {
-                id: "org_123".to_string(),
-                display_name: "Test organization".to_string(),
+            team::Response {
+                id: "team_123".to_string(),
+                display_name: "Test team".to_string(),
                 is_admin: true,
             }
         );
 
         let err = client
-            .create_organization(
+            .create_team(
                 u1,
-                &Organization {
-                    id: "org_987".to_string(),
-                    display_name: "Second organization".to_string(),
+                &Team {
+                    id: "team_987".to_string(),
+                    display_name: "Second team".to_string(),
                 },
             )
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::BAD_REQUEST),
-            "User cannot create more than one organization"
+            "User cannot create more than one team"
         );
 
         client.create_project(u1, "proj-o-1").await.unwrap();
@@ -277,7 +277,7 @@ mod needs_docker {
         assert_eq!(own, Owner::User(u1.to_string()));
 
         client
-            .transfer_project_to_org(u1, "proj-o-1", "org_123")
+            .transfer_project_to_team(u1, "proj-o-1", "team_123")
             .await
             .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
@@ -286,21 +286,15 @@ mod needs_docker {
         assert_eq!(p1.len(), 0);
 
         let own = client.get_project_owner(u1, "proj-o-1").await.unwrap();
-        assert_eq!(own, Owner::Organization("org_123".to_string()));
+        assert_eq!(own, Owner::Team("team_123".to_string()));
 
-        let err = client
-            .get_organization_projects(u2, "org_123")
-            .await
-            .unwrap_err();
+        let err = client.get_team_projects(u2, "team_123").await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "User cannot view projects on an organization it does not belong to"
+            "User cannot view projects on a team it does not belong to"
         );
 
-        let ps = client
-            .get_organization_projects(u1, "org_123")
-            .await
-            .unwrap();
+        let ps = client.get_team_projects(u1, "team_123").await.unwrap();
         assert_eq!(ps, vec!["proj-o-1"]);
 
         client.create_project(u2, "proj-o-2").await.unwrap();
@@ -311,16 +305,16 @@ mod needs_docker {
         assert_eq!(p2[0], "proj-o-2");
 
         let err = client
-            .transfer_project_to_org(u2, "proj-o-2", "org_123")
+            .transfer_project_to_team(u2, "proj-o-2", "team_123")
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Cannot transfer to organization that user is not admin of"
+            "Cannot transfer to team that user is not admin of"
         );
 
         let err = client
-            .transfer_project_to_org(u1, "proj-o-2", "org_123")
+            .transfer_project_to_team(u1, "proj-o-2", "team_123")
             .await
             .unwrap_err();
         assert!(
@@ -328,23 +322,23 @@ mod needs_docker {
             "Cannot transfer a project that user does not own"
         );
 
-        let err = client.delete_organization(u1, "org_123").await.unwrap_err();
+        let err = client.delete_team(u1, "team_123").await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::BAD_REQUEST),
-            "Cannot delete organization with projects in it"
+            "Cannot delete team with projects in it"
         );
 
         let err = client
-            .transfer_project_from_org(u2, "proj-o-1", "org_123")
+            .transfer_project_from_team(u2, "proj-o-1", "team_123")
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Cannot transfer from organization that user is not admin of"
+            "Cannot transfer from team that user is not admin of"
         );
 
         client
-            .transfer_project_from_org(u1, "proj-o-1", "org_123")
+            .transfer_project_from_team(u1, "proj-o-1", "team_123")
             .await
             .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
@@ -356,15 +350,15 @@ mod needs_docker {
         let own = client.get_project_owner(u1, "proj-o-1").await.unwrap();
         assert_eq!(own, Owner::User(u1.to_string()));
 
-        let err = client.delete_organization(u2, "org_123").await.unwrap_err();
+        let err = client.delete_team(u2, "team_123").await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Cannot delete organization that user does not own"
+            "Cannot delete team that user does not own"
         );
 
-        client.delete_organization(u1, "org_123").await.unwrap();
+        client.delete_team(u1, "team_123").await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
-        let o1 = client.get_organizations(u1).await.unwrap();
+        let o1 = client.get_teams(u1).await.unwrap();
 
         assert_eq!(o1, vec![]);
     }
@@ -372,7 +366,7 @@ mod needs_docker {
     #[test_context(Wrap)]
     #[tokio::test]
     #[serial]
-    async fn test_organization_members(Wrap(client): &mut Wrap) {
+    async fn test_team_members(Wrap(client): &mut Wrap) {
         let u1 = "user-om-1";
         let u2 = "user-om-2";
         let u3 = "user-om-3";
@@ -388,19 +382,19 @@ mod needs_docker {
         client.make_pro(u3).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        let org = Organization {
-            id: "org_345".to_string(),
+        let team = Team {
+            id: "team_345".to_string(),
             display_name: "Blazingly fast team".to_string(),
         };
 
-        client.create_organization(u1, &org).await.unwrap();
+        client.create_team(u1, &team).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
-        let o1 = client.get_organizations(u1).await.unwrap();
+        let o1 = client.get_teams(u1).await.unwrap();
 
         assert_eq!(
             o1,
-            vec![organization::Response {
-                id: "org_345".to_string(),
+            vec![team::Response {
+                id: "team_345".to_string(),
                 display_name: "Blazingly fast team".to_string(),
                 is_admin: true,
             }]
@@ -409,168 +403,138 @@ mod needs_docker {
         client.create_project(u1, "proj-om-1").await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
         client
-            .transfer_project_to_org(u1, "proj-om-1", "org_345")
+            .transfer_project_to_team(u1, "proj-om-1", "team_345")
             .await
             .unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        let ps = client
-            .get_organization_projects(u1, "org_345")
-            .await
-            .unwrap();
+        let ps = client.get_team_projects(u1, "team_345").await.unwrap();
         assert_eq!(ps, vec!["proj-om-1"]);
 
-        let o2 = client.get_organizations(u2).await.unwrap();
+        let o2 = client.get_teams(u2).await.unwrap();
         assert_eq!(o2, vec![]);
 
-        let err = client
-            .get_organization_projects(u2, "org_345")
-            .await
-            .unwrap_err();
+        let err = client.get_team_projects(u2, "team_345").await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Cannot view projects of an organization that user is not a member of"
+            "Cannot view projects of a team that user is not a member of"
         );
 
         let err = client
-            .add_organization_member(u1, "org_345", u2)
+            .add_team_member(u1, "team_345", u2)
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::BAD_REQUEST),
-            "Can only add Pro users to organizations"
+            "Can only add Pro users to teams"
         );
 
         client.make_pro(u2).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        client
-            .add_organization_member(u1, "org_345", u2)
-            .await
-            .unwrap();
+        client.add_team_member(u1, "team_345", u2).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        let o2 = client.get_organizations(u2).await.unwrap();
+        let o2 = client.get_teams(u2).await.unwrap();
         assert_eq!(
             o2,
-            vec![organization::Response {
-                id: "org_345".to_string(),
+            vec![team::Response {
+                id: "team_345".to_string(),
                 display_name: "Blazingly fast team".to_string(),
                 is_admin: false,
             }]
         );
 
-        let o = client.get_organization(u2, "org_345").await.unwrap();
+        let o = client.get_team(u2, "team_345").await.unwrap();
 
         assert_eq!(
             o,
-            organization::Response {
-                id: "org_345".to_string(),
+            team::Response {
+                id: "team_345".to_string(),
                 display_name: "Blazingly fast team".to_string(),
                 is_admin: false,
             }
         );
 
-        let ps2 = client
-            .get_organization_projects(u2, "org_345")
-            .await
-            .unwrap();
+        let ps2 = client.get_team_projects(u2, "team_345").await.unwrap();
         assert_eq!(ps2, vec!["proj-om-1"]);
 
         let own = client.get_project_owner(u2, "proj-om-1").await.unwrap();
-        assert_eq!(own, Owner::Organization("org_345".to_string()));
+        assert_eq!(own, Owner::Team("team_345".to_string()));
 
         let err = client
-            .add_organization_member(u2, "org_345", u3)
+            .add_team_member(u2, "team_345", u3)
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Only organization admin can add members"
+            "Only team admin can add members"
         );
 
-        let err = client
-            .get_organization_members(u3, "org_345")
-            .await
-            .unwrap_err();
+        let err = client.get_team_members(u3, "team_345").await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Only organization members can view members"
+            "Only team members can view members"
         );
 
-        let members = client
-            .get_organization_members(u1, "org_345")
-            .await
-            .unwrap();
+        let members = client.get_team_members(u1, "team_345").await.unwrap();
         assert_eq!(members.len(), 2);
-        assert!(members.contains(&organization::MemberResponse {
+        assert!(members.contains(&team::MemberResponse {
             id: u1.to_string(),
-            role: organization::MemberRole::Admin,
+            role: team::MemberRole::Admin,
         }));
-        assert!(members.contains(&organization::MemberResponse {
+        assert!(members.contains(&team::MemberResponse {
             id: u2.to_string(),
-            role: organization::MemberRole::Member,
+            role: team::MemberRole::Member,
         }));
 
-        let members = client
-            .get_organization_members(u2, "org_345")
-            .await
-            .unwrap();
+        let members = client.get_team_members(u2, "team_345").await.unwrap();
         assert_eq!(members.len(), 2);
-        assert!(members.contains(&organization::MemberResponse {
+        assert!(members.contains(&team::MemberResponse {
             id: u1.to_string(),
-            role: organization::MemberRole::Admin,
+            role: team::MemberRole::Admin,
         }));
-        assert!(members.contains(&organization::MemberResponse {
+        assert!(members.contains(&team::MemberResponse {
             id: u2.to_string(),
-            role: organization::MemberRole::Member,
+            role: team::MemberRole::Member,
         }));
 
         let err = client
-            .remove_organization_member(u1, "org_345", u1)
+            .remove_team_member(u1, "team_345", u1)
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::BAD_REQUEST),
-            "User cannot remove themselves from organizations"
+            "User cannot remove themselves from teams"
         );
 
         let err = client
-            .remove_organization_member(u2, "org_345", u1)
+            .remove_team_member(u2, "team_345", u1)
             .await
             .unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Only organization admin can remove members"
+            "Only team admin can remove members"
         );
 
-        client
-            .remove_organization_member(u1, "org_345", u2)
-            .await
-            .unwrap();
+        client.remove_team_member(u1, "team_345", u2).await.unwrap();
         tokio::time::sleep(tokio::time::Duration::from_millis(SLEEP)).await;
 
-        let o2 = client.get_organizations(u2).await.unwrap();
+        let o2 = client.get_teams(u2).await.unwrap();
         assert_eq!(o2, vec![]);
 
-        let err = client
-            .get_organization_projects(u2, "org_345")
-            .await
-            .unwrap_err();
+        let err = client.get_team_projects(u2, "team_345").await.unwrap_err();
         assert!(
             matches!(err, Error::ResponseError(ResponseContent { status, .. }) if status == StatusCode::FORBIDDEN),
-            "Cannot view projects of an organization that user is not a member of"
+            "Cannot view projects of a team that user is not a member of"
         );
 
-        let members = client
-            .get_organization_members(u1, "org_345")
-            .await
-            .unwrap();
+        let members = client.get_team_members(u1, "team_345").await.unwrap();
         assert_eq!(
             members,
-            vec![organization::MemberResponse {
+            vec![team::MemberResponse {
                 id: u1.to_string(),
-                role: organization::MemberRole::Admin,
+                role: team::MemberRole::Admin,
             },]
         );
     }

--- a/cargo-shuttle/src/client.rs
+++ b/cargo-shuttle/src/client.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use shuttle_common::constants::headers::X_CARGO_SHUTTLE_VERSION;
 use shuttle_common::log::LogsRange;
 use shuttle_common::models::deployment::DeploymentRequest;
-use shuttle_common::models::organization;
+use shuttle_common::models::team;
 use shuttle_common::models::{deployment, project, service, ToJson};
 use shuttle_common::secrets::Secret;
 use shuttle_common::{resource, ApiKey, ApiUrl, LogItem, VersionInfo};
@@ -181,15 +181,12 @@ impl Client {
         self.delete(path).await
     }
 
-    pub async fn get_organizations_list(&self) -> Result<Vec<organization::Response>> {
-        self.get("/organizations".to_string()).await
+    pub async fn get_teams_list(&self) -> Result<Vec<team::Response>> {
+        self.get("/teams".to_string()).await
     }
 
-    pub async fn get_organization_projects_list(
-        &self,
-        org_id: &str,
-    ) -> Result<Vec<project::Response>> {
-        let path = format!("/organizations/{org_id}/projects");
+    pub async fn get_team_projects_list(&self, team_id: &str) -> Result<Vec<project::Response>> {
+        let path = format!("/teams/{team_id}/projects");
 
         self.get(path).await
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1980,31 +1980,32 @@ impl Shuttle {
         println!("{}", "Personal Projects".bold());
         println!("{projects_table}");
 
-        let orgs = client.get_organizations_list().await?;
+        let teams = client.get_teams_list().await?;
 
-        for org in orgs {
-            let mut org_projects = client
-                .get_organization_projects_list(&org.id)
-                .await
-                .map_err(|err| {
-                    suggestions::project::project_request_failure(
-                        err,
-                        "Getting organization projects list failed",
-                        false,
-                        "getting the organization projects list fails repeatedly",
-                    )
-                })?;
-            let page_hint = if org_projects.len() == limit as usize {
-                org_projects.pop();
+        for team in teams {
+            let mut team_projects =
+                client
+                    .get_team_projects_list(&team.id)
+                    .await
+                    .map_err(|err| {
+                        suggestions::project::project_request_failure(
+                            err,
+                            "Getting teams projects list failed",
+                            false,
+                            "getting the team projects list fails repeatedly",
+                        )
+                    })?;
+            let page_hint = if team_projects.len() == limit as usize {
+                team_projects.pop();
                 true
             } else {
                 false
             };
-            let org_projects_table =
-                project::get_projects_table(&org_projects, page, raw, page_hint);
+            let team_projects_table =
+                project::get_projects_table(&team_projects, page, raw, page_hint);
 
-            println!("{}", format!("{}'s Projects", org.display_name).bold());
-            println!("{org_projects_table}");
+            println!("{}", format!("{}'s Projects", team.display_name).bold());
+            println!("{team_projects_table}");
         }
 
         Ok(CommandOutcome::Ok)

--- a/common/src/models/error.rs
+++ b/common/src/models/error.rs
@@ -82,11 +82,11 @@ impl From<InvalidProjectName> for ApiError {
 }
 
 #[derive(Debug, Clone, PartialEq, Error)]
-#[error("Invalid organization name. Must not be more than 30 characters long.")]
-pub struct InvalidOrganizationName;
+#[error("Invalid team name. Must not be more than 30 characters long.")]
+pub struct InvalidTeamName;
 
-impl From<InvalidOrganizationName> for ApiError {
-    fn from(err: InvalidOrganizationName) -> Self {
+impl From<InvalidTeamName> for ApiError {
+    fn from(err: InvalidTeamName) -> Self {
         Self::bad_request(err)
     }
 }

--- a/common/src/models/mod.rs
+++ b/common/src/models/mod.rs
@@ -1,11 +1,11 @@
 pub mod admin;
 pub mod deployment;
 pub mod error;
-pub mod organization;
 pub mod project;
 pub mod resource;
 pub mod service;
 pub mod stats;
+pub mod team;
 pub mod user;
 
 use anyhow::{Context, Result};

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -171,7 +171,7 @@ pub struct Config {
 #[serde(tag = "owner_type", content = "owner_id", rename_all = "lowercase")]
 pub enum Owner {
     User(String),
-    Organization(String),
+    Team(String),
 }
 
 pub fn get_projects_table(projects: &[Response], page: u32, raw: bool, page_hint: bool) -> String {

--- a/common/src/models/team.rs
+++ b/common/src/models/team.rs
@@ -3,30 +3,30 @@ use strum::{Display, EnumString};
 
 use super::user::UserId;
 
-/// Minimal organization information
+/// Minimal team information
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct Response {
-    /// Organization ID
+    /// Team ID
     pub id: String,
 
     /// Name used for display purposes
     pub display_name: String,
 
-    /// Is this user an admin of the organization
+    /// Is this user an admin of the team
     pub is_admin: bool,
 }
 
-/// Member of an organization
+/// Member of a team
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct MemberResponse {
     /// User ID
     pub id: UserId,
 
-    /// Role of the user in the organization
+    /// Role of the user in the team
     pub role: MemberRole,
 }
 
-/// Role of a user in an organization
+/// Role of a user in a team
 #[derive(Debug, Serialize, Deserialize, PartialEq, Display, EnumString)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]


### PR DESCRIPTION
## Description of change
Renames all references of organizations to teams



## How has this been tested? (if applicable)
The compiler :see_no_evil: and careful manual labour


