### PR TITLE
fix(gateway): use req.path in bouncer

### DIFF
--- a/gateway/src/proxy.rs
+++ b/gateway/src/proxy.rs
@@ -214,7 +214,7 @@ async fn bounce(State(state): State<Arc<Bouncer>>, req: Request<Body>) -> Result
     let hostname = host.hostname();
     let fqdn = fqdn!(hostname);
 
-    let path = req.uri();
+    let path = req.uri().path();
 
     if fqdn.is_subdomain_of(&state.public)
         || state


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

For HTTP clients that were sending the full URL as the request target, e.g. [rama](https://github.com/plabayo/rama), the location header had the full URL appended to the header, rather than just the path.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested with `curl --request-target <full url>`, rama and telnet on staging.
