### PR TITLE
feat: telemetry debugging variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -457,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.13"
+version = "1.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
+checksum = "0c3d1b2e905a3a7b00a6141adb0e4c0bb941d11caf55349d863942a1cc44e3c9"
 dependencies = [
  "jobserver",
  "libc",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.44"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+checksum = "1e3040c8291884ddf39445dc033c70abc2bc44a42f0a3a00571a0f483a83f0cd"
 dependencies = [
  "clap",
 ]
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1884,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2788,7 +2788,7 @@ dependencies = [
  "http",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -2905,7 +2905,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2920,7 +2920,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3059,7 +3059,7 @@ checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
  "getrandom 0.2.15",
- "rand",
+ "rand 0.8.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3073,9 +3073,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3101,8 +3101,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.1",
+ "zerocopy 0.8.19",
 ]
 
 [[package]]
@@ -3112,7 +3123,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.1",
 ]
 
 [[package]]
@@ -3122,6 +3143,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.19",
 ]
 
 [[package]]
@@ -3271,15 +3302,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "e75ec5e92c4d8aede845126adc388046234541629e76029599ed35a003c7ed24"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3721,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -3734,12 +3764,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3853,9 +3877,9 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4038,9 +4062,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4bf6fecd69fcdede0ec680aaf474cdab988f9de6bc73d3758f0160e3b7025a"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -4262,17 +4286,16 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413083a99c579593656008130e29255e54dcaae495be556cc26888f211648c24"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.0",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -4282,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "typeshare"
@@ -4316,9 +4339,9 @@ checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
 
 [[package]]
 name = "unicode-normalization"
@@ -4855,7 +4878,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207f485579465f62ae51a983e42c906736a17efd2de48b021e64f1bbd8e98c7"
+dependencies = [
+ "zerocopy-derive 0.8.19",
 ]
 
 [[package]]
@@ -4863,6 +4895,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dbe1304a711c6eb4cf1ed333aa0d9b344685e71f6f00c3b176072213bd3783e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4952,7 +4995,7 @@ dependencies = [
  "lzma-rs",
  "memchr",
  "pbkdf2",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 2.0.11",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,6 +2961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3174,6 +3189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,6 +3291,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88f8660c1ff60292143c98d08fc6e2f654d722db50410e3f3797d40baaf9d8f3"
 
 [[package]]
+name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,6 +3331,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3562,6 +3622,7 @@ dependencies = [
  "comfy-table",
  "crossterm",
  "http",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -3706,18 +3767,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 resolver = "2"
 members = [
-  "admin",
-  "api-client",
-  "cargo-shuttle",
-  "codegen",
-  "common",
-  "runtime",
-  "service",
+    "admin",
+    "api-client",
+    "cargo-shuttle",
+    "codegen",
+    "common",
+    "runtime",
+    "service",
 ]
 exclude = ["examples", "resources", "services"]
 
@@ -59,7 +59,7 @@ proc-macro2 = "1.0.89"
 quote = "1.0.21"
 regex = "1.9.5"
 reqwest = { version = "0.12.12", default-features = false, features = [
-  "rustls-tls",
+    "rustls-tls",
 ] }
 reqwest-middleware = "0.4.0"
 rexpect = "0.6.0"
@@ -67,20 +67,20 @@ semver = { version = "1.0.17", features = ["serde"] }
 serde = { version = "1.0.148", default-features = false }
 serde_json = "1.0.89"
 strfmt = "0.2.2"
-strum = { version = "0.26.1", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 syn = "2.0"
 tempfile = "3.4.0"
 thiserror = "2"
 tokio = "1.40.0"
 tokio-tungstenite = { version = "0.26.1", features = [
-  "rustls-tls-webpki-roots",
+    "rustls-tls-webpki-roots",
 ] }
 toml = "0.8.2"
 toml_edit = "0.22.22"
 tracing = { version = "0.1.37", default-features = false }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
-  "registry",
-  "json",
+    "registry",
+    "json",
 ] }
 trybuild = "1.0.72"
 typeshare = "1.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [workspace]
 resolver = "2"
 members = [
-    "admin",
-    "api-client",
-    "cargo-shuttle",
-    "codegen",
-    "common",
-    "runtime",
-    "service",
+  "admin",
+  "api-client",
+  "cargo-shuttle",
+  "codegen",
+  "common",
+  "runtime",
+  "service",
 ]
 exclude = ["examples", "resources", "services"]
 
@@ -59,7 +59,7 @@ proc-macro2 = "1.0.89"
 quote = "1.0.21"
 regex = "1.9.5"
 reqwest = { version = "0.12.12", default-features = false, features = [
-    "rustls-tls",
+  "rustls-tls",
 ] }
 reqwest-middleware = "0.4.0"
 rexpect = "0.6.0"
@@ -73,14 +73,14 @@ tempfile = "3.4.0"
 thiserror = "2"
 tokio = "1.40.0"
 tokio-tungstenite = { version = "0.26.1", features = [
-    "rustls-tls-webpki-roots",
+  "rustls-tls-webpki-roots",
 ] }
 toml = "0.8.2"
 toml_edit = "0.22.22"
 tracing = { version = "0.1.37", default-features = false }
 tracing-subscriber = { version = "0.3.16", default-features = false, features = [
-    "registry",
-    "json",
+  "registry",
+  "json",
 ] }
 trybuild = "1.0.72"
 typeshare = "1.0.3"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,6 +23,9 @@ tracing = { workspace = true, features = ["std"], optional = true }
 typeshare = { workspace = true }
 zeroize = { workspace = true }
 
+[dev-dependencies]
+rstest = "0.24.0"
+
 [features]
 # main features
 models = ["chrono/serde", "dep:tracing"]

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -41,7 +41,7 @@ impl DeploymentState {
             Self::Unknown => Color::Grey,
         }
     }
