### PR TITLE
fix(service): improve workspace member discovery and error

### DIFF
--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -104,7 +104,7 @@ pub async fn build_workspace(
     if packages.is_empty() {
         bail!(
             "Did not find any packages that Shuttle can run. \
-            Make sure your crate has a binary target and uses `#[shuttle_runtime::main]`."
+            Make sure your crate has a binary target that uses `#[shuttle_runtime::main]`."
         );
     }
 

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -101,6 +101,12 @@ pub async fn build_workspace(
 
     let metadata = async_cargo_metadata(manifest_path.as_path()).await?;
     let packages = find_shuttle_packages(&metadata)?;
+    if packages.is_empty() {
+        bail!(
+            "Did not find any packages that Shuttle can run. \
+            Make sure your crate has a binary target and uses `#[shuttle_runtime::main]`."
+        );
+    }
 
     let services = compile(
         packages,
@@ -147,13 +153,16 @@ pub fn find_shuttle_packages(metadata: &Metadata) -> anyhow::Result<Vec<Package>
     let mut packages = Vec::new();
     for member in metadata.workspace_packages() {
         // skip non-Shuttle-related crates
-        if !member
+        // (must have runtime dependency and not be just a library)
+        let has_runtime_dep = member
             .dependencies
             .iter()
-            .any(|dependency| dependency.name == RUNTIME_NAME)
-        {
+            .any(|dependency| dependency.name == RUNTIME_NAME);
+        let has_binary_target = member.targets.iter().any(|t| t.is_bin());
+        if !(has_runtime_dep && has_binary_target) {
             continue;
         }
+
         let mut shuttle_deps = member
             .dependencies
             .iter()
@@ -162,7 +171,6 @@ pub fn find_shuttle_packages(metadata: &Metadata) -> anyhow::Result<Vec<Package>
             .collect::<Vec<_>>();
         shuttle_deps.sort();
         info!(name = member.name, deps = ?shuttle_deps, "Found workspace member with shuttle dependencies");
-        ensure_binary(member)?;
         packages.push(member.to_owned());
     }
 
@@ -188,15 +196,6 @@ pub async fn clean_crate(project_path: &Path) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-/// Make sure the project is a binary for alpha projects.
-fn ensure_binary(package: &Package) -> anyhow::Result<()> {
-    if package.targets.iter().any(|target| target.is_bin()) {
-        Ok(())
-    } else {
-        bail!("Your Shuttle package must be a binary.")
-    }
 }
 
 async fn compile(

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -14,7 +14,7 @@ async fn not_shuttle() {
 
 #[tokio::test]
 #[should_panic(
-    expected = "Did not find any packages that Shuttle can run. Make sure your crate has a binary target and uses `#[shuttle_runtime::main]`."
+    expected = "Did not find any packages that Shuttle can run. Make sure your crate has a binary target that uses `#[shuttle_runtime::main]`."
 )]
 async fn not_bin() {
     let (tx, _) = tokio::sync::mpsc::channel::<String>(256);

--- a/service/tests/integration/build_crate.rs
+++ b/service/tests/integration/build_crate.rs
@@ -13,7 +13,9 @@ async fn not_shuttle() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "Your Shuttle package must be a binary.")]
+#[should_panic(
+    expected = "Did not find any packages that Shuttle can run. Make sure your crate has a binary target and uses `#[shuttle_runtime::main]`."
+)]
 async fn not_bin() {
     let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = format!("{}/tests/resources/not-bin", env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Supersedes https://github.com/shuttle-hq/shuttle/pull/1757

Improves logic for which workspace member(s) that are chosen for building by ignoring crates with no binary target.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested on a local example.
Having libs with runtime now works. Having no members with binaries now prints the new error.
