### PR TITLE
feat(cargo-shuttle): beta account command, cleanup

### DIFF
--- a/api-client/src/lib.rs
+++ b/api-client/src/lib.rs
@@ -103,7 +103,7 @@ impl ShuttleApiClient {
             .context("parsing name check response")
     }
 
-    pub async fn get_current_user(&self) -> Result<user::Response> {
+    pub async fn get_current_user_beta(&self) -> Result<user::Response> {
         self.get_json("/users/me".to_owned()).await
     }
 

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -122,6 +122,8 @@ pub enum Command {
     Resource(ResourceCommand),
     /// Remove cargo build artifacts in the Shuttle environment
     Clean,
+    /// BETA: Show info about your Shuttle account
+    Account,
     /// Login to the Shuttle platform
     Login(LoginArgs),
     /// Log out of the Shuttle platform

--- a/scripts/local-admin.sh
+++ b/scripts/local-admin.sh
@@ -7,6 +7,7 @@
 key="dh9z58jttoes3qvt" # arbitrary test key
 export SHUTTLE_API_KEY=$key
 export SHUTTLE_API="http://localhost:8001"
+unset SHUTTLE_BETA
 export PS1="(shuttle: local admin key) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"
 
 docker compose --file docker-compose.rendered.yml --project-name shuttle-dev exec auth /usr/local/bin/shuttle-auth --db-connection-uri=postgres://postgres:postgres@control-db init-admin --user-id admin --key $key

--- a/scripts/production.sh
+++ b/scripts/production.sh
@@ -6,4 +6,5 @@
 
 export SHUTTLE_API="https://api.shuttle.rs"
 unset SHUTTLE_API_KEY
+unset SHUTTLE_BETA
 export PS1="(shuttle: production) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"

--- a/scripts/unstable.sh
+++ b/scripts/unstable.sh
@@ -5,4 +5,5 @@
 
 export SHUTTLE_API="https://api.unstable.shuttle.rs"
 unset SHUTTLE_API_KEY
+unset SHUTTLE_BETA
 export PS1="(shuttle: unstable) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"


### PR DESCRIPTION
- account command, useful for checking your user id, name, tier, subscriptions
- if the json/error parser does not parse the response body, print it. (for examples when a 502 HTML response is given)