### PR TITLE
chore: move ApiKey type to backends, remove AccountTier sqlx::Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,6 +5675,8 @@ dependencies = [
  "permit-pdp-client-rs",
  "pin-project",
  "portpicker",
+ "proptest",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "ring 0.17.8",
  "rustrict",
@@ -5699,6 +5701,7 @@ dependencies = [
  "ttl_cache",
  "uuid",
  "wiremock",
+ "zeroize",
 ]
 
 [[package]]
@@ -5737,7 +5740,6 @@ dependencies = [
  "opentelemetry-http 0.10.0",
  "pin-project",
  "proptest",
- "rand 0.8.5",
  "reqwest 0.11.27",
  "semver 1.0.23",
  "serde",

--- a/auth/Cargo.toml
+++ b/auth/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 shuttle-backends = { workspace = true }
-shuttle-common = { workspace = true, features = ["models", "persist"] }
+shuttle-common = { workspace = true, features = ["models"] }
 
 anyhow = { workspace = true }
 async-stripe = { version = "0.25.1", default-features = false, features = ["checkout", "runtime-tokio-hyper-rustls"] }

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -7,11 +7,14 @@ mod user;
 use anyhow::Result;
 use args::{CopyPermitEnvArgs, StartArgs, SyncArgs};
 use http::StatusCode;
-use shuttle_backends::client::{
-    permit::{self, Error, ResponseContent},
-    PermissionsDal,
+use shuttle_backends::{
+    client::{
+        permit::{self, Error, ResponseContent},
+        PermissionsDal,
+    },
+    key::ApiKey,
 };
-use shuttle_common::{models::user::AccountTier, ApiKey};
+use shuttle_common::models::user::AccountTier;
 use sqlx::{query, PgPool};
 use tracing::info;
 pub use user::User;

--- a/auth/src/lib.rs
+++ b/auth/src/lib.rs
@@ -117,7 +117,7 @@ pub async fn init(pool: PgPool, args: InitArgs, tier: AccountTier) -> Result<()>
 
     query("INSERT INTO users (account_name, key, account_tier, user_id) VALUES ($1, $2, $3, $4)")
         .bind("")
-        .bind(&key)
+        .bind(key.as_ref())
         .bind(tier.to_string())
         .bind(&args.user_id)
         .execute(&pool)

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -8,14 +8,14 @@ use axum::{
     TypedHeader,
 };
 use chrono::{DateTime, Utc};
-use shuttle_backends::{client::PermissionsDal, headers::XShuttleAdminSecret};
+use shuttle_backends::{client::PermissionsDal, headers::XShuttleAdminSecret, key::ApiKey};
 use shuttle_common::{
     limits::Limits,
     models::{
         self,
         user::{AccountTier, UserId},
     },
-    ApiKey, Secret,
+    Secret,
 };
 use sqlx::{postgres::PgRow, query, FromRow, PgPool, Row};
 use stripe::{SubscriptionId, SubscriptionStatus};

--- a/auth/src/user.rs
+++ b/auth/src/user.rs
@@ -97,7 +97,7 @@ where
             "INSERT INTO users (account_name, key, account_tier, user_id, has_access_to_beta) VALUES ($1, $2, $3, $4, $5)",
         )
         .bind(&user.name)
-        .bind(user.key.expose())
+        .bind(user.key.expose().as_ref())
         .bind(user.account_tier.to_string())
         .bind(&user.id)
         .bind(false)
@@ -157,7 +157,7 @@ where
 
     async fn get_user_by_key(&self, key: ApiKey) -> Result<User, Error> {
         let mut user: User = sqlx::query_as("SELECT * FROM users WHERE key = $1")
-            .bind(&key)
+            .bind(key.as_ref())
             .fetch_optional(&self.pool)
             .await?
             .ok_or(Error::UserNotFound)?;
@@ -185,7 +185,7 @@ where
         let key = ApiKey::generate();
 
         let rows_affected = query("UPDATE users SET key = $1 WHERE user_id = $2")
-            .bind(&key)
+            .bind(key.as_ref())
             .bind(&user_id)
             .execute(&self.pool)
             .await?
@@ -391,7 +391,7 @@ impl FromRow<'_, PgRow> for User {
         Ok(User {
             name: row.try_get("account_name").unwrap(),
             id: row.try_get("user_id").unwrap(),
-            key: Secret::new(row.try_get("key").unwrap()),
+            key: Secret::new(ApiKey::parse(row.try_get("key").unwrap()).unwrap()),
             account_tier: AccountTier::from_str(row.try_get("account_tier").unwrap()).map_err(
                 |err| sqlx::Error::ColumnDecode {
                     index: "account_tier".to_string(),

--- a/backends/Cargo.toml
+++ b/backends/Cargo.toml
@@ -27,6 +27,7 @@ pin-project = { workspace = true }
 permit-client-rs = { git = "https://github.com/shuttle-hq/permit-client-rs", rev = "19085ba" }
 permit-pdp-client-rs = { git = "https://github.com/shuttle-hq/permit-pdp-client-rs", rev = "37c7296" }
 portpicker = { workspace = true, optional = true }
+rand = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 # keep locked to not accidentally invalidate someone's project name
 # higher versions have a lot more false positives
@@ -44,6 +45,7 @@ tracing = { workspace = true, features = ["std"] }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"]}
 ttl_cache = { workspace = true }
+zeroize = { workspace = true }
 wiremock = { workspace = true, optional = true }
 
 [features]
@@ -54,6 +56,7 @@ test-utils = ["portpicker", "wiremock"]
 base64 = { workspace = true }
 ctor = { workspace = true }
 jsonwebtoken = { workspace = true }
+proptest = "1.1.0"
 ring = { workspace = true }
 serial_test = "3.0.0"
 shuttle-common-tests = { workspace = true }

--- a/backends/src/key.rs
+++ b/backends/src/key.rs
@@ -1,0 +1,81 @@
+use anyhow::bail;
+use rand::distributions::{Alphanumeric, DistString};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+#[cfg_attr(feature = "sqlx", derive(PartialEq, Eq, Hash, sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(transparent))]
+pub struct ApiKey(String);
+
+impl Zeroize for ApiKey {
+    fn zeroize(&mut self) {
+        self.0.zeroize()
+    }
+}
+
+impl ApiKey {
+    pub fn parse(key: &str) -> anyhow::Result<Self> {
+        let key = key.trim();
+
+        let mut errors = vec![];
+        if !key.chars().all(char::is_alphanumeric) {
+            errors.push("The API key should consist of only alphanumeric characters.");
+        };
+
+        if key.len() != 16 {
+            errors.push("The API key should be exactly 16 characters in length.");
+        };
+
+        if !errors.is_empty() {
+            let message = errors.join("\n");
+            bail!("Invalid API key:\n{message}")
+        }
+
+        Ok(Self(key.to_string()))
+    }
+
+    pub fn generate() -> Self {
+        Self(Alphanumeric.sample_string(&mut rand::thread_rng(), 16))
+    }
+}
+
+impl AsRef<str> for ApiKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        // The API key should be a 16 character alphanumeric string.
+        fn parses_valid_api_keys(s in "[a-zA-Z0-9]{16}") {
+            ApiKey::parse(&s).unwrap();
+        }
+    }
+
+    #[test]
+    fn generated_api_key_is_valid() {
+        let key = ApiKey::generate();
+
+        assert!(ApiKey::parse(key.as_ref()).is_ok());
+    }
+
+    #[test]
+    #[should_panic(expected = "The API key should be exactly 16 characters in length.")]
+    fn invalid_api_key_length() {
+        ApiKey::parse("tooshort").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "The API key should consist of only alphanumeric characters.")]
+    fn non_alphanumeric_api_key() {
+        ApiKey::parse("dh9z58jttoes3qv@").unwrap();
+    }
+}

--- a/backends/src/key.rs
+++ b/backends/src/key.rs
@@ -22,11 +22,11 @@ impl ApiKey {
         let mut errors = vec![];
         if !key.chars().all(char::is_alphanumeric) {
             errors.push("The API key should consist of only alphanumeric characters.");
-        };
+        }
 
         if key.len() != 16 {
             errors.push("The API key should be exactly 16 characters in length.");
-        };
+        }
 
         if !errors.is_empty() {
             let message = errors.join("\n");

--- a/backends/src/lib.rs
+++ b/backends/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cache;
 pub mod client;
 mod future;
 pub mod headers;
+pub mod key;
 pub mod metrics;
 mod otlp_tracing_bridge;
 pub mod project_name;

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,7 +23,6 @@ jsonwebtoken = { workspace = true, optional = true }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
@@ -41,6 +40,9 @@ url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 zeroize = { workspace = true }
 wiremock = { workspace = true, optional = true }
+
+[dev-dependencies]
+proptest = "1.1.0"
 
 [features]
 axum = ["dep:axum"]
@@ -68,15 +70,11 @@ extract_propagation = [
     "tracing-opentelemetry",
 ]
 models = ["async-trait", "reqwest", "service"]
-persist = ["sqlx", "rand"]
 sqlx = ["dep:sqlx", "sqlx/sqlite", "sqlx/postgres"]
 service = ["chrono/serde", "display", "tracing", "tracing-subscriber", "uuid"]
 test-utils = ["wiremock"]
 tonic = ["dep:tonic"]
 tracing = ["dep:tracing"]
-
-[dev-dependencies]
-proptest = "1.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -29,56 +29,7 @@ pub mod tracing;
 
 use std::fmt::Debug;
 
-use anyhow::bail;
 use serde::{Deserialize, Serialize};
-use zeroize::Zeroize;
-
-#[derive(Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "persist", derive(PartialEq, Eq, Hash, sqlx::Type))]
-#[cfg_attr(feature = "persist", serde(transparent))]
-#[cfg_attr(feature = "persist", sqlx(transparent))]
-pub struct ApiKey(String);
-
-impl Zeroize for ApiKey {
-    fn zeroize(&mut self) {
-        self.0.zeroize()
-    }
-}
-
-impl ApiKey {
-    pub fn parse(key: &str) -> anyhow::Result<Self> {
-        let key = key.trim();
-
-        let mut errors = vec![];
-        if !key.chars().all(char::is_alphanumeric) {
-            errors.push("The API key should consist of only alphanumeric characters.");
-        };
-
-        if key.len() != 16 {
-            errors.push("The API key should be exactly 16 characters in length.");
-        };
-
-        if !errors.is_empty() {
-            let message = errors.join("\n");
-            bail!("Invalid API key:\n{message}")
-        }
-
-        Ok(Self(key.to_string()))
-    }
-
-    #[cfg(feature = "persist")]
-    pub fn generate() -> Self {
-        use rand::distributions::{Alphanumeric, DistString};
-
-        Self(Alphanumeric.sample_string(&mut rand::thread_rng(), 16))
-    }
-}
-
-impl AsRef<str> for ApiKey {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
 
 ////// Resource Input/Output types
 
@@ -296,37 +247,7 @@ pub fn semvers_are_compatible(a: &semver::Version, b: &semver::Version) -> bool 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use proptest::prelude::*;
     use std::str::FromStr;
-
-    proptest! {
-        #[test]
-        // The API key should be a 16 character alphanumeric string.
-        fn parses_valid_api_keys(s in "[a-zA-Z0-9]{16}") {
-            ApiKey::parse(&s).unwrap();
-        }
-    }
-
-    #[cfg(feature = "persist")]
-    #[test]
-    fn generated_api_key_is_valid() {
-        let key = ApiKey::generate();
-
-        assert!(ApiKey::parse(key.as_ref()).is_ok());
-    }
-
-    #[test]
-    #[should_panic(expected = "The API key should be exactly 16 characters in length.")]
-    fn invalid_api_key_length() {
-        ApiKey::parse("tooshort").unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "The API key should consist of only alphanumeric characters.")]
-    fn non_alphanumeric_api_key() {
-        ApiKey::parse("dh9z58jttoes3qv@").unwrap();
-    }
 
     #[test]
     fn semver_compatibility_check_works() {

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -47,8 +47,6 @@ impl UserResponse {
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "display", derive(strum::Display))]
 #[cfg_attr(feature = "display", strum(serialize_all = "lowercase"))]
-#[cfg_attr(feature = "persist", derive(sqlx::Type))]
-#[cfg_attr(feature = "persist", sqlx(rename_all = "lowercase"))]
 #[typeshare::typeshare]
 pub enum AccountTier {
     #[default]

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 shuttle-backends = { workspace = true, features = ["sqlx"] }
-shuttle-common = { workspace = true, features = ["models", "persist"] }
+shuttle-common = { workspace = true, features = ["models"] }
 shuttle-proto = { workspace = true, features = ["provisioner-client"] }
 
 async-trait = { workspace = true }

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -16,9 +16,8 @@ use once_cell::sync::Lazy;
 use opentelemetry::global;
 use opentelemetry_http::HeaderInjector;
 use shuttle_backends::{
-    auth::ConvertResponse, cache::CacheManagement, headers::XShuttleAdminSecret,
+    auth::ConvertResponse, cache::CacheManagement, headers::XShuttleAdminSecret, key::ApiKey,
 };
-use shuttle_common::ApiKey;
 use tower::{Layer, Service};
 use tracing::{error, trace, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;


### PR DESCRIPTION
- debloats common
- prevents mistake of binding an AccountTier and db not finding the type