### PR TITLE
feat(cargo-shuttle): Shuttle.toml new key names

### DIFF
--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -501,7 +501,7 @@ impl RequestContext {
             .unwrap()
             .deploy
             .as_ref()
-            .and_then(|d| d.include.as_ref().clone())
+            .and_then(|d| d.include.as_ref())
             .or(self
                 .project
                 .as_ref()

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -3049,7 +3049,7 @@ impl Shuttle {
     }
 
     fn make_archive(&self, secrets_file: Option<PathBuf>, zip: bool) -> Result<Vec<u8>> {
-        let include_patterns = self.ctx.assets();
+        let include_patterns = self.ctx.include();
 
         let working_directory = self.ctx.working_directory();
 


### PR DESCRIPTION
Renames...
- assets -> deploy.include
- build_assets -> build.assets

...with fallback to previous names. (no breaking change)

A fully utilized Shuttle.toml for beta would be

```toml
[deploy]
include = ["assets/*"]
deny_dirty = true

[build]
assets = ["assets/*"]
```