### PR TITLE
feat(cargo-shuttle): use api-provided console url on login if available

### DIFF
--- a/admin/src/args.rs
+++ b/admin/src/args.rs
@@ -1,10 +1,10 @@
 use clap::{Parser, Subcommand};
-use shuttle_common::{constants::API_URL_DEFAULT_BETA, models::project::ComputeTier};
+use shuttle_common::{constants::SHUTTLE_API_URL, models::project::ComputeTier};
 
 #[derive(Parser, Debug)]
 pub struct Args {
     /// run this command against the api at the supplied url
-    #[arg(long, default_value = API_URL_DEFAULT_BETA, env = "SHUTTLE_API")]
+    #[arg(long, env = "SHUTTLE_API", default_value = SHUTTLE_API_URL)]
     pub api_url: String,
 
     #[command(subcommand)]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -12,10 +12,7 @@ use clap::{
     Args, Parser, Subcommand, ValueEnum,
 };
 use clap_complete::Shell;
-use shuttle_common::{
-    constants::{EXAMPLES_REPO, SHUTTLE_CONSOLE_URL},
-    models::resource::ResourceType,
-};
+use shuttle_common::{constants::EXAMPLES_REPO, models::resource::ResourceType};
 
 #[derive(Parser)]
 #[command(

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -300,8 +300,8 @@ pub struct LoginArgs {
     #[arg(long)]
     pub api_key: Option<String>,
     /// URL to the Shuttle Console for automatic login
-    #[arg(long, env = "SHUTTLE_CONSOLE", default_value = SHUTTLE_CONSOLE_URL, hide_default_value = true)]
-    pub console_url: String,
+    #[arg(long, env = "SHUTTLE_CONSOLE", hide = true)]
+    pub console_url: Option<String>,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
-use shuttle_common::constants::API_URL_DEFAULT_BETA;
+use shuttle_common::constants::SHUTTLE_API_URL;
 use tracing::trace;
 
 use crate::args::ProjectArgs;
@@ -422,7 +422,7 @@ impl RequestContext {
         } else if let Some(api_url) = self.global.as_ref().unwrap().api_url() {
             api_url
         } else {
-            API_URL_DEFAULT_BETA.to_string()
+            SHUTTLE_API_URL.to_string()
         }
     }
 

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -4,7 +4,7 @@
 pub const STORAGE_DIRNAME: &str = ".shuttle-storage";
 
 // URLs
-pub const API_URL_DEFAULT_BETA: &str = "https://api.shuttle.dev";
+pub const SHUTTLE_API_URL: &str = "https://api.shuttle.dev";
 pub const SHUTTLE_CONSOLE_URL: &str = "https://console.shuttle.dev";
 
 pub const SHUTTLE_INSTALL_DOCS_URL: &str = "https://docs.shuttle.dev/getting-started/installation";

--- a/common/src/models/auth.rs
+++ b/common/src/models/auth.rs
@@ -2,7 +2,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize)]
 pub struct TokenMessage {
+    /// The token of this sign in request
     pub token: String,
+    /// The Console URL where this token can be authorized
+    pub url: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]


### PR DESCRIPTION
Forward compatible change to move console url logic to the api

Also renamed a constant