### PR TITLE
feat: Add client capability to set replicas

### DIFF
--- a/admin/src/args.rs
+++ b/admin/src/args.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use shuttle_common::{constants::SHUTTLE_API_URL, models::project::ComputeTier};
+use shuttle_common::constants::SHUTTLE_API_URL;
 
 #[derive(Parser, Debug)]
 pub struct Args {
@@ -22,13 +22,13 @@ pub enum Command {
         new_user_id: String,
     },
 
-    UpdateCompute {
+    UpdateProjectConfig {
         /// Project to update
         #[arg(long, visible_alias = "id")]
         project_id: String,
-        /// Compute tier to set.
-        #[arg(long, visible_alias = "tier")]
-        compute_tier: ComputeTier,
+        /// Project configuration as JSON
+        #[arg(long, visible_alias = "config")]
+        json: String,
     },
 
     /// Renew all old custom domain certificates

--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use serde_json::{json, Value};
 use shuttle_api_client::ShuttleApiClient;
 use shuttle_common::models::{
-    project::{ComputeTier, ProjectResponse, ProjectUpdateRequest},
+    project::{ProjectResponse, ProjectUpdateRequest},
     user::UserResponse,
 };
 
@@ -30,16 +30,16 @@ impl Client {
             .await
     }
 
-    pub async fn update_project_compute_tier(
+    pub async fn update_project_config(
         &self,
         project_id: &str,
-        compute_tier: ComputeTier,
+        config: serde_json::Value,
     ) -> Result<ProjectResponse> {
         self.inner
             .put_json(
                 format!("/projects/{project_id}"),
                 Some(ProjectUpdateRequest {
-                    compute_tier: Some(compute_tier),
+                    config: Some(config),
                     ..Default::default()
                 }),
             )

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -31,12 +31,9 @@ pub async fn run(args: Args) {
                 tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
             }
         }
-        Command::UpdateCompute {
-            project_id,
-            compute_tier,
-        } => {
+        Command::UpdateProjectConfig { project_id, json } => {
             let res = client
-                .update_project_compute_tier(&project_id, compute_tier)
+                .update_project_config(&project_id, serde_json::from_str(&json).unwrap())
                 .await
                 .unwrap();
             println!("{res:?}");

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -17,7 +17,7 @@ crossterm = { workspace = true, optional = true }
 http = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive", "std"] }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
 strum = { workspace = true, features = ["derive"] }
 tracing = { workspace = true, features = ["std"], optional = true }
 typeshare = { workspace = true }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -73,7 +73,7 @@ pub struct ProjectListResponse {
 }
 
 /// Set wanted field(s) to Some to update those parts of the project
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[typeshare::typeshare]
 pub struct ProjectUpdateRequest {
@@ -85,8 +85,8 @@ pub struct ProjectUpdateRequest {
     pub team_id: Option<String>,
     /// Transfer away from current team
     pub remove_from_team: Option<bool>,
-    /// Change compute tier
-    pub compute_tier: Option<ComputeTier>,
+    /// Project runtime configuration
+    pub config: Option<serde_json::Value>,
 }
 
 #[derive(

--- a/common/types.ts
+++ b/common/types.ts
@@ -205,8 +205,8 @@ export interface ProjectUpdateRequest {
 	team_id?: string;
 	/** Transfer away from current team */
 	remove_from_team?: boolean;
-	/** Change compute tier */
-	compute_tier?: ComputeTier;
+	/** Project runtime configuration */
+	config?: any;
 }
 
 export enum ResourceType {


### PR DESCRIPTION
## Description of change
Remove the update compute_tier functionality, replace with a freeform runtime configuration admin functionality.


## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


