### PR TITLE
wip: feat(runtime): expose otel tracing layer under otel-exporter flag

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -62,7 +62,7 @@ setup-tracing = [
     "tracing-subscriber/std",
     "tracing-subscriber/tracing-log",
 ]
-setup-otel-exporter = [
+otel-exporter = [
     "setup-tracing",
     "dep:log",
     "dep:opentelemetry",
@@ -78,3 +78,4 @@ setup-otel-exporter = [
     "tracing-subscriber/tracing",
     "tracing-subscriber/tracing-serde",
 ]
+setup-otel-exporter = ["otel-exporter"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -10,8 +10,8 @@ mod plugins;
 mod rt;
 mod start;
 
-#[cfg(feature = "setup-otel-exporter")]
-mod telemetry;
+#[cfg(feature = "otel-exporter")]
+pub mod telemetry;
 
 // Public API
 // Useful re-exports

--- a/runtime/src/start.rs
+++ b/runtime/src/start.rs
@@ -61,7 +61,25 @@ pub async fn start(
     }
 
     #[cfg(feature = "setup-otel-exporter")]
-    let _guard = crate::telemetry::init_tracing_subscriber(crate_name, package_version);
+    let _guard = {
+        use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter};
+        let (layers, guard) =
+            crate::telemetry::otel_tracing_subscriber(crate_name, package_version);
+
+        registry()
+            .with(layers)
+            .with(fmt::layer().without_time())
+            .with(
+                // let user override RUST_LOG in local run if they want to
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+                    // otherwise use our default
+                    format!("info,{}=debug", crate_name).into()
+                }),
+            )
+            .init();
+
+        guard
+    };
 
     #[cfg(any(feature = "setup-tracing", feature = "setup-otel-exporter"))]
     tracing::warn!("Default tracing subscriber initialized (https://docs.shuttle.dev/docs/logs)");


### PR DESCRIPTION
Allows getting the otel layers used by feature "setup-otel-exporter" under feature "otel-exporter".

Usage:
```rs
let (layers, _guard) = shuttle_runtime::telemetry::otel_tracing_subscriber(
    env!("CARGO_CRATE_NAME"),
    env!("CARGO_PKG_VERSION"),
);
// registry
...
    .with(layers)
    ...
    .init();
```