### PR TITLE
feat(cargo-shuttle): beta compact project and deployment tables

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -409,7 +409,7 @@ impl InitTemplateArg {
 
 #[derive(Parser, Clone, Debug, Default)]
 pub struct LogsArgs {
-    /// Deployment ID to get logs for. Defaults to currently running deployment
+    /// Deployment ID to get logs for. Defaults to the current deployment
     pub id: Option<String>,
     #[arg(short, long)]
     /// View logs from the most recent deployment (which is not always the latest running one)

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -32,7 +32,6 @@ use ignore::overrides::OverrideBuilder;
 use ignore::WalkBuilder;
 use indicatif::ProgressBar;
 use indoc::{formatdoc, printdoc};
-use shuttle_common::models::deployment::{deployments_table_beta, DeploymentRequestBeta};
 use shuttle_common::{
     constants::{
         API_URL_DEFAULT, DEFAULT_IDLE_MINUTES, EXAMPLES_REPO, EXECUTABLE_DIRNAME,
@@ -43,8 +42,8 @@ use shuttle_common::{
     log::LogsRange,
     models::{
         deployment::{
-            get_deployments_table, DeploymentRequest, CREATE_SERVICE_BODY_LIMIT,
-            GIT_STRINGS_MAX_LENGTH,
+            deployments_table_beta, get_deployments_table, DeploymentRequest,
+            DeploymentRequestBeta, CREATE_SERVICE_BODY_LIMIT, GIT_STRINGS_MAX_LENGTH,
         },
         error::ApiError,
         project,
@@ -59,9 +58,8 @@ use shuttle_proto::{
     provisioner::{provisioner_server::Provisioner, DatabaseRequest},
     runtime::{self, LoadRequest, StartRequest, StopRequest},
 };
-use shuttle_service::builder::{async_cargo_metadata, find_shuttle_packages};
 use shuttle_service::{
-    builder::{build_workspace, BuiltService},
+    builder::{async_cargo_metadata, build_workspace, find_shuttle_packages, BuiltService},
     runner, Environment,
 };
 use strum::{EnumMessage, VariantArray};
@@ -979,7 +977,9 @@ impl Shuttle {
                 .get_deployments_beta(proj_name)
                 .await
                 .map_err(suggestions::deployment::get_deployments_list_failure)?;
-            let table = deployments_table_beta(&deployments, proj_name, raw);
+            let table = deployments_table_beta(&deployments);
+
+            println!("Deployments in project '{}'", proj_name);
             println!("{table}");
             deployments.len()
         } else {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -852,16 +852,18 @@ impl Shuttle {
         let logs = if args.all_deployments {
             client.get_project_logs_beta(proj_name).await?.logs
         } else {
-            // TODO:
-            // let depl = client.get_current_deployment_beta(proj_name).await?;
-            let depls = client.get_deployments_beta(proj_name).await?;
-            let depl = depls
-                .first()
-                .expect("at least one deployment in this project");
-            client
-                .get_deployment_logs_beta(proj_name, &depl.id)
-                .await?
-                .logs
+            let id = if let Some(id) = args.id {
+                id
+            } else {
+                // TODO: fix the endpoint and use:
+                // let depl = client.get_current_deployment_beta(proj_name).await?;
+                let depls = client.get_deployments_beta(proj_name).await?;
+                let depl = depls
+                    .first()
+                    .expect("at least one deployment in this project");
+                depl.id.clone()
+            };
+            client.get_deployment_logs_beta(proj_name, &id).await?.logs
         };
         for log in logs {
             println!("{}", log);

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -979,7 +979,10 @@ impl Shuttle {
                 .map_err(suggestions::deployment::get_deployments_list_failure)?;
             let table = deployments_table_beta(&deployments);
 
-            println!("Deployments in project '{}'", proj_name);
+            println!(
+                "{}",
+                format!("Deployments in project '{}'", proj_name).bold()
+            );
             println!("{table}");
             deployments.len()
         } else {

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -154,10 +154,8 @@ pub fn deployments_table_beta(deployments: &[EcsResponse]) -> String {
             Cell::new("Deployment ID"),
             Cell::new("Status"),
             Cell::new("Last updated"),
-            Cell::new("Commit ID"),
-            Cell::new("Commit Message"),
             Cell::new("Branch"),
-            Cell::new("Dirty"),
+            Cell::new("Commit"),
         ]);
 
     for deploy in deployments.iter() {
@@ -172,7 +170,7 @@ pub fn deployments_table_beta(deployments: &[EcsResponse]) -> String {
             .git_commit_msg
             .as_ref()
             .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
-                val.chars().take(24).collect::<String>()
+                val.chars().take(24).collect()
             });
 
         table.add_row(vec![
@@ -181,19 +179,22 @@ pub fn deployments_table_beta(deployments: &[EcsResponse]) -> String {
                 // Unwrap is safe because Color::from_str returns the color white if str is not a Color.
                 .fg(Color::from_str(deploy.latest_deployment_state.get_color()).unwrap()),
             Cell::new(deploy.updated_at.format("%Y-%m-%dT%H:%M:%SZ")),
-            Cell::new(truncated_commit_id),
-            Cell::new(truncated_commit_msg),
             Cell::new(
                 deploy
                     .git_branch
                     .as_ref()
-                    .map_or(GIT_OPTION_NONE_TEXT, |val| val as &str),
+                    .unwrap_or(&GIT_OPTION_NONE_TEXT.to_owned()),
             ),
-            Cell::new(
-                deploy
-                    .git_dirty
-                    .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| val.to_string()),
-            ),
+            Cell::new(format!(
+                "{}{} {}",
+                truncated_commit_id,
+                if deploy.git_dirty.is_some_and(|d| d) {
+                    "*"
+                } else {
+                    ""
+                },
+                truncated_commit_msg,
+            )),
         ]);
     }
 

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS,
-    presets::{NOTHING, UTF8_FULL},
+    presets::{NOTHING, UTF8_BORDERS_ONLY, UTF8_FULL},
     Attribute, Cell, CellAlignment, Color, ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
@@ -145,128 +145,59 @@ impl EcsState {
     }
 }
 
-pub fn deployments_table_beta(
-    deployments: &Vec<EcsResponse>,
-    project_name: &str,
-    raw: bool,
-) -> String {
-    if deployments.is_empty() {
-        // The page starts at 1 in the CLI.
-        let mut s = "No deployments are linked to this service\n".to_string();
-        if !raw {
-            s = s.yellow().bold().to_string();
-        }
+pub fn deployments_table_beta(deployments: &[EcsResponse]) -> String {
+    let mut table = Table::new();
+    table
+        .load_preset(UTF8_BORDERS_ONLY)
+        .set_content_arrangement(ContentArrangement::Disabled)
+        .set_header(vec![
+            Cell::new("Deployment ID"),
+            Cell::new("Status"),
+            Cell::new("Last updated"),
+            Cell::new("Commit ID"),
+            Cell::new("Commit Message"),
+            Cell::new("Branch"),
+            Cell::new("Dirty"),
+        ]);
 
-        s
-    } else {
-        let mut table = Table::new();
+    for deploy in deployments.iter() {
+        let truncated_commit_id = deploy
+            .git_commit_id
+            .as_ref()
+            .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
+                val.chars().take(7).collect()
+            });
 
-        if raw {
-            table
-                .load_preset(NOTHING)
-                .set_content_arrangement(ContentArrangement::Disabled)
-                .set_header(vec![
-                    Cell::new("Deployment ID").set_alignment(CellAlignment::Left),
-                    Cell::new("Status").set_alignment(CellAlignment::Left),
-                    Cell::new("Last updated").set_alignment(CellAlignment::Left),
-                    Cell::new("Commit ID").set_alignment(CellAlignment::Left),
-                    Cell::new("Commit Message").set_alignment(CellAlignment::Left),
-                    Cell::new("Branch").set_alignment(CellAlignment::Left),
-                    Cell::new("Dirty").set_alignment(CellAlignment::Left),
-                ]);
-        } else {
-            table
-                .load_preset(UTF8_FULL)
-                .apply_modifier(UTF8_ROUND_CORNERS)
-                .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-                .set_header(vec![
-                    Cell::new("Deployment ID")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                    Cell::new("Status")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                    Cell::new("Last updated")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                    Cell::new("Commit ID")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                    Cell::new("Commit Message")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                    Cell::new("Branch")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                    Cell::new("Dirty")
-                        .set_alignment(CellAlignment::Center)
-                        .add_attribute(Attribute::Bold),
-                ]);
-        }
+        let truncated_commit_msg = deploy
+            .git_commit_msg
+            .as_ref()
+            .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
+                val.chars().take(24).collect::<String>()
+            });
 
-        for deploy in deployments.iter() {
-            let truncated_commit_id = deploy
-                .git_commit_id
-                .as_ref()
-                .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
-                    val.chars().take(7).collect()
-                });
-
-            let truncated_commit_msg = deploy
-                .git_commit_msg
-                .as_ref()
-                .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| {
-                    val.chars().take(24).collect::<String>()
-                });
-
-            if raw {
-                table.add_row(vec![
-                    Cell::new(&deploy.id),
-                    Cell::new(&deploy.latest_deployment_state),
-                    Cell::new(deploy.updated_at.format("%Y-%m-%dT%H:%M:%SZ")),
-                    Cell::new(truncated_commit_id),
-                    Cell::new(truncated_commit_msg),
-                    Cell::new(
-                        deploy
-                            .git_branch
-                            .as_ref()
-                            .map_or(GIT_OPTION_NONE_TEXT, |val| val as &str),
-                    ),
-                    Cell::new(
-                        deploy
-                            .git_dirty
-                            .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| val.to_string()),
-                    ),
-                ]);
-            } else {
-                table.add_row(vec![
-                    Cell::new(&deploy.id),
-                    Cell::new(&deploy.latest_deployment_state)
-                        // Unwrap is safe because Color::from_str returns the color white if str is not a Color.
-                        .fg(Color::from_str(deploy.latest_deployment_state.get_color()).unwrap())
-                        .set_alignment(CellAlignment::Center),
-                    Cell::new(deploy.updated_at.format("%Y-%m-%dT%H:%M:%SZ"))
-                        .set_alignment(CellAlignment::Center),
-                    Cell::new(truncated_commit_id),
-                    Cell::new(truncated_commit_msg),
-                    Cell::new(
-                        deploy
-                            .git_branch
-                            .as_ref()
-                            .map_or(GIT_OPTION_NONE_TEXT, |val| val as &str),
-                    ),
-                    Cell::new(
-                        deploy
-                            .git_dirty
-                            .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| val.to_string()),
-                    )
-                    .set_alignment(CellAlignment::Center),
-                ]);
-            }
-        }
-
-        format!("\nMost recent deployments for {project_name}\n{table}\n")
+        table.add_row(vec![
+            Cell::new(&deploy.id).add_attribute(Attribute::Bold),
+            Cell::new(&deploy.latest_deployment_state)
+                // Unwrap is safe because Color::from_str returns the color white if str is not a Color.
+                .fg(Color::from_str(deploy.latest_deployment_state.get_color()).unwrap()),
+            Cell::new(deploy.updated_at.format("%Y-%m-%dT%H:%M:%SZ")),
+            Cell::new(truncated_commit_id),
+            Cell::new(truncated_commit_msg),
+            Cell::new(
+                deploy
+                    .git_branch
+                    .as_ref()
+                    .map_or(GIT_OPTION_NONE_TEXT, |val| val as &str),
+            ),
+            Cell::new(
+                deploy
+                    .git_dirty
+                    .map_or(String::from(GIT_OPTION_NONE_TEXT), |val| val.to_string()),
+            ),
+        ]);
     }
+
+    table.to_string()
 }
 
 pub fn get_deployments_table(

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -269,7 +269,7 @@ pub fn get_projects_table_beta(projects: &[ResponseBeta]) -> String {
             .map(|s| s.get_color())
             .unwrap_or_default();
         table.add_row(vec![
-            Cell::new(&project.id),
+            Cell::new(&project.id).add_attribute(Attribute::Bold),
             Cell::new(&project.name),
             Cell::new(state)
                 // Unwrap is safe because Color::from_str returns the color white if the argument is not a Color.

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS,
-    presets::{NOTHING, UTF8_FULL},
+    presets::{NOTHING, UTF8_BORDERS_ONLY, UTF8_FULL},
     Attribute, Cell, CellAlignment, Color, ContentArrangement, Table,
 };
 use crossterm::style::Stylize;
@@ -247,20 +247,14 @@ pub fn get_projects_table(projects: &[Response], raw: bool) -> String {
 }
 
 pub fn get_projects_table_beta(projects: &[ResponseBeta]) -> String {
-    if projects.is_empty() {
-        return "No projects are linked to this account"
-            .yellow()
-            .to_string();
-    }
-
     let mut table = Table::new();
     table
-        .load_preset(NOTHING)
+        .load_preset(UTF8_BORDERS_ONLY)
         .set_content_arrangement(ContentArrangement::Disabled)
         .set_header(vec![
-            Cell::new("Project Name").set_alignment(CellAlignment::Left),
-            Cell::new("Project Id").set_alignment(CellAlignment::Left),
-            Cell::new("Deployment Status").set_alignment(CellAlignment::Left),
+            Cell::new("Project Id"),
+            Cell::new("Project Name"),
+            Cell::new("Deployment Status"),
         ]);
 
     for project in projects {
@@ -269,16 +263,17 @@ pub fn get_projects_table_beta(projects: &[ResponseBeta]) -> String {
             .as_ref()
             .map(|s| s.to_string())
             .unwrap_or_default();
+        let color = project
+            .deployment_state
+            .as_ref()
+            .map(|s| s.get_color())
+            .unwrap_or_default();
         table.add_row(vec![
-            Cell::new(&project.name),
             Cell::new(&project.id),
+            Cell::new(&project.name),
             Cell::new(state)
                 // Unwrap is safe because Color::from_str returns the color white if the argument is not a Color.
-                .fg(Color::from_str(
-                    // TODO: Color for EcsState
-                    "",
-                )
-                .unwrap()),
+                .fg(Color::from_str(color).unwrap()),
         ]);
     }
 


### PR DESCRIPTION
Unifying the raw/fancy versions into one more compact version that does not wrap words in cells.
The raw flag can then be replaced with supporting JSON output.

![image](https://github.com/shuttle-hq/shuttle/assets/54029719/fa99191c-18ca-4771-b6bc-427c08b6f104)
![image](https://github.com/shuttle-hq/shuttle/assets/54029719/b25f37f8-8c7d-4df5-ac3b-d65b34c009a2)
