### PR TITLE
feat: deprecate new deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,19 +224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-posthog"
-version = "0.2.3"
-source = "git+https://github.com/shuttle-hq/posthog-rs?branch=main#f20f60de7eb786ea80d7a276073fecdfc697bc61"
-dependencies = [
- "posthog-core",
- "reqwest 0.12.9",
- "serde",
- "serde_json",
- "thiserror 1.0.67",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,17 +4294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "posthog-core"
-version = "0.1.0"
-source = "git+https://github.com/shuttle-hq/posthog-rs?branch=main#f20f60de7eb786ea80d7a276073fecdfc697bc61"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
- "thiserror 1.0.67",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5715,7 +5691,6 @@ name = "shuttle-gateway"
 version = "0.49.0"
 dependencies = [
  "anyhow",
- "async-posthog",
  "async-trait",
  "axum",
  "axum-server",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -10,7 +10,6 @@ shuttle-backends = { workspace = true, features = ["sqlx"] }
 shuttle-common = { workspace = true, features = ["models", "persist"] }
 shuttle-proto = { workspace = true, features = ["provisioner-client"] }
 
-async-posthog = { git = "https://github.com/shuttle-hq/posthog-rs", branch = "main" }
 async-trait = { workspace = true }
 axum = { workspace = true, features = ["default", "headers"] }
 axum-server = { version = "0.5.1", features = ["tls-rustls"] }

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -420,7 +420,7 @@ async fn delete_project(
 #[instrument(skip_all, fields(shuttle.project.name = %scoped_user.scope))]
 async fn override_create_service(scoped_user: ScopedUser) -> Result<Response<Body>, ApiError> {
     // Creating new deployments on the shuttle.rs platform is deprecated as of the first of January
-    // 2024.
+    // 2025.
     return Err(Deprecated(
         "Creating new deployments on the shuttle.rs platform has been deprecated.".to_string(),
     )

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -1001,7 +1001,6 @@ pub(crate) struct RouterState {
     pub service: Arc<GatewayService>,
     pub sender: Sender<BoxedTask>,
     pub running_builds: Arc<Mutex<TtlCache<Uuid, ()>>>,
-    pub posthog_client: async_posthog::Client,
 }
 
 #[derive(Default)]
@@ -1009,7 +1008,6 @@ pub struct ApiBuilder {
     router: Router<RouterState>,
     service: Option<Arc<GatewayService>>,
     sender: Option<Sender<BoxedTask>>,
-    posthog_client: Option<async_posthog::Client>,
     bind: Option<SocketAddr>,
 }
 
@@ -1058,11 +1056,6 @@ impl ApiBuilder {
 
     pub fn with_sender(mut self, sender: Sender<BoxedTask>) -> Self {
         self.sender = Some(sender);
-        self
-    }
-
-    pub fn with_posthog_client(mut self, posthog_client: async_posthog::Client) -> Self {
-        self.posthog_client = Some(posthog_client);
         self
     }
 
@@ -1209,7 +1202,6 @@ impl ApiBuilder {
     pub fn into_router(self) -> Router {
         let service = self.service.expect("a GatewayService is required");
         let sender = self.sender.expect("a task Sender is required");
-        let posthog_client = self.posthog_client.expect("a task Sender is required");
 
         // Allow about 4 cores per build, but use at most 75% (* 3 / 4) of all cores and at least 1 core
         // Assumes each builder (deployer) is assigned 4 cores
@@ -1220,7 +1212,6 @@ impl ApiBuilder {
         self.router.with_state(RouterState {
             service,
             sender,
-            posthog_client,
             running_builds,
         })
     }

--- a/gateway/src/api/latest.rs
+++ b/gateway/src/api/latest.rs
@@ -418,11 +418,7 @@ async fn delete_project(
 }
 
 #[instrument(skip_all, fields(shuttle.project.name = %scoped_user.scope))]
-async fn override_create_service(
-    _state: State<RouterState>,
-    scoped_user: ScopedUser,
-    _req: Request<Body>,
-) -> Result<Response<Body>, ApiError> {
+async fn override_create_service(scoped_user: ScopedUser) -> Result<Response<Body>, ApiError> {
     // Creating new deployments on the shuttle.rs platform is deprecated as of the first of January
     // 2024.
     return Err(Deprecated(

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -725,7 +725,7 @@ impl GatewayService {
             // Project creation is deprecated on the legacy platform as of the 19th of December
             // 2024.
             Err(Deprecated(
-                "New project creation on the shuttle.rs platform is deprecated.".to_string(),
+                "New project creation on the shuttle.rs platform has been deprecated.".to_string(),
             )
             .into())
         } else {


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

As of the 1st of January 2025, making new deployments on the shuttle.rs platform has been deprecated, and users will be directed to upgrade to the shuttle.dev platform.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Will test in staging.
