### PR TITLE
feat: bump common msrv to 1.81, our images to 1.83

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
   docker-rust:
     docker:
       # Note: Let CI use our MSRV, rather than latest
-      - image: cimg/rust:1.78.0
+      - image: cimg/rust:1.81.0
     resource_class: small
   machine-ubuntu:
     machine:
@@ -103,7 +103,7 @@ commands:
       - run:
           name: Install Rust (MSRV)
           # Note: Let CI use our MSRV, rather than latest
-          command: which cargo || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.78.0
+          command: which cargo || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.81.0
   install-protoc:
     steps:
       - run:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILDX_FLAGS=$(BUILDX_OP) $(PLATFORM_FLAGS)
 
 # The Rust version used by our containers
 # Can be updated to the latest stable
-RUSTUP_TOOLCHAIN=1.82.0
+RUSTUP_TOOLCHAIN=1.83.0
 
 TAG?=$(shell git describe --tags --abbrev=0)
 AUTH_TAG?=$(TAG)

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 description = "Common library for the shuttle platform (https://www.shuttle.rs/)"
 # Base MSRV for the Shuttle crates. If some other crate has a higher MSRV, set it in that crate.
-rust-version = "1.78"
+rust-version = "1.81"
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Five of our resource crates now have MSRV of 1.81 due to an update of the cargo `home` crate msrv in a patch release, which causes failures in our CI. I'm bumping our general MSRV since 1.81 was released in early September, with 1.83 being the current, and 1.84 being released on the 9th of January.

![image](https://github.com/user-attachments/assets/c346a419-8ec2-469b-b26e-0a32d1a35f8f)

