### PR TITLE
Prepare for Hyper 1.0.0 Upgrade: Enable Deprecated Features and Resolve Deprecations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,28 +1,24 @@
 [workspace]
 resolver = "2"
 members = [
-  "admin",
-  "api-client",
-  "auth",
-  "backends",
-  "cargo-shuttle",
-  "codegen",
-  "common",
-  "common-tests",
-  "deployer",
-  "gateway",
-  "logger",
-  "proto",
-  "provisioner",
-  "resource-recorder",
-  "runtime",
-  "service",
+    "admin",
+    "api-client",
+    "auth",
+    "backends",
+    "cargo-shuttle",
+    "codegen",
+    "common",
+    "common-tests",
+    "deployer",
+    "gateway",
+    "logger",
+    "proto",
+    "provisioner",
+    "resource-recorder",
+    "runtime",
+    "service",
 ]
-exclude = [
-  "examples",
-  "resources",
-  "services",
-]
+exclude = ["examples", "resources", "services"]
 
 [workspace.package]
 version = "0.49.0"
@@ -62,7 +58,7 @@ headers = "0.3.8"
 home = "0.5.4"
 http = "0.2.8"
 http-body = "0.4.5"
-hyper = "0.14.23"
+hyper = { version = "0.14.23", features = ["backports", "deprecated"] }
 # not great, but waiting for WebSocket changes to be merged
 hyper-reverse-proxy = { git = "https://github.com/chesedo/hyper-reverse-proxy", branch = "bug/host_header" }
 jsonwebtoken = "9.0.0"
@@ -70,7 +66,12 @@ once_cell = "1.16.0"
 opentelemetry = "0.21.0"
 opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio", "logs"] }
 opentelemetry-http = "0.10.0"
-opentelemetry-otlp = { version = "0.14.0", features = ["logs", "http-proto", "reqwest-client", "reqwest-rustls"] }
+opentelemetry-otlp = { version = "0.14.0", features = [
+    "logs",
+    "http-proto",
+    "reqwest-client",
+    "reqwest-rustls",
+] }
 opentelemetry-proto = "0.4.0"
 opentelemetry-contrib = { version = "0.4.0", features = ["datadog"] }
 opentelemetry-appender-tracing = "0.2.0"
@@ -81,7 +82,9 @@ pretty_assertions = "1.3.0"
 prost = "0.12.1"
 prost-types = "0.12.1"
 rand = "0.8.5"
-reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.13", default-features = false, features = [
+    "rustls-tls",
+] }
 ring = "0.17.4"
 rmp-serde = "1.1.1"
 semver = { version = "1.0.17", features = ["serde"] }
@@ -97,7 +100,7 @@ thiserror = "2"
 tokio = "1.22.0"
 tokio-stream = "0.1.11"
 tokio-tungstenite = { version = "0.20.1", features = [
-  "rustls-tls-webpki-roots",
+    "rustls-tls-webpki-roots",
 ] }
 tokio-util = "0.7.10"
 toml = "0.8.2"
@@ -108,8 +111,8 @@ tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = { version = "0.1.37", default-features = false }
 tracing-opentelemetry = "0.22.0"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
-  "registry",
-  "json",
+    "registry",
+    "json",
 ] }
 typeshare = "1.0.3"
 ttl_cache = "0.5.1"

