### PR TITLE
Introducing Shuttle Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
   <a href="https://circleci.com/gh/shuttle-hq/shuttle/">
     <img alt="build status" src="https://circleci.com/gh/shuttle-hq/shuttle.svg?style=shield"/>
   </a>
+  <a href="https://gurubase.io/g/shuttle">
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Shuttle%20Guru-006BFF"/>
+  </a>
 </p>
 <p align="center">
   <a href="https://crates.io/crates/cargo-shuttle">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Shuttle Guru](https://gurubase.io/g/shuttle) to Gurubase. Shuttle Guru uses the data from this repo and data from the [docs](https://docs.shuttle.rs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Shuttle Guru", which highlights that Shuttle now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Shuttle Guru in Gurubase, just let me know that's totally fine.
