### PR TITLE
fix: don't attempt project linking on local run, create project and link on beta init

### DIFF
--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -148,9 +148,9 @@ impl GlobalConfig {
 /// Shuttle.toml schema (User-facing project-local config)
 #[derive(Deserialize, Serialize, Default)]
 pub struct ProjectConfig {
-    // unused on new platform
+    // unused on new platform, but still used for project names in local runs
     pub name: Option<String>,
-    // deprecated name
+    /// Deprecated, now [`ProjectDeployConfig::include`]
     pub assets: Option<Vec<String>>,
     pub deploy: Option<ProjectDeployConfig>,
     pub build: Option<ProjectBuildConfig>,
@@ -161,7 +161,7 @@ pub struct ProjectDeployConfig {
     /// Successor to `assets`.
     /// Patterns of ignored files that should be included in deployments.
     pub include: Option<Vec<String>>,
-    /// set to true to deny deployments with uncommited changes. (can use `--allow-dirty`)
+    /// Set to true to deny deployments with uncommited changes. (use `--allow-dirty` to override)
     pub deny_dirty: Option<bool>,
 }
 /// Builder config

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -266,6 +266,7 @@ impl Shuttle {
                 | Command::Status
                 | Command::Logs { .. }
         ) {
+            // Command::Run only uses load_local (below) instead of load_project since it does not target a project in the API
             self.load_project(
                 &args.project_args,
                 matches!(args.cmd, Command::Project(ProjectCommand::Link)),
@@ -703,20 +704,14 @@ impl Shuttle {
                 .as_ref()
                 .expect("to have a project name provided");
 
-            let prompt = if self.beta {
-                format!(
-                    r#"Create an environment for the "{}" project on Shuttle?"#,
-                    name
-                )
-            } else {
-                format!(
-                    r#"Claim the project name "{}" by starting a project container on Shuttle?"#,
-                    name
-                )
-            };
-
             let should_create = Confirm::with_theme(&theme)
-                .with_prompt(prompt)
+                .with_prompt(if self.beta {
+                    format!(r#"Create a project on Shuttle with the name "{name}"?"#)
+                } else {
+                    format!(
+                        r#"Claim the project name "{name}" by starting a project container on Shuttle?"#
+                    )
+                })
                 .default(true)
                 .interact()?;
             if !should_create && !self.beta {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -295,8 +295,8 @@ impl Shuttle {
             Command::Logout(logout_args) => self.logout(logout_args).await,
             Command::Feedback => feedback(),
             Command::Run(run_args) => {
+                self.ctx.load_local(&args.project_args)?;
                 if self.beta {
-                    self.ctx.load_local(&args.project_args)?;
                     self.local_run_beta(run_args, args.debug).await
                 } else {
                     self.local_run(run_args).await


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

- Don't prompt for project linking on local run. 
- Refactor init to prompt the .dev client user if they want to create the project

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested locally and against the .dev api.
