### PR TITLE
ci: windows builds (#1770)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -443,13 +443,14 @@ jobs:
           name: Install Rust
           # Note: Let binary build use latest
           command: |
+            choco uninstall rust # The one coming from choco interferes with the one coming from rustup
             wget -OutFile "C:\rustup-init.exe" https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
             C:\rustup-init.exe -y --target x86_64-pc-windows-msvc
           shell: powershell.exe
       - run:
           name: Build
           command: |
-            ..\.cargo\bin\cargo.exe build --release --package cargo-shuttle --target x86_64-pc-windows-msvc
+            cargo.exe build --release --package cargo-shuttle --target x86_64-pc-windows-msvc
           shell: powershell.exe
       - make-artifact:
           target: x86_64-pc-windows-msvc

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1675,7 +1675,7 @@ impl Shuttle {
         let mut signal_received = false;
         for (i, service) in services.iter().enumerate() {
             signal_received = tokio::select! {
-                res = Shuttle::spin_local_runtime(&run_args, service, i as u16) => {
+                res = Shuttle::spin_local_runtime(self.beta, &run_args, service, i as u16) => {
                     Shuttle::add_runtime_info(res.unwrap(), &mut runtimes).await?;
                     false
                 },


### PR DESCRIPTION
* misc: uninstall rust coming from choco

This install causes the rust coming from rustup to not be able to find `core` correctly.

* refactor: missing beta arg

* misc: restore other ci steps

## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->



## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


