### PR TITLE
fix: remove teams call for beta project list

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -2703,19 +2703,22 @@ impl Shuttle {
         println!("{}", "Personal Projects".bold());
         println!("{projects_table}\n");
 
-        let teams = client.get_teams_list().await?;
+        if !self.beta {
+            let teams = client.get_teams_list().await?;
 
-        for team in teams {
-            let team_projects_table = if self.beta {
-                let team_projects = client.get_team_projects_list_beta(&team.id).await?.projects;
-                project::get_projects_table_beta(&team_projects, table_args.raw)
-            } else {
-                let team_projects = client.get_team_projects_list(&team.id).await?;
-                project::get_projects_table(&team_projects, table_args.raw)
-            };
+            for team in teams {
+                let team_projects_table = if self.beta {
+                    let team_projects =
+                        client.get_team_projects_list_beta(&team.id).await?.projects;
+                    project::get_projects_table_beta(&team_projects, table_args.raw)
+                } else {
+                    let team_projects = client.get_team_projects_list(&team.id).await?;
+                    project::get_projects_table(&team_projects, table_args.raw)
+                };
 
-            println!("{}", format!("{}'s Projects", team.display_name).bold());
-            println!("{team_projects_table}\n");
+                println!("{}", format!("{}'s Projects", team.display_name).bold());
+                println!("{team_projects_table}\n");
+            }
         }
 
         Ok(CommandOutcome::Ok)

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -2707,14 +2707,9 @@ impl Shuttle {
             let teams = client.get_teams_list().await?;
 
             for team in teams {
-                let team_projects_table = if self.beta {
-                    let team_projects =
-                        client.get_team_projects_list_beta(&team.id).await?.projects;
-                    project::get_projects_table_beta(&team_projects, table_args.raw)
-                } else {
-                    let team_projects = client.get_team_projects_list(&team.id).await?;
-                    project::get_projects_table(&team_projects, table_args.raw)
-                };
+                let team_projects = client.get_team_projects_list(&team.id).await?;
+                let team_projects_table =
+                    project::get_projects_table(&team_projects, table_args.raw);
 
                 println!("{}", format!("{}'s Projects", team.display_name).bold());
                 println!("{team_projects_table}\n");


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

The teams feature is disabled on the beta platform, so we get a 404 if we try to call that endpoint.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested in beta dev environment.