--- a/auth/tests/api/auth.rs
+++ b/auth/tests/api/auth.rs
@@ -15,7 +15,11 @@ mod needs_docker {
         let response = app.post_user("test-user-basic", "basic").await;
         assert_eq!(response.status(), StatusCode::OK);
         // Extract the API key from the response so we can use it in a future request.
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+
         let user: Value = serde_json::from_slice(&body).unwrap();
         let basic_user_key = user["key"].as_str().unwrap();
 

--- a/auth/tests/api/helpers.rs
+++ b/auth/tests/api/helpers.rs
@@ -103,7 +103,10 @@ impl TestApp {
 
     pub async fn get_user_typed(&self, user_id: &str) -> user::UserResponse {
         let response = self.get_user(user_id).await;
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
 
         serde_json::from_slice(&body).unwrap()
     }
@@ -174,7 +177,10 @@ impl TestApp {
     }
 
     pub async fn claim_from_response(&self, res: Response) -> Claim {
-        let body = hyper::body::to_bytes(res.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(res.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let convert: Value = serde_json::from_slice(&body).unwrap();
         let token = convert["token"].as_str().unwrap();
 
@@ -188,7 +194,10 @@ impl TestApp {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let public_key = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let public_key = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
 
         Claim::from_token(token, &public_key).unwrap()
     }

--- a/auth/tests/api/users.rs
+++ b/auth/tests/api/users.rs
@@ -46,7 +46,10 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         let user_id1 = user.id.clone();
 
@@ -60,7 +63,10 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         let user_id2 = user.id.clone();
 
@@ -88,7 +94,11 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let post_body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let post_body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+
         let user: user::UserResponse = serde_json::from_slice(&post_body).unwrap();
         let user_id = user.id;
 
@@ -123,7 +133,10 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let get_body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let get_body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
 
         assert_eq!(post_body, get_body);
     }
@@ -137,7 +150,10 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         let user_id = &user.id;
 
@@ -160,7 +176,10 @@ mod needs_docker {
             .await;
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let pro_user: user::UserResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(user.name, pro_user.name);
@@ -187,7 +206,10 @@ mod needs_docker {
         // POST user first so one exists in the database.
         let response = app.post_user("test-user", "basic").await;
         assert_eq!(response.status(), StatusCode::OK);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         let user_id = &user.id;
 
@@ -214,7 +236,10 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let actual_user: user::UserResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(actual_user.account_tier, AccountTier::PendingPaymentPro);
@@ -238,7 +263,10 @@ mod needs_docker {
         assert_eq!(response.status(), StatusCode::OK);
 
         // Extract the API key from the response so we can use it in a future request.
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         let user_id = &user.id;
         let basic_user_key = &user.key;
@@ -330,7 +358,10 @@ mod needs_docker {
         // Create user with basic tier
         let response = app.post_user("test-user", "basic").await;
         assert_eq!(response.status(), StatusCode::OK);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         let user_id = &user.id;
 
@@ -364,7 +395,11 @@ mod needs_docker {
 
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
         assert_eq!(user.account_tier, AccountTier::CancelledPro);
 
@@ -379,7 +414,11 @@ mod needs_docker {
             .await;
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+
         let user: user::UserResponse = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(user.account_tier, AccountTier::Basic);

--- a/backends/src/auth.rs
+++ b/backends/src/auth.rs
@@ -152,7 +152,7 @@ impl PublicKeyFn for AuthPublicKey {
             });
 
             let res = client.request(request.body(Body::empty())?).await?;
-            let buf = body::to_bytes(res).await?;
+            let buf = body::HttpBody::collect(res).await?.to_bytes();
 
             trace!("inserting public key from auth service into cache");
             self.cache_manager.insert(
@@ -637,7 +637,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let body = body::to_bytes(response.into_body()).await.unwrap();
+        let body = body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
 
         assert_eq!(&body[..], b"Hello, ferries");
     }

--- a/backends/src/axum.rs
+++ b/backends/src/axum.rs
@@ -97,7 +97,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+
         assert_eq!(&body[..], b"test123");
 
         let response = app
@@ -105,7 +109,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
+
         assert!(&body[..].starts_with(br#"{"message":"Invalid project name"#));
 
         let response = app
@@ -113,7 +121,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         assert_eq!(&body[..], b"test123 123");
 
         let response = app
@@ -121,7 +132,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         assert!(&body[..].starts_with(br#"{"message":"Invalid URL"#));
     }
 }

--- a/backends/src/metrics.rs
+++ b/backends/src/metrics.rs
@@ -213,7 +213,6 @@ mod tests {
         body::Body, extract::Path, http::Request, http::StatusCode, middleware::from_extractor,
         response::IntoResponse, routing::get, Router,
     };
-    use hyper::body;
     use tower::ServiceExt;
     use tracing::field;
     use tracing_fluent_assertions::{AssertionRegistry, AssertionsLayer};
@@ -269,7 +268,10 @@ mod tests {
 
             assert_eq!(response.status(), StatusCode::OK);
 
-            let body = body::to_bytes(response.into_body()).await.unwrap();
+            let body = hyper::body::HttpBody::collect(response.into_body())
+                .await
+                .unwrap()
+                .to_bytes();
 
             assert_eq!(&body[..], b"hello");
             request_span.assert();
@@ -315,7 +317,10 @@ mod tests {
 
             assert_eq!(response.status(), StatusCode::OK);
 
-            let body = body::to_bytes(response.into_body()).await.unwrap();
+            let body = hyper::body::HttpBody::collect(response.into_body())
+                .await
+                .unwrap()
+                .to_bytes();
 
             assert_eq!(&body[..], b"hello ferries");
             request_span.assert();

--- a/deployer/src/handlers/local.rs
+++ b/deployer/src/handlers/local.rs
@@ -44,7 +44,10 @@ pub async fn set_jwt_bearer<B>(
             .await
             .expect("failed to proxy request to auth service");
 
-        let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+        let body = hyper::body::HttpBody::collect(response.into_body())
+            .await
+            .unwrap()
+            .to_bytes();
         let convert: Value = serde_json::from_slice(&body)
             .expect("failed to deserialize body as JSON, did you login?");
 

--- a/gateway/src/api/auth_layer.rs
+++ b/gateway/src/api/auth_layer.rs
@@ -232,11 +232,13 @@ where
                             return Ok(Response::from_parts(parts, body));
                         }
 
-                        let body = match hyper::body::to_bytes(token_response.into_body()).await {
-                            Ok(body) => body,
-                            Err(error) => {
+                        let body = match hyper::body::HttpBody::collect(token_response.into_body())
+                            .await
+                        {
+                            Ok(aggregated_body) => aggregated_body.to_bytes(),
+                            Err(err) => {
                                 error!(
-                                    error = &error as &dyn std::error::Error,
+                                    error = &err as &dyn std::error::Error,
                                     "failed to get response body"
                                 );
 

--- a/gateway/src/api/project_caller.rs
+++ b/gateway/src/api/project_caller.rs
@@ -135,7 +135,9 @@ impl ProjectCaller {
         match res.status() {
             StatusCode::NOT_FOUND => Ok(None),
             StatusCode::OK => {
-                let body_bytes = hyper::body::to_bytes(res.into_body()).await?;
+                let body_bytes = hyper::body::HttpBody::collect(res.into_body())
+                    .await?
+                    .to_bytes();
 
                 let body = serde_json::from_slice(&body_bytes)?;
 

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -807,7 +807,11 @@ pub mod tests {
                     .unwrap();
 
                 assert_eq!(resp.status(), StatusCode::OK);
-                let body = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+                let body = hyper::body::HttpBody::collect(resp.into_body())
+                    .await
+                    .unwrap()
+                    .to_bytes();
+
                 let project: project::Response = serde_json::from_slice(&body).unwrap();
 
                 if project.state == state {
@@ -958,7 +962,11 @@ pub mod tests {
                     .unwrap();
 
                 assert_eq!(resp.status(), StatusCode::OK);
-                let body = hyper::body::to_bytes(resp.into_body()).await.unwrap();
+                let body = hyper::body::HttpBody::collect(resp.into_body())
+                    .await
+                    .unwrap()
+                    .to_bytes();
+
                 let service: service::Summary = serde_json::from_slice(&body).unwrap();
 
                 if service.deployment.is_some() {

--- a/gateway/src/project.rs
+++ b/gateway/src/project.rs
@@ -1560,7 +1560,9 @@ impl Service {
         let resp = timeout(IS_HEALTHY_TIMEOUT, CLIENT.request(req)).await??;
 
         if resp.status() == 200 {
-            let body = hyper::body::to_bytes(resp.into_body()).await?;
+            let body = hyper::body::HttpBody::collect(resp.into_body())
+                .await?
+                .to_bytes();
 
             let service: service::Summary = serde_json::from_slice(&body)?;
 

--- a/gateway/src/service.rs
+++ b/gateway/src/service.rs
@@ -1255,9 +1255,11 @@ impl GatewayContext {
         let resp = timeout(IS_HEALTHY_TIMEOUT, AUTH_CLIENT.request(req)).await;
 
         if let Ok(Ok(resp)) = resp {
-            let body = hyper::body::to_bytes(resp.into_body())
+            let body = hyper::body::HttpBody::collect(resp.into_body())
                 .await
-                .unwrap_or_default();
+                .unwrap_or_default()
+                .to_bytes();
+
             let convert: serde_json::Value = serde_json::from_slice(&body).unwrap_or_default();
 
             trace!(?convert, "got jwt response");


### PR DESCRIPTION
This change allows us to address deprecation warnings without immediately migrating to the newer Hyper 1.0.0 APIs. A full upgrade will be planned in subsequent PRs.

## Description of change
<!-- Please write a summary of your changes and why you made them. -->

This PR prepares the codebase for upgrading Hyper from version 0.14 to 1.0.0 by addressing deprecation warnings and enabling compatibility with newer APIs. Key changes include:

Enabled the deprecated feature flag in Hyper 0.14 to resolve immediate deprecation warnings.
Refactored usages of deprecated APIs (e.g., aggregate and to_bytes) to align with Hyper's updated patterns.
Ensured tests and functionality remain intact with the current version while paving the way for the full migration to Hyper 1.0.0.

These changes ensure that the upgrade process is smoother and minimize risks of breaking changes in subsequent steps.



<!-- Be sure to reference any related issues by adding `Closes #`. -->

#1517 

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

- `cargo test` has been run...
- Deprecated API's updated in tests...

