### PR TITLE
bug: arg for provisioner-uri

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,7 +85,7 @@ services:
       - "--docker-host=/var/run/docker.sock"
       - "--auth-uri=http://auth:8000"
       - "--deploys-api-key=${DEPLOYS_API_KEY}"
-      - "--provisioner-host=provisioner"
+      - "--provisioner-uri=http://provisioner:8000"
       - "--proxy-fqdn=${APPS_FQDN}"
       - "--use-tls=${USE_TLS}"
       - "--cors-origin=http://localhost:3001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
       - "--docker-host=/var/run/docker.sock"
       - "--auth-uri=http://auth:8000"
       - "--deploys-api-key=${DEPLOYS_API_KEY}"
-      - "--provisioner-host=provisioner"
+      - "--provisioner-uri=http://provisioner:8000"
       - "--proxy-fqdn=${APPS_FQDN}"
       - "--use-tls=${USE_TLS}"
       - "--cors-origin=https://console.shuttle.rs"


### PR DESCRIPTION
## Description of change
Missed updating the docker args in #1762 

## How has this been tested? (if applicable)
Starting a local stack


