### PR TITLE
fix: failing install on Arch Linux (#1810)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ _install_arch_linux() {
       _install_unsupported
     else
       echo "Installing with pacman"
-      sudo pacman -S cargo-shuttle
+      sudo pacman -S --noconfirm cargo-shuttle
     fi
   else
     echo "Pacman not found"


### PR DESCRIPTION
## Description of change
Added flag for install.sh, such that for Arch Linux, it does not try to ask for confirmation.


## How has this been tested? (if applicable)
I modified the Dockerfile I used for replicating the bug, such that it runs install.sh instead of downloading the script from the Shuttle website. It seems to work fine


