### PR TITLE
Update async-openai to 0.28.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "examples"]
-	path = examples
-	url = ../shuttle-examples.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "examples"]
+	path = examples
+	url = ../shuttle-examples.git

--- a/resources/openai/Cargo.toml
+++ b/resources/openai/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/shuttle-hq/shuttle"
 keywords = ["shuttle-service", "openai"]
 
 [dependencies]
-async-openai = "0.23.0"
+async-openai = "0.28.0"
 async-trait = "0.1.56"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Description of change
Update async-openai to 0.28.0
The async-openai upstream version has more Voices available in the text to speech api.
https://platform.openai.com/docs/guides/text-to-speech


## How has this been tested? (if applicable)
Locally on my branch.


