### PR TITLE
chore: use `TelemetryResourceDetector` for telemetry sdk values when creating default resource

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -31,9 +31,7 @@ opentelemetry-otlp = { version = "0.27.0", optional = true, default-features = f
     "reqwest-client",
     "trace",
 ] }
-# NOTE: If the version of `opentelemetry_sdk` is changed/updated, remember up update the
-# `telemetry.sdk.version` value in `src/trace.rs:373`
-opentelemetry_sdk = { version = "=0.27.1", optional = true, default-features = false, features = [
+opentelemetry_sdk = { version = "0.27.0", optional = true, default-features = false, features = [
     "http",
     "logs",
     "metrics",


### PR DESCRIPTION
PR removes the need to manually keep pinned version of `opentelemetry-sdk` in sync with static string value in `runtime/src/telemetry.rs`

> **Credit:** [lalitb](https://github.com/lalitb)'s suggestion [here](https://github.com/open-telemetry/opentelemetry-rust/pull/2504#discussion_r1936042877)

