### PR TITLE
build(shared-db): upgrade diesel-async to v0.5.2

### DIFF
--- a/resources/shared-db/Cargo.toml
+++ b/resources/shared-db/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["shuttle-service", "database"]
 
 [dependencies]
 async-trait = "0.1.56"
-diesel-async = { version = "0.4.1", optional = true }
+diesel-async = { version = "0.5.2", optional = true }
 opendal = { version = "0.51", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Upgrades `shuttle-shared-db`'s dependency on `diesel-async` from v0.4.1 to v0.5.2.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Clippy gives no warnings, compilation is successful.
