### PR TITLE
improvement: update the Turso resource to use libsql 0.6.0

### DIFF
--- a/resources/turso/Cargo.toml
+++ b/resources/turso/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["shuttle-service", "turso"]
 [dependencies]
 async-trait = "0.1.56"
 dunce = "1.0.4"
-libsql = { version = "0.3.1", default-features = false, features = ["core", "remote"] }
+libsql = { version = "0.6.0", default-features = false, features = ["core", "remote"] }
 serde = { version = "1", features = ["derive"] }
 shuttle-service = { path = "../../service", version = "0.49.0" }
 url = { version = "2.3.1", features = ["serde"] }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Bumped the `libsql` dependency in the Turso resource to version 0.6.0.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Ran the unit tests associated with the Turso crate.
