### PR TITLE
feat: Add `diesel-async` support for `shuttle-aws-rds`

### DIFF
--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["shuttle-service", "rds"]
 
 [dependencies]
 async-trait = "0.1.56"
+diesel-async = { version = "0.4.1", optional = true }
 paste = "1.0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -19,9 +20,14 @@ sqlx = { version = "0.7.1", optional = true }
 default = []
 
 # Database
-postgres = ["sqlx?/postgres"]
-mysql = ["sqlx?/mysql"]
+postgres = ["sqlx?/postgres", "diesel-async?/postgres"]
+mysql = ["sqlx?/mysql", "diesel-async?/mysql"]
 mariadb = ["sqlx?/mysql"]
+
+# Databases with diesel-async support
+diesel-async = ["dep:diesel-async"]
+diesel-async-bb8 = [ "diesel-async", "diesel-async/bb8" ]
+diesel-async-deadpool = [ "diesel-async", "diesel-async/deadpool" ]
 
 # Add an sqlx Pool as a resource output type
 sqlx = ["dep:sqlx", "sqlx/runtime-tokio", "sqlx/tls-rustls"]

--- a/resources/aws-rds/Cargo.toml
+++ b/resources/aws-rds/Cargo.toml
@@ -22,7 +22,7 @@ default = []
 # Database
 postgres = ["sqlx?/postgres", "diesel-async?/postgres"]
 mysql = ["sqlx?/mysql", "diesel-async?/mysql"]
-mariadb = ["sqlx?/mysql"]
+mariadb = ["sqlx?/mysql", "diesel-async?/mysql"]
 
 # Databases with diesel-async support
 diesel-async = ["dep:diesel-async"]

--- a/resources/aws-rds/src/lib.rs
+++ b/resources/aws-rds/src/lib.rs
@@ -108,7 +108,7 @@ mod _diesel_async {
         }
     }
 
-    #[cfg(feature = "mysql")]
+    #[cfg(any(feature = "mysql", feature = "mariadb"))]
     #[async_trait]
     impl IntoResource<diesel_async::AsyncMysqlConnection> for OutputWrapper {
         async fn into_resource(self) -> Result<diesel_async::AsyncMysqlConnection, Error> {
@@ -143,7 +143,7 @@ mod _diesel_async_bb8 {
         }
     }
 
-    #[cfg(feature = "mysql")]
+    #[cfg(any(feature = "mysql", feature = "mariadb"))]
     #[async_trait]
     impl IntoResource<diesel_bb8::Pool<diesel_async::AsyncMysqlConnection>> for OutputWrapper {
         async fn into_resource(
@@ -184,7 +184,7 @@ mod _diesel_async_deadpool {
         }
     }
 
-    #[cfg(feature = "mysql")]
+    #[cfg(any(feature = "mysql", feature = "mariadb"))]
     #[async_trait]
     impl IntoResource<diesel_deadpool::Pool<diesel_async::AsyncMysqlConnection>> for OutputWrapper {
         async fn into_resource(

--- a/resources/aws-rds/src/lib.rs
+++ b/resources/aws-rds/src/lib.rs
@@ -8,6 +8,15 @@ use shuttle_service::{
     DatabaseResource, DbInput, Error, IntoResource, ResourceFactory, ResourceInputBuilder,
 };
 
+#[cfg(any(feature = "diesel-async-bb8", feature = "diesel-async-deadpool"))]
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+
+#[cfg(feature = "diesel-async-bb8")]
+use diesel_async::pooled_connection::bb8 as diesel_bb8;
+
+#[cfg(feature = "diesel-async-deadpool")]
+use diesel_async::pooled_connection::deadpool as diesel_deadpool;
+
 macro_rules! aws_engine {
     ($feature:expr, $struct_ident:ident) => {
         paste::paste! {
@@ -76,6 +85,71 @@ impl IntoResource<String> for OutputWrapper {
 }
 
 // If these were done in the main macro above, this would produce two conflicting `impl IntoResource<sqlx::MySqlPool>`
+
+#[cfg(feature = "diesel_async")]
+mod _diesel_async {
+    use super::*;
+
+    #[cfg(feature = "postgres")]
+    #[async_trait]
+    impl IntoResource<diesel_async::AsyncPgConnection> for OutputWrapper {
+        async fn into_resource(self) -> Result<diesel_async::AsyncPgConnection, Error> {
+            use diesel_async::{AsyncConnection, AsyncPgConnection};
+
+            let connection_string: String = self.into_resource().await.unwrap();
+            Ok(AsyncPgConnection::establish(&connection_string)
+                .await
+                .map_err(shuttle_service::error::CustomError::new)?)
+        }
+    }
+}
+
+#[cfg(feature = "diesel-async-bb8")]
+mod _diesel_async_bb8 {
+    use super::*;
+
+    #[cfg(feature = "postgres")]
+    #[async_trait]
+    impl IntoResource<diesel_bb8::Pool<diesel_async::AsyncPgConnection>> for OutputWrapper {
+        async fn into_resource(
+            self,
+        ) -> Result<diesel_bb8::Pool<diesel_async::AsyncPgConnection>, Error> {
+            let connection_string: String = self.into_resource().await.unwrap();
+
+            Ok(diesel_bb8::Pool::builder()
+                .min_idle(Some(1))
+                .max_size(5)
+                .build(AsyncDieselConnectionManager::new(connection_string))
+                .await
+                .map_err(shuttle_service::error::CustomError::new)?)
+        }
+    }
+}
+
+#[cfg(feature = "diesel-async-deadpool")]
+mod _diesel_async_deadpool {
+    use super::*;
+
+    #[cfg(feature = "postgres")]
+    #[async_trait]
+    impl IntoResource<diesel_deadpool::Pool<diesel_async::AsyncPgConnection>> for OutputWrapper {
+        async fn into_resource(
+            self,
+        ) -> Result<diesel_deadpool::Pool<diesel_async::AsyncPgConnection>, Error> {
+            let connection_string: String = self.into_resource().await.unwrap();
+
+            Ok(
+                diesel_deadpool::Pool::builder(AsyncDieselConnectionManager::new(
+                    connection_string,
+                ))
+                .max_size(5 as usize)
+                .build()
+                .map_err(shuttle_service::error::CustomError::new)?,
+            )
+        }
+    }
+}
+
 #[cfg(feature = "sqlx")]
 mod _sqlx {
     use super::*;


### PR DESCRIPTION
## Description of change
The following commits bring support to output `diesel-async` resources from all of the following databases:
- `#[shuttle_aws_rds::Postgres]`
- `#[shuttle_aws_rds::MariaDB]` 
- `#[shuttle_aws_rds::MySql]`

closely following the changes made in https://github.com/shuttle-hq/shuttle/pull/1664

It closes: https://github.com/shuttle-hq/shuttle/issues/1692



## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->
I have a local project for PoC which I can upload to github if needed. 


