### PR TITLE
feat: re-export supported framework crates

### DIFF
--- a/services/shuttle-actix-web/src/lib.rs
+++ b/services/shuttle-actix-web/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 use std::net::SocketAddr;
 
+pub use actix_web;
+
 /// A wrapper type for a closure that returns an [actix_web::web::ServiceConfig] so we can implement
 /// [shuttle_runtime::Service] for it.
 #[derive(Clone)]

--- a/services/shuttle-axum/src/lib.rs
+++ b/services/shuttle-axum/src/lib.rs
@@ -3,6 +3,11 @@ use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
 #[cfg(feature = "axum")]
+pub use axum;
+#[cfg(feature = "axum-0-7")]
+pub use axum_0_7 as axum;
+
+#[cfg(feature = "axum")]
 use axum::Router;
 #[cfg(feature = "axum-0-7")]
 use axum_0_7::Router;

--- a/services/shuttle-poem/src/lib.rs
+++ b/services/shuttle-poem/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+
+pub use poem;
+
 /// A wrapper type for [poem::Endpoint] so we can implement [shuttle_runtime::Service] for it.
 pub struct PoemService<T>(pub T);
 

--- a/services/shuttle-rocket/src/lib.rs
+++ b/services/shuttle-rocket/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 use std::net::SocketAddr;
 
+pub use rocket;
+
 /// A wrapper type for [rocket::Rocket<rocket::Build>] so we can implement [shuttle_runtime::Service] for it.
 pub struct RocketService(pub rocket::Rocket<rocket::Build>);
 

--- a/services/shuttle-salvo/src/lib.rs
+++ b/services/shuttle-salvo/src/lib.rs
@@ -3,6 +3,8 @@ use salvo::Listener;
 use shuttle_runtime::Error;
 use std::net::SocketAddr;
 
+pub use salvo;
+
 /// A wrapper type for [salvo::Router] so we can implement [shuttle_runtime::Service] for it.
 pub struct SalvoService(pub salvo::Router);
 

--- a/services/shuttle-serenity/src/lib.rs
+++ b/services/shuttle-serenity/src/lib.rs
@@ -2,6 +2,8 @@
 use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
+pub use serenity;
+
 #[cfg(feature = "serenity")]
 use serenity::Client;
 #[cfg(feature = "serenity-0-11")]

--- a/services/shuttle-serenity/src/lib.rs
+++ b/services/shuttle-serenity/src/lib.rs
@@ -2,12 +2,15 @@
 use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
-pub use serenity;
-
 #[cfg(feature = "serenity")]
 use serenity::Client;
 #[cfg(feature = "serenity-0-11")]
 use serenity_0_11::Client;
+
+#[cfg(feature = "serenity")]
+pub use serenity;
+#[cfg(feature = "serenity-0-11")]
+pub use serenity_0_11 as serenity;
 
 /// A wrapper type for [serenity::Client] so we can implement [shuttle_runtime::Service] for it.
 pub struct SerenityService(pub Client);
@@ -31,3 +34,4 @@ impl From<Client> for SerenityService {
 
 #[doc = include_str!("../README.md")]
 pub type ShuttleSerenity = Result<SerenityService, Error>;
+

--- a/services/shuttle-serenity/src/lib.rs
+++ b/services/shuttle-serenity/src/lib.rs
@@ -34,4 +34,3 @@ impl From<Client> for SerenityService {
 
 #[doc = include_str!("../README.md")]
 pub type ShuttleSerenity = Result<SerenityService, Error>;
-

--- a/services/shuttle-thruster/src/lib.rs
+++ b/services/shuttle-thruster/src/lib.rs
@@ -2,6 +2,8 @@
 use shuttle_runtime::Error;
 use std::net::SocketAddr;
 
+pub use thruster;
+
 /// A wrapper type for [thruster::ThrusterServer] so we can implement [shuttle_runtime::Service] for it.
 pub struct ThrusterService<T>(pub T);
 

--- a/services/shuttle-tide/src/lib.rs
+++ b/services/shuttle-tide/src/lib.rs
@@ -2,7 +2,9 @@
 use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
-/// A wrapper type for [tide::Server<T] so we can implement [shuttle_runtime::Service] for it.
+pub use tide;
+
+/// A wrapper type for [tide::Server<T>] so we can implement [shuttle_runtime::Service] for it.
 pub struct TideService<T>(pub tide::Server<T>);
 
 #[shuttle_runtime::async_trait]

--- a/services/shuttle-tower/src/lib.rs
+++ b/services/shuttle-tower/src/lib.rs
@@ -2,6 +2,8 @@
 use shuttle_runtime::{CustomError, Error};
 use std::net::SocketAddr;
 
+pub use tower;
+
 /// A wrapper type for [tower::Service] so we can implement [shuttle_runtime::Service] for it.
 pub struct TowerService<T>(pub T);
 

--- a/services/shuttle-warp/src/lib.rs
+++ b/services/shuttle-warp/src/lib.rs
@@ -3,6 +3,8 @@ use shuttle_runtime::Error;
 use std::net::SocketAddr;
 use std::ops::Deref;
 
+pub use warp;
+
 /// A wrapper type for [warp::Filter] so we can implement [shuttle_runtime::Service] for it.
 pub struct WarpService<T>(pub T);
 


### PR DESCRIPTION
## Description of change

PR re-exports the top-level crate of each "wrapped" / supported web framework. This frees Shuttle users from having to pin a version of their preferred framework *and* a version of the framework's Shuttle wrapper.

This change is purely a quality-of-life change, and does not require users to change anything about their existing code or dependency manifests. It simply allows this ...:

```rust
use axum::{routing::get, Router};

async fn hello_world() -> &'static str {
    "Hello, world!"
}

#[shuttle_runtime::main]
async fn main() -> shuttle_axum::ShuttleAxum {
    let router = Router::new().route("/", get(hello_world));

    Ok(router.into())
}
```

... to become this:

```rust
use shuttle_axum::{ShuttleAxum, axum::{routing::get, Router}};

async fn hello_world() -> &'static str {
    "Hello, world!"
}

#[shuttle_runtime::main]
async fn main() -> ShuttleAxum {
    let router = Router::new().route("/", get(hello_world));

    Ok(router.into())
}
```
