### PR TITLE
fix(cargo-shuttle): don't override user provided RUST_LOG on local run

### DIFF
--- a/runtime/src/start.rs
+++ b/runtime/src/start.rs
@@ -79,7 +79,13 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
                 // let user override RUST_LOG in local run if they want to
                 EnvFilter::try_from_default_env()
                     // otherwise use our default
-                    .or_else(|_| EnvFilter::try_new("info,shuttle=trace"))
+                    .or_else(|_| {
+                        EnvFilter::try_new(if args.beta {
+                            "info"
+                        } else {
+                            "info,shuttle=trace"
+                        })
+                    })
                     .unwrap(),
             )
             .init();


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Fixes RUST_LOG override in `shuttle run` reported in https://discord.com/channels/803236282088161321/1318703796007735306

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Local run with `RUST_LOG=trace` now shows `trace!()` logs from the user code.
