### PR TITLE
fix(cargo-shuttle): beta: create missing project on deploy, fix local run, better project link dialogue

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -248,7 +248,8 @@ pub enum ProjectCommand {
     /// Check the status of this project's environment on Shuttle
     Status {
         #[arg(short, long)]
-        /// Follow status of project command
+        /// Follow status of project
+        // unused in beta (project has no state to follow)
         follow: bool,
     },
     /// Destroy this project's environment (container) on Shuttle

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -264,14 +264,16 @@ fn get_secrets_table_beta(
     let Some(secrets) = secrets.first() else {
         return String::new();
     };
+    let secrets = serde_json::from_value::<SecretStore>(secrets.output.clone()).unwrap();
+    if secrets.secrets.is_empty() {
+        return String::new();
+    }
 
     let mut table = Table::new();
     table
         .load_preset(if raw { NOTHING } else { UTF8_BORDERS_ONLY })
         .set_content_arrangement(ContentArrangement::Disabled)
         .set_header(vec!["Key"]);
-
-    let secrets = serde_json::from_value::<SecretStore>(secrets.output.clone()).unwrap();
 
     for key in secrets.secrets.keys() {
         table.add_row(vec![key]);


### PR DESCRIPTION
- deploying to non-existent project name creates it
- local run requires `--name` or to link a project
- don't ask to select `[CREATE NEW]` if user has no projects
- minor refactors
-
