### PR TITLE
feat: user project telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,7 +3090,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3106,7 +3106,6 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-util",
  "rustls 0.23.20",
- "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -4972,7 +4971,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -5018,7 +5017,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.20",
- "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5257,19 +5255,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.2.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -5418,19 +5404,6 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.7.0",
  "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
-dependencies = [
- "bitflags 2.7.0",
- "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6162,14 +6135,12 @@ dependencies = [
  "strfmt",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tonic 0.10.2",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3090,7 +3090,7 @@ dependencies = [
  "hyper 0.14.32",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3106,6 +3106,7 @@ dependencies = [
  "hyper 1.5.2",
  "hyper-util",
  "rustls 0.23.20",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -4087,6 +4088,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-appender-tracing"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4094,7 +4109,7 @@ checksum = "12c4bd073648dae8ac45cfc81588d74b3dc5f334119ac08567ddcbfe16f2d809"
 dependencies = [
  "once_cell",
  "opentelemetry 0.21.0",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.21.2",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -4142,6 +4157,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.2.0",
+ "opentelemetry 0.27.1",
+ "reqwest 0.12.12",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,14 +4180,32 @@ dependencies = [
  "http 0.2.12",
  "opentelemetry 0.21.0",
  "opentelemetry-http 0.10.0",
- "opentelemetry-proto",
- "opentelemetry-semantic-conventions",
- "opentelemetry_sdk",
+ "opentelemetry-proto 0.4.0",
+ "opentelemetry-semantic-conventions 0.13.0",
+ "opentelemetry_sdk 0.21.2",
  "prost 0.11.9",
  "reqwest 0.11.27",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.2.0",
+ "opentelemetry 0.27.1",
+ "opentelemetry-http 0.27.0",
+ "opentelemetry-proto 0.27.0",
+ "opentelemetry_sdk 0.27.1",
+ "prost 0.13.4",
+ "reqwest 0.12.12",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4169,9 +4215,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
  "opentelemetry 0.21.0",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.21.2",
  "prost 0.11.9",
  "tonic 0.9.2",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
+ "prost 0.13.4",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -4182,6 +4240,12 @@ checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
  "opentelemetry 0.21.0",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -4198,6 +4262,27 @@ dependencies = [
  "once_cell",
  "opentelemetry 0.21.0",
  "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "http 1.2.0",
+ "opentelemetry 0.27.1",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
@@ -4576,6 +4661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.4",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4593,6 +4688,19 @@ name = "prost-derive"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -4864,7 +4972,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4910,6 +5018,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.20",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5148,7 +5257,19 @@ dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -5297,6 +5418,19 @@ checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.7.0",
  "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.7.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5666,7 +5800,7 @@ dependencies = [
  "tokio",
  "tower 0.4.13",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "ulid",
  "wiremock",
@@ -5690,8 +5824,8 @@ dependencies = [
  "opentelemetry 0.21.0",
  "opentelemetry-appender-tracing",
  "opentelemetry-http 0.10.0",
- "opentelemetry-otlp",
- "opentelemetry_sdk",
+ "opentelemetry-otlp 0.14.0",
+ "opentelemetry_sdk 0.21.2",
  "permit-client-rs",
  "permit-pdp-client-rs",
  "pin-project",
@@ -5717,7 +5851,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-fluent-assertions",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "ttl_cache",
  "uuid",
@@ -5771,7 +5905,7 @@ dependencies = [
  "tonic 0.10.2",
  "tower 0.4.13",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "typeshare",
  "url",
@@ -5838,7 +5972,7 @@ dependencies = [
  "tonic 0.10.2",
  "tower 0.4.13",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "ulid",
  "uuid",
@@ -5899,7 +6033,7 @@ dependencies = [
  "tower 0.4.13",
  "tower-http",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-subscriber",
  "ttl_cache",
  "ulid",
@@ -6012,6 +6146,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "hyper 0.14.32",
+ "log",
+ "opentelemetry 0.27.1",
+ "opentelemetry-otlp 0.27.0",
+ "opentelemetry-semantic-conventions 0.27.0",
+ "opentelemetry_sdk 0.27.1",
  "portpicker",
  "serde",
  "serde_json",
@@ -6026,6 +6165,9 @@ dependencies = [
  "tokio-util",
  "tonic 0.10.2",
  "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-opentelemetry 0.28.0",
  "tracing-subscriber",
  "uuid",
 ]
@@ -6995,6 +7137,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.4",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7124,13 +7287,30 @@ dependencies = [
  "js-sys",
  "once_cell",
  "opentelemetry 0.21.0",
- "opentelemetry_sdk",
+ "opentelemetry_sdk 0.21.2",
  "smallvec",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
  "web-time 0.2.4",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.27.1",
+ "opentelemetry_sdk 0.27.1",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -7152,6 +7332,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
+ "parking_lot",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,11 +112,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -808,9 +809,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -1058,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "jobserver",
  "libc",
@@ -1161,9 +1162,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clap_mangen"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbfe6ac42a2438d0968beba18e3c35cacf16b0c25310bc22b1f5f3cffff09f4"
+checksum = "724842fa9b144f9b89b3f3d371a89f3455eea660361d13a554f68f8ae5d6c13a"
 dependencies = [
  "clap",
  "roff",
@@ -1383,7 +1384,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "libc",
  "mio 0.8.11",
@@ -1494,9 +1495,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "deadpool"
@@ -1998,7 +1999,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -2067,8 +2068,8 @@ dependencies = [
  "gix-date",
  "gix-utils",
  "itoa",
- "thiserror 2.0.10",
- "winnow 0.6.22",
+ "thiserror 2.0.11",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -2084,7 +2085,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "unicode-bom",
 ]
 
@@ -2094,7 +2095,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48b897b4bbc881aea994b4a5bbb340a04979d7be9089791304e04a9fbc66b53"
 dependencies = [
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2103,7 +2104,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6ffbeb3a5c0b8b84c3fe4133a6f8c82fa962f4caefe8d0762eced025d3eb4f7"
 dependencies = [
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2129,7 +2130,7 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "memmap2",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2150,7 +2151,7 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "unicode-bom",
- "winnow 0.6.22",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -2159,11 +2160,11 @@ version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aaeef5d98390a3bcf9dbc6440b520b793d1bf3ed99317dc407b02be995b28e"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2180,7 +2181,7 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2192,7 +2193,7 @@ dependencies = [
  "bstr",
  "itoa",
  "jiff",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2239,7 +2240,7 @@ dependencies = [
  "once_cell",
  "prodash",
  "sha1_smol",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "walkdir",
 ]
 
@@ -2281,7 +2282,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf69a6bec0a3581567484bf99a4003afcaf6c469fd4214352517ea355cf3435"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -2294,7 +2295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5eccc17194ed0e67d49285e4853307e4147e95407f91c1c3e4a13ba9f4e4ce"
 dependencies = [
  "faster-hex",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2327,7 +2328,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27619009ca1ea33fd885041273f5fa5a09163a5c1d22a913b28d7b985e66fe29"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bstr",
  "filetime",
  "fnv",
@@ -2357,7 +2358,7 @@ checksum = "1cd3ab68a452db63d9f3ebdacb10f30dba1fa0d31ac64f4203d395ed1102d940"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2366,7 +2367,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414806291838c3349ea939c6d840ff854f84cd29bd3dde8f904f60b0e5b7d0bd"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2393,7 +2394,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 1.0.69",
- "winnow 0.6.22",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -2446,7 +2447,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2458,7 +2459,7 @@ dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2471,7 +2472,7 @@ dependencies = [
  "gix-trace",
  "home",
  "once_cell",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2480,13 +2481,13 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c472dfbe4a4e96fcf7efddcd4771c9037bb4fdea2faaabf2f4888210c75b81e"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2499,7 +2500,7 @@ dependencies = [
  "gix-config-value",
  "parking_lot",
  "rustix",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2516,8 +2517,8 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror 2.0.10",
- "winnow 0.6.22",
+ "thiserror 2.0.11",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -2528,7 +2529,7 @@ checksum = "64a1e282216ec2ab2816cd57e6ed88f8009e634aec47562883c05ac8a7009a63"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2549,7 +2550,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 1.0.69",
- "winnow 0.6.22",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -2602,7 +2603,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b876ef997a955397809a2ec398d6a45b7a55b4918f2446344330f778d14fd6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "gix-path",
  "libc",
  "windows-sys 0.52.0",
@@ -2658,7 +2659,7 @@ dependencies = [
  "gix-sec",
  "gix-url",
  "reqwest 0.12.12",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -2667,7 +2668,7 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f20f1b13cc4fa6ba92b24e6aa0c2fb6a34beb4458ef88c6300212db504e818df"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2688,7 +2689,7 @@ dependencies = [
  "gix-features",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "url",
 ]
 
@@ -2709,7 +2710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd520d09f9f585b34b32aba1d0b36ada89ab7fefb54a8ca3fe37fc482a750937"
 dependencies = [
  "bstr",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3105,7 +3106,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.2",
  "hyper-util",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -3485,6 +3486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3492,9 +3502,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0ce60560149333a8e41ca7dc78799c47c5fd435e2bc18faf6a054382eec037"
+checksum = "7597657ea66d53f6e926a67d4cc3d125c4b57fa662f2d007a5476307de948453"
 dependencies = [
  "jiff-tzdb-platform",
  "log",
@@ -3552,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3623,7 +3633,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "libc",
  "redox_syscall",
 ]
@@ -3687,9 +3697,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "lru-cache"
@@ -3797,9 +3807,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -3886,7 +3896,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "libc",
 ]
@@ -4018,7 +4028,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "block2",
  "libc",
  "objc2",
@@ -4307,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "outref"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "overload"
@@ -4602,9 +4612,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -4627,7 +4637,7 @@ checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -4702,7 +4712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.96",
@@ -4734,9 +4744,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "socket2 0.5.8",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -4752,10 +4762,10 @@ dependencies = [
  "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tinyvec",
  "tracing",
  "web-time 1.1.0",
@@ -4888,7 +4898,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -5016,7 +5026,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -5213,7 +5223,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5234,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -5402,7 +5412,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5769,7 +5779,7 @@ dependencies = [
  "shuttle-common",
  "shuttle-common-tests",
  "sqlx",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -5817,7 +5827,7 @@ dependencies = [
  "sqlx",
  "strum 0.26.3",
  "test-context",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tonic 0.10.2",
  "tower 0.4.13",
@@ -5874,7 +5884,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum 0.26.3",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tonic 0.10.2",
  "tower 0.4.13",
  "tracing",
@@ -5938,7 +5948,7 @@ dependencies = [
  "strum 0.26.3",
  "tar",
  "tempfile",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "toml",
@@ -6000,7 +6010,7 @@ dependencies = [
  "tar",
  "tempfile",
  "test-context",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tonic 0.10.2",
  "tower 0.4.13",
@@ -6032,7 +6042,7 @@ dependencies = [
  "shuttle-common-tests",
  "shuttle-proto",
  "sqlx",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tonic 0.10.2",
@@ -6080,7 +6090,7 @@ dependencies = [
  "shuttle-common-tests",
  "shuttle-proto",
  "sqlx",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tonic 0.10.2",
  "tracing",
@@ -6104,7 +6114,7 @@ dependencies = [
  "shuttle-proto",
  "sqlx",
  "strum 0.26.3",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "tonic 0.10.2",
  "tracing",
@@ -6155,7 +6165,7 @@ dependencies = [
  "shuttle-common",
  "shuttle-proto",
  "strfmt",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "tokio",
  "toml",
  "tracing",
@@ -6209,13 +6219,13 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -6423,7 +6433,7 @@ checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -6467,7 +6477,7 @@ checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
  "base64 0.21.7",
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "byteorder",
  "chrono",
  "crc",
@@ -6689,7 +6699,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -6813,11 +6823,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ac7f54ca534db81081ef1c1e7f6ea8a3ef428d2fc069097c079443d24124d3"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.10",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -6833,9 +6843,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9465d30713b56a37ede7185763c3492a91be2f5fa68d958c44e41ab9248beb"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6963,7 +6973,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.21",
  "tokio",
 ]
 
@@ -7049,7 +7059,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.22",
+ "winnow 0.6.24",
 ]
 
 [[package]]
@@ -7169,7 +7179,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7592,9 +7602,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "744018581f9a3454a9e15beb8a33b017183f1e7c0cd170232a2d1453b23a51c4"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
@@ -7678,20 +7688,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -7703,9 +7714,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7716,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7726,9 +7737,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7739,15 +7750,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8117,9 +8131,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -8358,7 +8372,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "rand 0.8.5",
  "sha1",
- "thiserror 2.0.10",
+ "thiserror 2.0.11",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "jobserver",
  "libc",
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.33.1"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b24171f514cef7bb4dfb72a0b06dacf609b33ba8ad2489d4c4559a03b7afb3"
+checksum = "20018a1a6332e065f1fcc8305c1c932c6b8c9985edea2284b3c79dc6fa3ee4b2"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2091,18 +2091,18 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48b897b4bbc881aea994b4a5bbb340a04979d7be9089791304e04a9fbc66b53"
+checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
 dependencies = [
  "thiserror 2.0.11",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ffbeb3a5c0b8b84c3fe4133a6f8c82fa962f4caefe8d0762eced025d3eb4f7"
+checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
 dependencies = [
  "thiserror 2.0.11",
 ]
@@ -2156,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49aaeef5d98390a3bcf9dbc6440b520b793d1bf3ed99317dc407b02be995b28e"
+checksum = "11365144ef93082f3403471dbaa94cfe4b5e72743bdb9560719a251d439f4cee"
 dependencies = [
  "bitflags 2.8.0",
  "bstr",
@@ -2440,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911aeea8b2dabeed2f775af9906152a1f0109787074daf9e64224e3892dde453"
+checksum = "c7e5ae6bc3ac160a6bf44a55f5537813ca3ddb08549c0fd3e7ef699c73c439cd"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2452,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9004ce1bc00fd538b11c1ec8141a1558fb3af3d2b7ac1ac5c41881f9e42d2a"
+checksum = "c1cbf8767c6abd5a6779f586702b5bcd8702380f4208219449cf1c9d0cd1e17c"
 dependencies = [
  "bstr",
  "faster-hex",
@@ -2464,9 +2464,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.10.13"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc292ef1a51e340aeb0e720800338c805975724c1dfbd243185452efd8645b7"
+checksum = "c40f12bb65a8299be0cfb90fe718e3be236b7a94b434877012980863a883a99f"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2523,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a1e282216ec2ab2816cd57e6ed88f8009e634aec47562883c05ac8a7009a63"
+checksum = "e49357fccdb0c85c0d3a3292a9f6db32d9b3535959b5471bb9624908f4a066c6"
 dependencies = [
  "bstr",
  "gix-utils",
@@ -2599,9 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.10.10"
+version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b876ef997a955397809a2ec398d6a45b7a55b4918f2446344330f778d14fd6"
+checksum = "d84dae13271f4313f8d60a166bf27e54c968c7c33e2ffd31c48cafe5da649875"
 dependencies = [
  "bitflags 2.8.0",
  "gix-path",
@@ -2639,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bdde120c29f1fc23a24d3e115aeeea3d60d8e65bab92cc5f9d90d9302eb952"
+checksum = "7c396a2036920c69695f760a65e7f2677267ccf483f25046977d87e4cb2665f7"
 
 [[package]]
 name = "gix-transport"
@@ -2695,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba427e3e9599508ed98a6ddf8ed05493db114564e338e41f6a996d2e4790335f"
+checksum = "ff08f24e03ac8916c478c8419d7d3c33393da9bb41fa4c24455d5406aeefd35f"
 dependencies = [
  "fastrand 2.3.0",
  "unicode-normalization",
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd520d09f9f585b34b32aba1d0b36ada89ab7fefb54a8ca3fe37fc482a750937"
+checksum = "9eaa01c3337d885617c0a42e92823922a2aea71f4caeace6fe87002bdcadbd90"
 dependencies = [
  "bstr",
  "thiserror 2.0.11",
@@ -3502,9 +3502,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jiff"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7597657ea66d53f6e926a67d4cc3d125c4b57fa662f2d007a5476307de948453"
+checksum = "d2bb0c2e28117985a4d90e3bc70092bc8f226f434c7ec7e23dd9ff99c5c5721a"
 dependencies = [
  "jiff-tzdb-platform",
  "log",
@@ -3516,15 +3516,15 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+checksum = "cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3"
 
 [[package]]
 name = "jiff-tzdb-platform"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9835f0060a626fe59f160437bc725491a6af23133ea906500027d1bd2f8f4329"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
 dependencies = [
  "jiff-tzdb",
 ]
@@ -7612,9 +7612,9 @@ dependencies = [
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ opentelemetry = "0.21.0"
 opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio", "logs"] }
 opentelemetry-http = "0.10.0"
 opentelemetry-otlp = { version = "0.14.0", features = ["logs", "http-proto", "reqwest-client", "reqwest-rustls"] }
-opentelemetry-proto = "0.4.0"
 opentelemetry-contrib = { version = "0.4.0", features = ["datadog"] }
 opentelemetry-appender-tracing = "0.2.0"
 percent-encoding = "2.2"
@@ -99,7 +98,6 @@ tokio-stream = "0.1.11"
 tokio-tungstenite = { version = "0.20.1", features = [
   "rustls-tls-webpki-roots",
 ] }
-tokio-util = "0.7.10"
 toml = "0.8.2"
 toml_edit = "0.20.2"
 tonic = "0.10.2"

--- a/codegen/src/shuttle_main.rs
+++ b/codegen/src/shuttle_main.rs
@@ -25,8 +25,9 @@ pub(crate) fn tokens(_attr: TokenStream, item: TokenStream) -> TokenStream {
                         __runner,
                         env!("CARGO_CRATE_NAME"),
                         env!("CARGO_PKG_VERSION"),
-                ).await;
-            })
+                    )
+                    .await;
+                })
         }
 
         #loader_runner

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -352,7 +352,7 @@ mod test {
         ];
 
         for input in inputs {
-            let actual = ResourceTypeBeta::from_str(&input.to_string()).unwrap();
+            let actual = ResourceTypeBeta::from_str(input.as_ref()).unwrap();
             assert_eq!(input, actual, ":{} should map back to itself", input);
         }
     }

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -182,6 +182,10 @@ pub enum ResourceTypeBeta {
     #[strum(to_string = "database::aws_rds::mariadb")]
     #[serde(rename = "database::aws_rds::mariadb")]
     DatabaseAwsRdsMariaDB,
+    /// Project-specific telemetry configuration data
+    #[strum(to_string = "project::telemetry::config")]
+    #[serde(rename = "project::telemetry::config")]
+    ProjectTelemetryConfig,
     /// (Will probably be removed)
     #[strum(to_string = "secrets")]
     #[serde(rename = "secrets")]
@@ -250,7 +254,7 @@ impl Display for Type {
 // this can be removed when deployers AND r-r no longer hold resources in sqlite state
 #[cfg(feature = "sqlx")]
 mod _sqlx {
-    use std::{borrow::Cow, str::FromStr};
+    use std::{borrow::Cow, boxed::Box, str::FromStr};
 
     use sqlx::{
         postgres::{PgArgumentBuffer, PgValueRef},
@@ -285,16 +289,16 @@ mod _sqlx {
         }
     }
 
-    impl<DB: sqlx::Database> sqlx::Type<DB> for ResourceState
+    impl<DB: Database> sqlx::Type<DB> for ResourceState
     where
         str: sqlx::Type<DB>,
     {
-        fn type_info() -> <DB as sqlx::Database>::TypeInfo {
+        fn type_info() -> <DB as Database>::TypeInfo {
             <str as sqlx::Type<DB>>::type_info()
         }
     }
 
-    impl sqlx::Encode<'_, sqlx::Postgres> for ResourceState {
+    impl sqlx::Encode<'_, Postgres> for ResourceState {
         fn encode_by_ref(&self, buf: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
             #[allow(clippy::needless_borrows_for_generic_args)]
             <&str as sqlx::Encode<Postgres>>::encode(&self.to_string(), buf)
@@ -307,6 +311,28 @@ mod _sqlx {
 
             let state = ResourceState::from_str(value)?;
             Ok(state)
+        }
+    }
+
+    impl<DB: Database> sqlx::Type<DB> for super::ResourceTypeBeta
+    where
+        str: sqlx::Type<DB>,
+    {
+        fn type_info() -> <DB as Database>::TypeInfo {
+            <str as sqlx::Type<DB>>::type_info()
+        }
+    }
+
+    impl sqlx::Encode<'_, Postgres> for super::ResourceTypeBeta {
+        fn encode_by_ref(&self, args: &mut PgArgumentBuffer) -> sqlx::encode::IsNull {
+            <&str as sqlx::Encode<Postgres>>::encode(self.to_string().as_str(), args)
+        }
+    }
+
+    impl<'r> sqlx::Decode<'r, Postgres> for super::ResourceTypeBeta {
+        fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+            <&str as sqlx::Decode<Postgres>>::decode(value)
+                .and_then(|value| super::ResourceTypeBeta::from_str(value).map_err(Into::into))
         }
     }
 }

--- a/common/src/resource.rs
+++ b/common/src/resource.rs
@@ -165,7 +165,16 @@ pub enum Type {
 }
 
 #[derive(
-    Clone, Copy, Debug, strum::EnumString, strum::Display, Deserialize, Serialize, Eq, PartialEq,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Serialize,
+    strum::AsRefStr,
+    strum::EnumString,
+    strum::Display,
 )]
 #[typeshare::typeshare]
 // is a flat enum instead of nested enum to allow typeshare

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -45,22 +45,11 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
-tracing = { workspace = true, optional = true, features = ["attributes", "std"] }
+tracing = { workspace = true, features = ["attributes", "std"] }
 tracing-core = { version = "0.1", optional = true, default-features = false, features = ["std"] }
 tracing-log = { version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
 tracing-opentelemetry = { version = "0.28.0", optional = true, default-features = false, features = ["metrics"] }
-tracing-subscriber = { workspace = true, optional = true, features = [
-    "alloc",
-    "env-filter",
-    "fmt",
-    "parking_lot",
-    "registry",
-    "smallvec",
-    "std",
-    "tracing",
-    "tracing-log",
-    "tracing-serde",
-] }
+tracing-subscriber = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 portpicker = { workspace = true }
@@ -73,14 +62,26 @@ default = ["setup-tracing"]
 api-client-tracing = ["shuttle-api-client/tracing"]
 
 setup-tracing = [
+    "tracing-subscriber/ansi",
+    "tracing-subscriber/env-filter",
+    "tracing-subscriber/fmt",
+    "tracing-subscriber/smallvec",
+    "tracing-subscriber/std",
+    "tracing-subscriber/tracing-log",
+]
+setup-telemetry = [
+    "setup-tracing",
     "dep:log",
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-semantic-conventions",
-    "dep:tracing",
     "dep:tracing-core",
     "dep:tracing-log",
     "dep:tracing-opentelemetry",
-    "dep:tracing-subscriber",
+    "tracing-subscriber/alloc",
+    "tracing-subscriber/parking_lot",
+    "tracing-subscriber/registry",
+    "tracing-subscriber/tracing",
+    "tracing-subscriber/tracing-serde",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -19,6 +19,25 @@ shuttle-service = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 hyper = { workspace = true, features = ["http1", "server", "tcp"] }
+log = { version = "0.4", optional = true, default-features = false }
+opentelemetry = { version = "0.27", optional = true, default-features = false, features = ["logs", "metrics", "trace", "tracing"] }
+opentelemetry-otlp = { version = "0.27", optional = true, default-features = false, features = [
+    "http-proto",
+    "logs",
+    "metrics",
+    "reqwest-client",
+    "reqwest-rustls",
+    "trace",
+] }
+opentelemetry_sdk = { version = "0.27", optional = true, default-features = false, features = [
+    "http",
+    "logs",
+    "metrics",
+    "rt-tokio",
+    "trace",
+    "spec_unstable_logs_enabled",
+] }
+opentelemetry-semantic-conventions = { version = "0.27", optional = true, default-features = false, features = ["semconv_experimental"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strfmt = { workspace = true }
@@ -26,8 +45,22 @@ tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true, features = ["attributes", "std"] }
+tracing-core = { version = "0.1", optional = true, default-features = false, features = ["std"] }
+tracing-log = { version = "0.2", optional = true, default-features = false, features = ["log-tracer", "std"] }
+tracing-opentelemetry = { version = "0.28.0", optional = true, default-features = false, features = ["metrics"] }
+tracing-subscriber = { workspace = true, optional = true, features = [
+    "alloc",
+    "env-filter",
+    "fmt",
+    "parking_lot",
+    "registry",
+    "smallvec",
+    "std",
+    "tracing",
+    "tracing-log",
+    "tracing-serde",
+] }
 
 [dev-dependencies]
 portpicker = { workspace = true }
@@ -40,6 +73,14 @@ default = ["setup-tracing"]
 api-client-tracing = ["shuttle-api-client/tracing"]
 
 setup-tracing = [
-    "tracing-subscriber/default",
-    "tracing-subscriber/env-filter",
+    "dep:log",
+    "dep:opentelemetry",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-semantic-conventions",
+    "dep:tracing",
+    "dep:tracing-core",
+    "dep:tracing-log",
+    "dep:tracing-opentelemetry",
+    "dep:tracing-subscriber",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -28,7 +28,9 @@ opentelemetry-otlp = { version = "0.27.0", optional = true, default-features = f
     "reqwest-client",
     "trace",
 ] }
-opentelemetry_sdk = { version = "0.27.0", optional = true, default-features = false, features = [
+# NOTE: If the version of `opentelemetry_sdk` is changed/updated, remember up update the
+# `telemetry.sdk.version` value in `src/trace.rs:373`
+opentelemetry_sdk = { version = "=0.27.1", optional = true, default-features = false, features = [
     "http",
     "logs",
     "metrics",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,15 +20,15 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 hyper = { workspace = true, features = ["http1", "server", "tcp"] }
 log = { version = "0.4", optional = true, default-features = false }
-opentelemetry = { version = "0.27", optional = true, default-features = false, features = ["logs", "metrics", "trace", "tracing"] }
-opentelemetry-otlp = { version = "0.27", optional = true, default-features = false, features = [
+opentelemetry = { version = "0.27.0", optional = true, default-features = false, features = ["logs", "metrics", "trace", "tracing"] }
+opentelemetry-otlp = { version = "0.27.0", optional = true, default-features = false, features = [
     "http-proto",
     "logs",
     "metrics",
     "reqwest-client",
     "trace",
 ] }
-opentelemetry_sdk = { version = "0.27", optional = true, default-features = false, features = [
+opentelemetry_sdk = { version = "0.27.0", optional = true, default-features = false, features = [
     "http",
     "logs",
     "metrics",
@@ -36,7 +36,7 @@ opentelemetry_sdk = { version = "0.27", optional = true, default-features = fals
     "trace",
     "spec_unstable_logs_enabled",
 ] }
-opentelemetry-semantic-conventions = { version = "0.27", optional = true, default-features = false, features = ["semconv_experimental"] }
+opentelemetry-semantic-conventions = { version = "0.27.0", optional = true, default-features = false, features = ["semconv_experimental"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strfmt = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,7 +26,6 @@ opentelemetry-otlp = { version = "0.27", optional = true, default-features = fal
     "logs",
     "metrics",
     "reqwest-client",
-    "reqwest-rustls",
     "trace",
 ] }
 opentelemetry_sdk = { version = "0.27", optional = true, default-features = false, features = [
@@ -42,7 +41,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strfmt = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true, features = ["attributes", "std"] }
@@ -55,7 +53,6 @@ tracing-subscriber = { workspace = true, optional = true, default-features = fal
 portpicker = { workspace = true }
 shuttle-service = { workspace = true, features = ["builder", "runner"] }
 shuttle-proto = { workspace = true, features = ["provisioner"] }
-uuid = { workspace = true }
 
 [features]
 default = ["setup-tracing"]

--- a/runtime/src/alpha.rs
+++ b/runtime/src/alpha.rs
@@ -118,7 +118,7 @@ where
                 }
             },
             Err(error) => {
-                if error.is_panic() {
+                return if error.is_panic() {
                     let panic = error.into_panic();
                     let msg = match panic.downcast_ref::<String>() {
                         Some(msg) => msg.to_string(),
@@ -128,18 +128,18 @@ where
                         },
                     };
                     println!("loading service panicked: {msg}");
-                    return Ok(Response::new(LoadResponse {
+                    Ok(Response::new(LoadResponse {
                         success: false,
                         message: msg,
                         resources: vec![],
-                    }));
+                    }))
                 } else {
                     println!("loading service crashed: {error:#}");
-                    return Ok(Response::new(LoadResponse {
+                    Ok(Response::new(LoadResponse {
                         success: false,
                         message: error.to_string(),
                         resources: vec![],
-                    }));
+                    }))
                 }
             }
         };
@@ -214,7 +214,7 @@ where
 
         println!("Starting on {service_address}");
 
-        let (kill_tx, kill_rx) = tokio::sync::oneshot::channel();
+        let (kill_tx, kill_rx) = oneshot::channel();
         *self.kill_tx.lock().unwrap() = Some(kill_tx);
 
         let handle = tokio::runtime::Handle::current();
@@ -296,7 +296,7 @@ where
         } else {
             println!("failed to stop deployment");
 
-            Ok(tonic::Response::new(StopResponse { success: false }))
+            Ok(Response::new(StopResponse { success: false }))
         }
     }
 
@@ -324,7 +324,7 @@ where
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn version(&self, _requset: Request<Ping>) -> Result<Response<VersionInfo>, Status> {
+    async fn version(&self, _request: Request<Ping>) -> Result<Response<VersionInfo>, Status> {
         Ok(Response::new(VersionInfo {
             version: crate::VERSION_STRING.to_owned(),
         }))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,7 +12,7 @@ mod plugins;
 mod rt;
 mod start;
 
-#[cfg(feature = "setup-tracing")]
+#[cfg(feature = "setup-telemetry")]
 mod trace;
 
 // Public API

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,6 +12,9 @@ mod plugins;
 mod rt;
 mod start;
 
+#[cfg(feature = "setup-tracing")]
+mod trace;
+
 // Public API
 pub use plugins::{Metadata, Secrets};
 pub use shuttle_codegen::main;
@@ -51,7 +54,7 @@ pub mod __internals {
         O: Future<Output = Result<Vec<Vec<u8>>, Error>> + Send,
     {
         async fn load(self, factory: ResourceFactory) -> Result<Vec<Vec<u8>>, Error> {
-            (self)(factory).await
+            self(factory).await
         }
     }
 
@@ -72,7 +75,7 @@ pub mod __internals {
         type Service = S;
 
         async fn run(self, resources: Vec<Vec<u8>>) -> Result<Self::Service, Error> {
-            (self)(resources).await
+            self(resources).await
         }
     }
 }

--- a/runtime/src/rt.rs
+++ b/runtime/src/rt.rs
@@ -93,7 +93,7 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
             // light hyper server
             let make_service = make_service_fn(|_conn| async {
                 Ok::<_, Infallible>(service_fn(|_req| async move {
-                    trace!("Receivied health check");
+                    trace!("Received health check");
                     // TODO: A hook into the `Service` trait can be added here
                     trace!("Responding to health check");
                     Result::<Response<Body>, hyper::Error>::Ok(Response::new(Body::empty()))
@@ -130,7 +130,7 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
     // Sort secrets by key
     let secrets = BTreeMap::from_iter(secrets.into_iter().map(|(k, v)| (k, Secret::new(v))));
 
-    // TODO: rework resourcefactory
+    // TODO: rework `ResourceFactory`
     let factory = ResourceFactory::new(project_name, secrets.clone(), env);
     let mut resources = match loader.load(factory).await {
         Ok(r) => r,

--- a/runtime/src/start.rs
+++ b/runtime/src/start.rs
@@ -51,10 +51,9 @@ impl Args {
 pub async fn start(
     loader: impl Loader + Send + 'static,
     runner: impl Runner + Send + 'static,
+    #[cfg_attr(not(feature = "setup-telemetry"), allow(unused_variables))] crate_name: &'static str,
     #[cfg_attr(not(feature = "setup-telemetry"), allow(unused_variables))]
-    project_name: &'static str,
-    #[cfg_attr(not(feature = "setup-telemetry"), allow(unused_variables))]
-    project_version: &'static str,
+    package_version: &'static str,
 ) {
     // `--version` overrides any other arguments. Used by cargo-shuttle to check compatibility on local runs.
     if std::env::args().any(|arg| arg == "--version") {
@@ -62,7 +61,12 @@ pub async fn start(
         return;
     }
 
-    println!("{} starting", crate::VERSION_STRING);
+    println!(
+        "{} starting: {} {}",
+        crate::VERSION_STRING,
+        crate_name,
+        package_version
+    );
 
     let args = match Args::parse() {
         Ok(args) => args,
@@ -92,7 +96,7 @@ pub async fn start(
                         } else {
                             "info,shuttle=trace"
                         },
-                        project_name
+                        crate_name
                     ))
                 }),
             )
@@ -100,7 +104,7 @@ pub async fn start(
     }
 
     #[cfg(feature = "setup-telemetry")]
-    let _guard = crate::trace::init_tracing_subscriber(project_name, project_version);
+    let _guard = crate::trace::init_tracing_subscriber(crate_name, package_version);
 
     #[cfg(any(feature = "setup-tracing", feature = "setup-telemetry"))]
     if args.beta {

--- a/runtime/src/trace.rs
+++ b/runtime/src/trace.rs
@@ -17,7 +17,7 @@ use opentelemetry_sdk::{
     metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider, Temporality},
     propagation::TraceContextPropagator,
     runtime,
-    trace::{RandomIdGenerator, Sampler, TracerProvider},
+    trace::TracerProvider,
     Resource,
 };
 use opentelemetry_semantic_conventions::{
@@ -427,12 +427,13 @@ pub fn init_meter_provider(endpoint: &Option<String>, resource: Resource) -> Sdk
 // Construct TracerProvider for OpenTelemetryLayer
 pub fn init_tracer_provider(endpoint: &Option<String>, resource: Resource) -> TracerProvider {
     // TODO(the-wondersmith): make trace sample rate & strategy configurable
-    let sampler = Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(1.0)));
+    // let sampler = opentelemetry_sdk::trace::Sampler::ParentBased(Box::new(
+    //     opentelemetry_sdk::trace::Sampler::TraceIdRatioBased(1.0),
+    // ));
 
     let mut builder = TracerProvider::builder()
-        .with_sampler(sampler)
-        .with_resource(resource)
-        .with_id_generator(RandomIdGenerator::default());
+        // .with_sampler(sampler)
+        .with_resource(resource);
 
     if let Some(endpoint) = endpoint {
         let exporter = opentelemetry_otlp::SpanExporter::builder()

--- a/runtime/src/trace.rs
+++ b/runtime/src/trace.rs
@@ -1,0 +1,481 @@
+use opentelemetry::trace::{SpanId, TraceId};
+use opentelemetry::{
+    global,
+    logs::{LogRecord as OtelLogRecord, Logger as OtelLogger, LoggerProvider as _, Severity},
+    trace::TracerProvider as _,
+    KeyValue,
+};
+use opentelemetry_otlp::{
+    WithExportConfig, OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT,
+};
+use opentelemetry_sdk::{
+    logs::{LogRecord, Logger, LoggerProvider},
+    metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider, Temporality},
+    propagation::TraceContextPropagator,
+    runtime,
+    trace::{RandomIdGenerator, Sampler, TracerProvider},
+    Resource,
+};
+use opentelemetry_semantic_conventions::{
+    attribute::{
+        CODE_FILEPATH, CODE_LINENO, DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_NAME, SERVICE_VERSION,
+        TELEMETRY_SDK_LANGUAGE, TELEMETRY_SDK_NAME, TELEMETRY_SDK_VERSION,
+    },
+    SCHEMA_URL,
+};
+use std::time::SystemTime;
+use std::{collections::BTreeMap, marker::PhantomData, sync::Arc, time::Duration};
+use tracing::Event as TracingEvent;
+use tracing_core::{
+    span::{Attributes, Id, Record},
+    Field, Subscriber,
+};
+use tracing_log::AsLog;
+use tracing_opentelemetry::{MetricsLayer, OpenTelemetryLayer, OtelData};
+use tracing_subscriber::{
+    layer::{Context, SubscriberExt},
+    registry::LookupSpan,
+    util::SubscriberInitExt,
+    EnvFilter, Layer,
+};
+
+#[derive(Clone, Debug)]
+pub struct ProviderGuard {
+    logger: LoggerProvider,
+    tracer: TracerProvider,
+    meter: SdkMeterProvider,
+}
+
+impl Drop for ProviderGuard {
+    fn drop(&mut self) {
+        if let Err(error) = self.tracer.shutdown() {
+            tracing::error!(%error, "Failed to shutdown tracer provider gracefully");
+        }
+
+        if let Err(error) = self.meter.shutdown() {
+            tracing::error!(%error, "Failed to shutdown metrics provider gracefully");
+        }
+
+        if let Err(error) = self.logger.shutdown() {
+            eprintln!(
+                "ERROR - Failed to shutdown logger provider gracefully: {}",
+                error
+            );
+        }
+    }
+}
+
+trait SpanFieldVisitor {
+    fn visit(&mut self, key: &'static str, value: opentelemetry::logs::AnyValue);
+}
+
+macro_rules! impl_visit {
+    ($t:ty) => {
+        impl tracing::field::Visit for $t {
+            #[inline(always)]
+            fn record_f64(&mut self, field: &Field, value: f64) {
+                <Self as SpanFieldVisitor>::visit(self, field.name(), value.into());
+            }
+
+            #[inline(always)]
+            fn record_i64(&mut self, field: &Field, value: i64) {
+                <Self as SpanFieldVisitor>::visit(self, field.name(), value.into());
+            }
+
+            #[inline(always)]
+            fn record_u64(&mut self, field: &Field, value: u64) {
+                match i64::try_from(value) {
+                    Ok(value) => self.record_i64(field, value),
+                    Err(_) => <Self as SpanFieldVisitor>::visit(
+                        self,
+                        field.name(),
+                        value.to_string().into(),
+                    ),
+                }
+            }
+
+            #[inline(always)]
+            fn record_i128(&mut self, field: &Field, value: i128) {
+                match i64::try_from(value) {
+                    Ok(value) => self.record_i64(field, value),
+                    Err(_) => <Self as SpanFieldVisitor>::visit(
+                        self,
+                        field.name(),
+                        value.to_string().into(),
+                    ),
+                }
+            }
+
+            #[inline(always)]
+            fn record_u128(&mut self, field: &Field, value: u128) {
+                match i64::try_from(value) {
+                    Ok(value) => self.record_i64(field, value),
+                    Err(_) => <Self as SpanFieldVisitor>::visit(
+                        self,
+                        field.name(),
+                        value.to_string().into(),
+                    ),
+                }
+            }
+
+            #[inline(always)]
+            fn record_bool(&mut self, field: &Field, value: bool) {
+                <Self as SpanFieldVisitor>::visit(self, field.name(), value.into());
+            }
+
+            #[inline(always)]
+            fn record_str(&mut self, field: &Field, value: &str) {
+                <Self as SpanFieldVisitor>::visit(self, field.name(), value.to_string().into());
+            }
+
+            #[inline(always)]
+            fn record_bytes(&mut self, field: &Field, value: &[u8]) {
+                <Self as SpanFieldVisitor>::visit(
+                    self,
+                    field.name(),
+                    opentelemetry::logs::AnyValue::Bytes(Box::new(value.to_vec())),
+                );
+            }
+
+            #[inline(always)]
+            fn record_error(&mut self, field: &Field, value: &(dyn 'static + std::error::Error)) {
+                <Self as SpanFieldVisitor>::visit(self, field.name(), value.to_string().into());
+            }
+
+            #[inline(always)]
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                <Self as SpanFieldVisitor>::visit(
+                    self,
+                    field.name(),
+                    format!("{:?}", value).into(),
+                );
+            }
+        }
+    };
+}
+
+#[derive(Clone, Debug, Default)]
+struct SpanFieldValues(BTreeMap<opentelemetry::Key, opentelemetry::logs::AnyValue>);
+
+impl SpanFieldVisitor for SpanFieldValues {
+    fn visit(&mut self, key: &'static str, value: opentelemetry::logs::AnyValue) {
+        self.0.insert(key.into(), value);
+    }
+}
+
+impl_visit!(SpanFieldValues);
+
+#[derive(Clone, Debug, Default)]
+struct EventFieldValues {
+    data: SpanFieldValues,
+    message: Option<opentelemetry::logs::AnyValue>,
+}
+
+impl EventFieldValues {
+    const REMAPPED_FIELDS: [(&'static str, &'static str); 4] = [
+        ("log.line", CODE_LINENO),
+        ("log.file", CODE_FILEPATH),
+        ("log.target", "code.target"),
+        ("log.module_path", "code.module_path"),
+    ];
+}
+
+impl SpanFieldVisitor for EventFieldValues {
+    fn visit(&mut self, key: &'static str, value: opentelemetry::logs::AnyValue) {
+        // this block can be uncommented to filter out "empty" log events if needed, (i.e. events that have
+        // attributes, but don't have an actual "message", e.x. events emitted by `#[tracing::instrument(ret)]`)
+        // match &value {
+        //     opentelemetry::logs::AnyValue::String(inner) if inner.as_str().trim().is_empty() => {
+        //         return;
+        //     }
+        //     _ => {}
+        // };
+
+        if key == "message"
+            && (self.message.is_none()
+                || matches!(
+                    &self.message,
+                    Some(opentelemetry::logs::AnyValue::String(inner)) if inner.as_str().trim().is_empty(),
+                ))
+        {
+            self.message = Some(value);
+            return;
+        }
+
+        let key = Self::REMAPPED_FIELDS
+            .iter()
+            .find_map(|(bad_key, replacement)| {
+                if key == *bad_key {
+                    Some(*replacement)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(key);
+
+        self.data.0.insert(key.into(), value);
+    }
+}
+
+impl_visit!(EventFieldValues);
+
+#[derive(Clone, Debug)]
+pub struct LogCourier<S> {
+    logger: Arc<Logger>,
+    marker: PhantomData<S>,
+}
+
+impl<S> LogCourier<S> {
+    pub fn new(logger: Logger) -> Self {
+        Self {
+            logger: Arc::new(logger),
+            marker: Default::default(),
+        }
+    }
+}
+
+impl<S> Layer<S> for LogCourier<S>
+where
+    S: Subscriber + std::fmt::Debug + for<'span> LookupSpan<'span>,
+    for<'span> <S as LookupSpan<'span>>::Data: std::fmt::Debug,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        let fields = match extensions.get_mut::<SpanFieldValues>() {
+            Some(fields) => fields,
+            None => {
+                extensions.insert(SpanFieldValues::default());
+                extensions.get_mut::<SpanFieldValues>().unwrap()
+            }
+        };
+
+        attrs.record(fields);
+    }
+
+    fn on_record(&self, span: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let span = ctx.span(span).expect("Span not found, this is a bug");
+        let mut extensions = span.extensions_mut();
+
+        let fields = match extensions.get_mut::<SpanFieldValues>() {
+            Some(fields) => fields,
+            None => {
+                extensions.insert(SpanFieldValues::default());
+                extensions.get_mut::<SpanFieldValues>().unwrap()
+            }
+        };
+
+        values.record(fields);
+    }
+
+    fn on_event(&self, event: &TracingEvent<'_>, ctx: Context<'_, S>) {
+        let (metadata, mut record, mut attributes) = (
+            event.metadata(),
+            LogRecord::default(),
+            EventFieldValues::default(),
+        );
+
+        event.record(&mut attributes);
+
+        let (mut attributes, Some(message)) = (attributes.data, attributes.message) else {
+            return;
+        };
+
+        record.set_body(message);
+        record.set_target(metadata.target());
+        record.set_event_name(metadata.name());
+        record.set_timestamp(SystemTime::now());
+        record.set_severity_text(metadata.level().as_str());
+        record.set_severity_number(log_level_as_severity(metadata.level().as_log()));
+
+        if let Some((trace_id, span_id)) = ctx
+            .event_span(event)
+            .or_else(|| ctx.lookup_current())
+            .and_then(|span| {
+                span.extensions_mut()
+                    .get_mut::<OtelData>()
+                    .and_then(|data| {
+                        data.builder
+                            .trace_id
+                            .or(Some(TraceId::INVALID))
+                            .zip(data.builder.span_id.or(Some(SpanId::INVALID)))
+                    })
+            })
+        {
+            record.set_trace_context(trace_id, span_id, None);
+        }
+
+        attributes.0.extend(
+            ctx.event_scope(event)
+                .into_iter()
+                .flatten()
+                .flat_map(
+                    |span| match span.extensions_mut().get_mut::<SpanFieldValues>() {
+                        Some(values) if !values.0.is_empty() => Some(values.clone().0.into_iter()),
+                        _ => None,
+                    },
+                )
+                .flatten()
+                .chain(
+                    [
+                        metadata.file().map(|file| {
+                            (
+                                opentelemetry::Key::from(CODE_FILEPATH),
+                                opentelemetry::logs::AnyValue::from(file.to_string()),
+                            )
+                        }),
+                        metadata.line().map(|line| {
+                            (
+                                opentelemetry::Key::from(CODE_LINENO),
+                                opentelemetry::logs::AnyValue::from(line),
+                            )
+                        }),
+                        metadata.module_path().map(|path| {
+                            (
+                                opentelemetry::Key::from("code.module_path"),
+                                opentelemetry::logs::AnyValue::from(path.to_string()),
+                            )
+                        }),
+                    ]
+                    .into_iter()
+                    .flatten(),
+                ),
+        );
+
+        record.add_attributes(attributes.0);
+
+        self.logger.emit(record)
+    }
+}
+
+/// Convert a [`log::Level`] to its equivalent [`Severity`]
+#[inline(always)]
+pub(crate) fn log_level_as_severity(level: log::Level) -> Severity {
+    match level {
+        log::Level::Info => Severity::Info,
+        log::Level::Warn => Severity::Warn,
+        log::Level::Debug => Severity::Debug,
+        log::Level::Trace => Severity::Trace,
+        log::Level::Error => Severity::Error,
+    }
+}
+
+// Create a Resource that captures information about the entity for which telemetry is recorded.
+pub fn resource(project_name: &'static str, project_version: &'static str) -> Resource {
+    Resource::from_schema_url(
+        [
+            Some(KeyValue::new(SERVICE_NAME, project_name)),
+            Some(KeyValue::new(SERVICE_VERSION, project_version)),
+            Some(KeyValue::new(TELEMETRY_SDK_NAME, "opentelemetry")),
+            Some(KeyValue::new(TELEMETRY_SDK_VERSION, "0.27.1")),
+            Some(KeyValue::new(TELEMETRY_SDK_LANGUAGE, "rust")),
+            std::env::var("SHUTTLE_ENV")
+                .ok()
+                .map(|value| KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, value)),
+        ]
+        .into_iter()
+        .flatten(),
+        SCHEMA_URL,
+    )
+}
+
+pub fn init_log_subscriber(endpoint: &str, resource: Resource) -> LoggerProvider {
+    let exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_http()
+        .with_endpoint(format!("{endpoint}/v1/logs"))
+        .build()
+        .unwrap();
+
+    LoggerProvider::builder()
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .with_resource(resource)
+        .build()
+}
+
+// Construct MeterProvider for MetricsLayer
+pub fn init_meter_provider(endpoint: &str, resource: Resource) -> SdkMeterProvider {
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_temporality(Temporality::default())
+        .with_http()
+        .with_endpoint(format!("{endpoint}/v1/metrics"))
+        .build()
+        .unwrap();
+
+    let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+        .with_interval(Duration::from_secs(30)) // TODO(the-wondersmith): make metrics read period configurable
+        .build();
+
+    let provider = MeterProviderBuilder::default()
+        .with_resource(resource)
+        .with_reader(reader)
+        .build();
+
+    global::set_meter_provider(provider.clone());
+
+    provider
+}
+
+// Construct TracerProvider for OpenTelemetryLayer
+pub fn init_tracer_provider(endpoint: &str, resource: Resource) -> TracerProvider {
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_http()
+        .with_endpoint(format!("{endpoint}/v1/traces"))
+        .build()
+        .unwrap();
+
+    let provider = TracerProvider::builder()
+        // Customize sampling strategy
+        .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+            1.0, // TODO(the-wondersmith): make trace sample rate configurable
+        ))))
+        .with_id_generator(RandomIdGenerator::default())
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .with_resource(resource)
+        .build();
+
+    global::set_tracer_provider(provider.clone());
+
+    provider
+}
+
+// Initialize tracing-subscriber and return ExporterGuard for opentelemetry-related termination processing
+pub fn init_tracing_subscriber(
+    project_name: &'static str,
+    project_version: &'static str,
+) -> ProviderGuard {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let resource = resource(project_name, project_version);
+
+    // The OTLP_HOST env var is useful for setting a specific host when running locally
+    let endpoint = std::env::var(OTEL_EXPORTER_OTLP_ENDPOINT)
+        .unwrap_or(OTEL_EXPORTER_OTLP_ENDPOINT_DEFAULT.into());
+
+    let tracer = init_tracer_provider(&endpoint, resource.clone());
+    let meter = init_meter_provider(&endpoint, resource.clone());
+
+    let level_filter =
+        std::env::var("RUST_LOG").unwrap_or_else(|_| format!("info,{}=debug", project_name));
+
+    let logger = init_log_subscriber(&endpoint, resource);
+
+    let layers = EnvFilter::from(&level_filter)
+        .and_then(MetricsLayer::new(meter.clone()))
+        .and_then(OpenTelemetryLayer::new(tracer.tracer("shuttle-telemetry")))
+        .and_then(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_level(true)
+                .with_target(true),
+        )
+        .and_then(LogCourier::new(logger.logger("shuttle-telemetry")));
+
+    tracing_subscriber::registry().with(layers).init();
+
+    ProviderGuard {
+        logger,
+        tracer,
+        meter,
+    }
+}


### PR DESCRIPTION
## Description of change
PR expands on the existing `tracing` setup/configuration feature in `shuttle-runtime`, adding an enhanced subscriber that includes an [OpenTelemetry](https://crates.io/crates/tracing-opentelemetry) layer and enables exporting all telemetry data (traces, metrics, and logs) generated by a Shuttle project to any compatible OTLP collector.

The new behavior is gated behind a new `setup-telemetry` feature flag.

> [!IMPORTANT]
> PR changes the default `RUST_LOG` configuration from `info` to `info,{crate_name}=debug`

