### PR TITLE
refactor: record the correct shuttle.user.id for the new platform

### DIFF
--- a/common/src/claims.rs
+++ b/common/src/claims.rs
@@ -347,6 +347,9 @@ impl<S> FromRequestParts<S> for Claim {
         // Record current account name for tracing purposes
         Span::current().record("account.user_id", &claim.sub);
 
+        // And for the new system
+        Span::current().record("shuttle.user.id", &claim.sub);
+
         trace!(?claim, "got user");
 
         Ok(claim.clone())


### PR DESCRIPTION
## Description of change
Small update to align with the recording of the user id on the new platform

## How has this been tested? (if applicable)
Na