-    #[cfg(feature = "display")]
+    #[cfg(all(feature = "tables", feature = "display"))]
     pub fn get_color_comfy_table(&self) -> comfy_table::Color {
         use comfy_table::Color;
 

--- a/common/src/models/log.rs
+++ b/common/src/models/log.rs
@@ -47,43 +47,39 @@ pub struct LogsResponse {
 
 #[cfg(test)]
 mod tests {
+    #[cfg_attr(not(feature = "display"), allow(unused_imports))]
     use super::*;
 
     // Chrono uses std Time (to libc) internally, if you want to use this method
     // in more than one test, you need to handle async tests properly.
+    #[cfg(feature = "display")]
     fn with_tz<F: FnOnce()>(tz: &str, f: F) {
-        let prev_tz = std::env::var("TZ").unwrap_or("".to_string());
+        let prev_tz = std::env::var("TZ").unwrap_or_default();
         std::env::set_var("TZ", tz);
         f();
         std::env::set_var("TZ", prev_tz);
     }
 
-    #[test]
-    fn test_timezone_formatting() {
+    #[cfg(feature = "display")]
+    #[rstest::rstest]
+    #[case::utc("utc")]
+    #[case::cest("cest")]
+    fn test_timezone_formatting(#[case] tz: &str) {
         let item = LogItem::new(
             Utc::now(),
             "test".to_string(),
             r#"{"message": "Building"}"#.to_owned(),
         );
 
-        with_tz("CEST", || {
-            let cest_dt = item
+        with_tz(tz, || {
+            let value = item
                 .timestamp
                 .with_timezone(&chrono::Local)
                 .to_rfc3339_opts(chrono::SecondsFormat::Millis, false);
+
             let log_line = format!("{}", &item);
 
-            assert!(log_line.contains(&cest_dt));
-        });
-
-        with_tz("UTC", || {
-            let utc_dt = item
-                .timestamp
-                .with_timezone(&chrono::Local)
-                .to_rfc3339_opts(chrono::SecondsFormat::Millis, false);
-            let log_line = format!("{}", &item);
-
-            assert!(log_line.contains(&utc_dt));
+            assert!(log_line.contains(&value));
         });
     }
 }

--- a/common/src/models/telemetry.rs
+++ b/common/src/models/telemetry.rs
@@ -1,4 +1,10 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
+
+const fn default_betterstack_host() -> Cow<'static, str> {
+    Cow::Borrowed("in-otel.logs.betterstack.com")
+}
 
 /// Status of a telemetry export configuration for an external sink
 #[derive(Eq, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -23,6 +29,7 @@ impl From<Vec<TelemetrySinkConfig>> for TelemetryConfigResponse {
 
         for sink in value {
             match sink {
+                TelemetrySinkConfig::Debug(_) => {}
                 TelemetrySinkConfig::Betterstack(_) => {
                     instance.betterstack = Some(TelemetrySinkStatus { enabled: true })
                 }
@@ -53,19 +60,31 @@ impl From<Vec<TelemetrySinkConfig>> for TelemetryConfigResponse {
     strum::EnumDiscriminants,
 )]
 #[cfg_attr(feature = "integration-tests", derive(Debug))]
+#[cfg_attr(any(test, feature = "integration-tests"), derive(strum::EnumIter))]
 #[serde(tag = "type", content = "content", rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
 #[typeshare::typeshare]
+#[cfg_attr(
+    any(test, feature = "integration-tests"),
+    strum_discriminants(derive(strum::EnumIter))
+)]
 #[strum_discriminants(derive(Serialize, Deserialize, strum::AsRefStr))]
 #[strum_discriminants(serde(rename_all = "snake_case"))]
 #[strum_discriminants(strum(serialize_all = "snake_case"))]
 pub enum TelemetrySinkConfig {
     /// [Betterstack](https://betterstack.com/docs/logs/open-telemetry/)
     Betterstack(BetterstackConfig),
+
     /// [Datadog](https://docs.datadoghq.com/opentelemetry/collector_exporter/otel_collector_datadog_exporter)
     Datadog(DatadogConfig),
+
     /// [Grafana Cloud](https://grafana.com/docs/grafana-cloud/send-data/otlp/)
     GrafanaCloud(GrafanaCloudConfig),
+
+    /// Internal Debugging
+    #[doc(hidden)]
+    #[strum_discriminants(doc(hidden))]
+    Debug(serde_json::Value),
 }
 
 impl TelemetrySinkConfig {
@@ -85,18 +104,36 @@ impl TelemetrySinkConfigDiscriminants {
 #[typeshare::typeshare]
 pub struct BetterstackConfig {
     #[serde(default = "default_betterstack_host")]
-    pub ingesting_host: String,
+    pub ingesting_host: Cow<'static, str>,
     pub source_token: String,
 }
-fn default_betterstack_host() -> String {
-    "in-otel.logs.betterstack.com".to_owned()
+
+#[cfg(any(test, feature = "integration-tests"))]
+impl Default for BetterstackConfig {
+    fn default() -> Self {
+        Self {
+            source_token: "some-source-token".into(),
+            ingesting_host: default_betterstack_host(),
+        }
+    }
 }
+
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "integration-tests", derive(Debug))]
 #[typeshare::typeshare]
 pub struct DatadogConfig {
     pub api_key: String,
 }
+
+#[cfg(any(test, feature = "integration-tests"))]
+impl Default for DatadogConfig {
+    fn default() -> Self {
+        Self {
+            api_key: "some-api-key".into(),
+        }
+    }
+}
+
 #[derive(Eq, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "integration-tests", derive(Debug))]
 #[typeshare::typeshare]
@@ -104,6 +141,17 @@ pub struct GrafanaCloudConfig {
     pub token: String,
     pub endpoint: String,
     pub instance_id: String,
+}
+
+#[cfg(any(test, feature = "integration-tests"))]
+impl Default for GrafanaCloudConfig {
+    fn default() -> Self {
+        Self {
+            token: "some-auth-token".into(),
+            instance_id: String::from("0000000"),
+            endpoint: "https://prometheus-env-id-env-region.grafana.net/api/prom/push".into(),
+        }
+    }
 }
 
 #[cfg(feature = "integration-tests")]
@@ -174,38 +222,58 @@ mod tests {
 
     #[test]
     fn sink_config_enum() {
-        assert_eq!(
-            "betterstack",
-            TelemetrySinkConfig::Betterstack(BetterstackConfig {
-                ingesting_host: "".into(),
-                source_token: "".into()
-            })
-            .as_ref()
-        );
-        assert_eq!(
-            "project::telemetry::betterstack::config",
-            TelemetrySinkConfig::Betterstack(BetterstackConfig {
-                ingesting_host: "".into(),
-                source_token: "".into()
-            })
-            .as_db_type()
-        );
+        for variant in <TelemetrySinkConfig as strum::IntoEnumIterator>::iter() {
+            match variant {
+                sink @ TelemetrySinkConfig::Betterstack(_) => {
+                    assert_eq!("betterstack", sink.as_ref());
+                    assert_eq!("project::telemetry::betterstack::config", sink.as_db_type());
+                }
+                sink @ TelemetrySinkConfig::Datadog(_) => {
+                    assert_eq!("datadog", sink.as_ref());
+                    assert_eq!("project::telemetry::datadog::config", sink.as_db_type());
+                }
+                sink @ TelemetrySinkConfig::GrafanaCloud(_) => {
+                    assert_eq!("grafana_cloud", sink.as_ref());
+                    assert_eq!(
+                        "project::telemetry::grafana_cloud::config",
+                        sink.as_db_type()
+                    );
+                }
+                sink @ TelemetrySinkConfig::Debug(_) => {
+                    assert_eq!("debug", sink.as_ref());
+                    assert_eq!("project::telemetry::debug::config", sink.as_db_type());
+                }
+            }
+        }
 
-        assert_eq!(
-            "betterstack",
-            TelemetrySinkConfigDiscriminants::Betterstack.as_ref()
-        );
-        assert_eq!(
-            "grafana_cloud",
-            TelemetrySinkConfigDiscriminants::GrafanaCloud.as_ref()
-        );
-        assert_eq!(
-            "\"betterstack\"",
-            serde_json::to_string(&TelemetrySinkConfigDiscriminants::Betterstack).unwrap()
-        );
-        assert_eq!(
-            "\"grafana_cloud\"",
-            serde_json::to_string(&TelemetrySinkConfigDiscriminants::GrafanaCloud).unwrap()
-        );
+        for variant in <TelemetrySinkConfigDiscriminants as strum::IntoEnumIterator>::iter() {
+            match variant {
+                discriminant @ TelemetrySinkConfigDiscriminants::Betterstack => {
+                    assert_eq!("betterstack", discriminant.as_ref());
+                    assert_eq!(
+                        r#""betterstack""#,
+                        serde_json::to_string(&discriminant).unwrap()
+                    );
+                }
+                discriminant @ TelemetrySinkConfigDiscriminants::Datadog => {
+                    assert_eq!("datadog", discriminant.as_ref());
+                    assert_eq!(
+                        r#""datadog""#,
+                        serde_json::to_string(&discriminant).unwrap()
+                    );
+                }
+                discriminant @ TelemetrySinkConfigDiscriminants::GrafanaCloud => {
+                    assert_eq!("grafana_cloud", discriminant.as_ref());
+                    assert_eq!(
+                        r#""grafana_cloud""#,
+                        serde_json::to_string(&discriminant).unwrap()
+                    );
+                }
+                discriminant @ TelemetrySinkConfigDiscriminants::Debug => {
+                    assert_eq!("debug", discriminant.as_ref());
+                    assert_eq!(r#""debug""#, serde_json::to_string(&discriminant).unwrap());
+                }
+            }
+        }
     }
 }

--- a/common/src/models/telemetry.rs
+++ b/common/src/models/telemetry.rs
@@ -83,6 +83,7 @@ pub enum TelemetrySinkConfig {
 
     /// Internal Debugging
     #[doc(hidden)]
+    #[typeshare(skip)]
     #[strum_discriminants(doc(hidden))]
     Debug(serde_json::Value),
 }


### PR DESCRIPTION
## Description of change
PR adds a `Debug` variant of the `TelemetrySinkConfig` enum for internal use in developing, testing, and debugging generated configurations for user telemetry data export.


