### PR TITLE
feat: use 'shuttle' feature flag if it exists

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -26,8 +26,6 @@ args = [
     "--",
     "-D",
     "warnings",
-    "-A",
-    "clippy::assigning_clones",
 ]
 
 # Provide the name of the workspace member

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -24,8 +24,10 @@ args = [
     "--all-features",
     "--no-deps",
     "--",
-    "--D",
+    "-D",
     "warnings",
+    "-A",
+    "clippy::assigning_clones",
 ]
 
 # Provide the name of the workspace member

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1792,12 +1792,21 @@ impl Shuttle {
 
             let metadata = async_cargo_metadata(manifest_path.as_path()).await?;
             let packages = find_shuttle_packages(&metadata)?;
-            let package_name = packages
+            // TODO: support overriding this
+            let package = packages
                 .first()
-                .expect("at least one shuttle crate in the workspace")
-                .name
-                .to_owned();
+                .expect("at least one shuttle crate in the workspace");
+            let package_name = package.name.to_owned();
             deployment_req_beta.package_name = package_name;
+
+            // TODO: add these to the request and builder
+            let (_no_default_features, _features) = if package.features.contains_key("shuttle") {
+                (true, vec!["shuttle".to_owned()])
+            } else {
+                (false, vec![])
+            };
+            // TODO: determine which (one) binary to build
+            // TODO: have the above be configurable in CLI and Shuttle.toml
         }
 
         if let Ok(repo) = Repository::discover(working_directory) {

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -56,7 +56,7 @@ pub fn get_resource_tables(
             output.push(get_secrets_table(secrets, service_name, raw));
         };
 
-        if resource_groups.get("Persist").is_some() {
+        if resource_groups.contains_key("Persist") {
             output.push(format!("This persist instance is linked to {service_name}\nShuttle Persist: {service_name}\n"));
         };
 

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -223,10 +223,10 @@ async fn compile(
         cmd.arg("--jobs=4");
     }
 
-    // TODO: Compile only one package.
-    // (later: only one binary target)
-    // (both package/binary flag should be configurable in Shuttle.toml, but the default should be auto discovered)
-    // (These flags should also be determined at deploy time in CLI, since our new builder does not run any of this library's code)
+    // TODO later:
+    //   Compile only one binary target in the package.
+    //   (Both package/binary flag should be configurable in Shuttle.toml, but the default should be auto discovered)
+    //   (These flags should also be determined at deploy time in CLI, since our new builder does not run any of this library's code)
     for package in &packages {
         // Allows a custom feature set when compiling for Shuttle.
         // ```toml
@@ -236,7 +236,6 @@ async fn compile(
         // bar = []
         // shuttle = ["default", "bar"]
         // ```
-        // Check: Can shuttle->default->shuttle cause problem?
         if package.features.contains_key("shuttle") {
             cmd.arg("--no-default-features").arg("--features=shuttle");
         }

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -223,7 +223,23 @@ async fn compile(
         cmd.arg("--jobs=4");
     }
 
+    // TODO: Compile only one package.
+    // (later: only one binary target)
+    // (both package/binary flag should be configurable in Shuttle.toml, but the default should be auto discovered)
+    // (These flags should also be determined at deploy time in CLI, since our new builder does not run any of this library's code)
     for package in &packages {
+        // Allows a custom feature set when compiling for Shuttle.
+        // ```toml
+        // [features]
+        // default = ["foo"]
+        // foo = []
+        // bar = []
+        // shuttle = ["default", "bar"]
+        // ```
+        // Check: Can shuttle->default->shuttle cause problem?
+        if package.features.contains_key("shuttle") {
+            cmd.arg("--no-default-features").arg("--features=shuttle");
+        }
         cmd.arg("--package").arg(package.name.as_str());
     }
 

--- a/service/src/builder.rs
+++ b/service/src/builder.rs
@@ -223,19 +223,8 @@ async fn compile(
         cmd.arg("--jobs=4");
     }
 
-    // TODO later:
-    //   Compile only one binary target in the package.
-    //   (Both package/binary flag should be configurable in Shuttle.toml, but the default should be auto discovered)
-    //   (These flags should also be determined at deploy time in CLI, since our new builder does not run any of this library's code)
+    // TODO: Compile only one binary target in the package.
     for package in &packages {
-        // Allows a custom feature set when compiling for Shuttle.
-        // ```toml
-        // [features]
-        // default = ["foo"]
-        // foo = []
-        // bar = []
-        // shuttle = ["default", "bar"]
-        // ```
         if package.features.contains_key("shuttle") {
             cmd.arg("--no-default-features").arg("--features=shuttle");
         }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Allows setting a custom set of feature flags on Shuttle via the 'shuttle' feature flag.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

https://github.com/shuttle-hq/shuttle-examples/pull/171
