### PR TITLE
feat(common): add forward-compatible variants on user facing enums

### DIFF
--- a/api-client/Cargo.toml
+++ b/api-client/Cargo.toml
@@ -8,7 +8,7 @@ description = "A library for interacting with the Shuttle platform API (https://
 homepage = "https://www.shuttle.dev"
 
 [dependencies]
-shuttle-common = { workspace = true, features = ["models"] }
+shuttle-common = { workspace = true, features = ["models", "unknown-variants"] }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -94,6 +94,7 @@ impl ProjectArgs {
     }
 }
 
+#[allow(rustdoc::bare_urls)]
 /// CLI for the Shuttle platform (https://www.shuttle.dev/)
 ///
 /// See the CLI docs for more information: https://docs.shuttle.dev/guides/cli

--- a/cargo-shuttle/src/init.rs
+++ b/cargo-shuttle/src/init.rs
@@ -259,7 +259,7 @@ fn edit_shuttle_toml(path: &Path, set_name: Option<&str>) -> Result<()> {
 
         doc.remove("name");
 
-        if doc.len() == 0 {
+        if doc.is_empty() {
             // if "name" was the only property in the doc, delete the file
             let _ = std::fs::remove_file(&path);
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -198,7 +198,7 @@ impl Shuttle {
                     // ProjectCommand::List does not need to know which project we are in
                     ProjectCommand::Create
                         | ProjectCommand::Update(..)
-                        | ProjectCommand::Status { .. }
+                        | ProjectCommand::Status
                         | ProjectCommand::Delete { .. }
                         | ProjectCommand::Link
                 )

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -904,7 +904,7 @@ impl Shuttle {
                     DeploymentState::Building // a building deployment should take it back to InProgress then Running, so don't follow that sequence
                     | DeploymentState::Failed
                     | DeploymentState::Stopped
-                    | DeploymentState::Unknown => Ok(Some(cleanup)),
+                    | DeploymentState::Unknown(_) => Ok(Some(cleanup)),
                 }
         })
         .await?;
@@ -1616,7 +1616,7 @@ impl Shuttle {
                 DeploymentState::Running
                 | DeploymentState::Stopped
                 | DeploymentState::Stopping
-                | DeploymentState::Unknown
+                | DeploymentState::Unknown(_)
                 | DeploymentState::Failed => Ok(Some(cleanup)),
             }
         })

--- a/cargo-shuttle/src/provisioner_server.rs
+++ b/cargo-shuttle/src/provisioner_server.rs
@@ -533,7 +533,7 @@ async fn provision(
                         .context("deserializing resource config")?;
                     let res = prov.get_db_connection_string(
                             &state.project_name,
-                            shuttle_resource.r#type,
+                            shuttle_resource.r#type.clone(),
                             config.db_name,
                         )
                         .await
@@ -564,7 +564,7 @@ async fn provision(
                     config: shuttle_resource.config,
                     output: serde_json::to_value(&state.secrets).unwrap(),
                 },
-                ResourceType::Unknown => bail!("request for unknown resource type recieved"),
+                ResourceType::Unknown(s) => bail!("request for unknown resource type {s} recieved"),
             };
 
             let table = get_resource_tables(&[response.clone()], "local service", false, true);

--- a/cargo-shuttle/src/provisioner_server.rs
+++ b/cargo-shuttle/src/provisioner_server.rs
@@ -564,6 +564,7 @@ async fn provision(
                     config: shuttle_resource.config,
                     output: serde_json::to_value(&state.secrets).unwrap(),
                 },
+                ResourceType::Unknown => bail!("request for unknown resource type recieved"),
             };
 
             let table = get_resource_tables(&[response.clone()], "local service", false, true);

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -35,8 +35,8 @@ models = ["chrono/serde", "dep:tracing"]
 axum = ["dep:axum", "dep:tracing"]
 display = ["chrono/clock", "dep:crossterm"]
 tables = ["models", "display", "dep:comfy-table"]
-
-utoipa = ["dep:utoipa"]
+unknown-variants = [] # add fallback to Unknown variant on enum model deser
+utoipa = ["dep:utoipa"] # derive OpenAPI definitions for models
 
 # internal / utility features
 integration-tests = []

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -24,6 +24,7 @@ pub enum DeploymentState {
     Failed,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]
@@ -44,6 +45,7 @@ impl DeploymentState {
             Self::Stopped => Color::DarkBlue,
             Self::Stopping => Color::Blue,
             Self::Failed => Color::Red,
+            #[cfg(feature = "unknown-variants")]
             Self::Unknown(_) => Color::Grey,
         }
     }
@@ -59,6 +61,7 @@ impl DeploymentState {
             Self::Stopped => Color::DarkBlue,
             Self::Stopping => Color::Blue,
             Self::Failed => Color::Red,
+            #[cfg(feature = "unknown-variants")]
             Self::Unknown(_) => Color::Grey,
         }
     }
@@ -263,7 +266,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn deploymnet_state_from_and_to_str() {
+    fn deployment_state_from_and_to_str() {
         assert_eq!(
             DeploymentState::Building,
             DeploymentState::from_str("Building").unwrap()
@@ -280,6 +283,11 @@ mod tests {
             DeploymentState::Building.to_string(),
             "building".to_string()
         );
+    }
+
+    #[cfg(feature = "unknown-variants")]
+    #[test]
+    fn unknown_state() {
         assert_eq!(
             DeploymentState::Unknown("flying".to_string()),
             DeploymentState::from_str("flying").unwrap()

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -22,7 +22,12 @@ pub enum DeploymentState {
     Stopped,
     Stopping,
     Failed,
-    /// Fallback
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
     Unknown,
 }
 
@@ -125,6 +130,8 @@ pub enum DeploymentRequest {
     // TODO?: Add GitRepo(DeploymentRequestGitRepo)
     /// Use this image directly. Can be used to skip the build step.
     Image(DeploymentRequestImage),
+    //
+    // No Unknown variant: is a Request type and should only be deserialized on backend
 }
 
 #[derive(Default, Deserialize, Serialize)]
@@ -140,14 +147,14 @@ pub struct DeploymentRequestBuildArchive {
     pub build_meta: Option<BuildMeta>,
 }
 
-#[derive(Deserialize, Serialize, Default)]
+#[derive(Deserialize, Serialize)]
 #[serde(tag = "type", content = "content")]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[typeshare::typeshare]
 pub enum BuildArgs {
     Rust(BuildArgsRust),
-    #[default]
-    Unknown,
+    //
+    // No Unknown variant: is a Request type and should only be deserialized on backend
 }
 
 #[derive(Deserialize, Serialize)]
@@ -246,6 +253,8 @@ pub enum Environment {
     Local,
     #[strum(serialize = "production")] // Keep this around for a while for backward compat
     Deployment,
+    //
+    // No Unknown variant: is not deserialized in user facing libraries (just FromStr parsed)
 }
 
 #[cfg(test)]

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -26,9 +26,9 @@ pub enum DeploymentState {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }
 
 impl DeploymentState {
@@ -44,7 +44,7 @@ impl DeploymentState {
             Self::Stopped => Color::DarkBlue,
             Self::Stopping => Color::Blue,
             Self::Failed => Color::Red,
-            Self::Unknown => Color::Grey,
+            Self::Unknown(_) => Color::Grey,
         }
     }
     #[cfg(all(feature = "tables", feature = "display"))]
@@ -59,7 +59,7 @@ impl DeploymentState {
             Self::Stopped => Color::DarkBlue,
             Self::Stopping => Color::Blue,
             Self::Failed => Color::Red,
-            Self::Unknown => Color::Grey,
+            Self::Unknown(_) => Color::Grey,
         }
     }
     #[cfg(feature = "display")]
@@ -263,7 +263,7 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_state_deser() {
+    fn deploymnet_state_from_and_to_str() {
         assert_eq!(
             DeploymentState::Building,
             DeploymentState::from_str("Building").unwrap()
@@ -276,10 +276,22 @@ mod tests {
             DeploymentState::Building,
             DeploymentState::from_str("building").unwrap()
         );
+        assert_eq!(
+            DeploymentState::Building.to_string(),
+            "building".to_string()
+        );
+        assert_eq!(
+            DeploymentState::Unknown("flying".to_string()),
+            DeploymentState::from_str("flying").unwrap()
+        );
+        assert_eq!(
+            DeploymentState::Unknown("flying".to_string()).to_string(),
+            "Unknown: flying".to_string()
+        );
     }
 
     #[test]
-    fn test_env_deser() {
+    fn env_from_str() {
         assert_eq!(Environment::Local, Environment::from_str("local").unwrap());
         assert_eq!(
             Environment::Deployment,

--- a/common/src/models/log.rs
+++ b/common/src/models/log.rs
@@ -66,7 +66,7 @@ mod tests {
     #[rstest::rstest]
     #[case::utc("utc")]
     #[case::cest("cest")]
-    fn test_timezone_formatting(#[case] tz: &str) {
+    fn timezone_formatting(#[case] tz: &str) {
         let item = LogItem::new(
             Utc::now(),
             "test".to_string(),

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -105,4 +105,11 @@ pub enum ComputeTier {
     L,
     XL,
     XXL,
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
+    Unknown,
 }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -90,9 +90,7 @@ pub struct ProjectUpdateRequest {
     pub config: Option<serde_json::Value>,
 }
 
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, Display, Serialize, Deserialize, EnumString,
-)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Display, Serialize, Deserialize, EnumString)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -109,7 +107,7 @@ pub enum ComputeTier {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }

--- a/common/src/models/project.rs
+++ b/common/src/models/project.rs
@@ -105,6 +105,7 @@ pub enum ComputeTier {
     XXL,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -35,6 +35,13 @@ pub enum ResourceState {
     Ready,
     Deleting,
     Deleted,
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
+    Unknown,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -92,6 +99,13 @@ pub enum ResourceType {
     #[strum(to_string = "container")]
     #[serde(rename = "container")]
     Container,
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
+    Unknown,
 }
 
 #[cfg(test)]

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -39,9 +39,9 @@ pub enum ResourceState {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -65,7 +65,6 @@ pub struct ResourceListResponse {
 
 #[derive(
     Clone,
-    Copy,
     Debug,
     Deserialize,
     Serialize,
@@ -103,13 +102,13 @@ pub enum ResourceType {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::str::FromStr;
 
     use super::*;

--- a/common/src/models/resource.rs
+++ b/common/src/models/resource.rs
@@ -37,6 +37,7 @@ pub enum ResourceState {
     Deleted,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]
@@ -100,6 +101,7 @@ pub enum ResourceType {
     Container,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]

--- a/common/src/models/team.rs
+++ b/common/src/models/team.rs
@@ -67,9 +67,9 @@ pub enum TeamRole {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }
 
 /// Provide user id to add user.

--- a/common/src/models/team.rs
+++ b/common/src/models/team.rs
@@ -65,6 +65,7 @@ pub enum TeamRole {
     Member,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]

--- a/common/src/models/team.rs
+++ b/common/src/models/team.rs
@@ -63,6 +63,13 @@ pub enum TeamRole {
     Owner,
     Admin,
     Member,
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
+    Unknown,
 }
 
 /// Provide user id to add user.

--- a/common/src/models/telemetry.rs
+++ b/common/src/models/telemetry.rs
@@ -102,15 +102,15 @@ pub enum TelemetrySinkConfig {
     Debug(serde_json::Value),
     //
     // No Unknown variant: is not deserialized in user facing libraries
-    // (this is what it would look like 💀)
+    // (this is what it would look like 💀):
     //   #[doc(hidden)]
     //   #[typeshare(skip)]
-    //   #[serde(other, skip_serializing)]
-    //   #[strum(to_string = "[UNKNOWN]")]
+    //   #[serde(untagged, skip_serializing)]
+    //   #[strum(default, to_string = "Unknown: {0}")]
     //   #[strum_discriminants(doc(hidden))]
-    //   #[strum_discriminants(serde(other, skip_serializing))]
-    //   #[strum_discriminants(strum(to_string = "[UNKNOWN]"))]
-    //   Unknown,
+    //   #[strum_discriminants(serde(untagged, skip_serializing))]
+    //   #[strum_discriminants(strum(default, to_string = "Unknown: {0}"))]
+    //   Unknown(String),
 }
 
 impl TelemetrySinkConfig {

--- a/common/src/models/telemetry.rs
+++ b/common/src/models/telemetry.rs
@@ -31,7 +31,6 @@ impl From<Vec<TelemetrySinkConfig>> for TelemetryConfigResponse {
 
         for sink in value {
             match sink {
-                TelemetrySinkConfig::Debug(_) => {}
                 TelemetrySinkConfig::Betterstack(_) => {
                     instance.betterstack = Some(TelemetrySinkStatus { enabled: true })
                 }
@@ -41,6 +40,7 @@ impl From<Vec<TelemetrySinkConfig>> for TelemetryConfigResponse {
                 TelemetrySinkConfig::GrafanaCloud(_) => {
                     instance.grafana_cloud = Some(TelemetrySinkStatus { enabled: true })
                 }
+                TelemetrySinkConfig::Debug(_) => {}
             }
         }
 
@@ -89,6 +89,17 @@ pub enum TelemetrySinkConfig {
     #[typeshare(skip)]
     #[strum_discriminants(doc(hidden))]
     Debug(serde_json::Value),
+    //
+    // No Unknown variant: is not deserialized in user facing libraries
+    // (this is what it would look like 💀)
+    //   #[doc(hidden)]
+    //   #[typeshare(skip)]
+    //   #[serde(other, skip_serializing)]
+    //   #[strum(to_string = "[UNKNOWN]")]
+    //   #[strum_discriminants(doc(hidden))]
+    //   #[strum_discriminants(serde(other, skip_serializing))]
+    //   #[strum_discriminants(strum(to_string = "[UNKNOWN]"))]
+    //   Unknown,
 }
 
 impl TelemetrySinkConfig {

--- a/common/src/models/telemetry.rs
+++ b/common/src/models/telemetry.rs
@@ -103,6 +103,7 @@ pub enum TelemetrySinkConfig {
     //
     // No Unknown variant: is not deserialized in user facing libraries
     // (this is what it would look like 💀):
+    //   #[cfg(feature = "unknown-variants")]
     //   #[doc(hidden)]
     //   #[typeshare(skip)]
     //   #[serde(untagged, skip_serializing)]

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -88,6 +88,13 @@ pub enum AccountTier {
     Employee,
     /// Unlimited resources, full API access, admin endpoint access
     Admin,
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -131,4 +138,32 @@ pub struct SubscriptionRequest {
 pub enum SubscriptionType {
     Pro,
     Rds,
+
+    /// Forward compatibility
+    #[doc(hidden)]
+    #[typeshare(skip)]
+    #[serde(other, skip_serializing)]
+    #[strum(to_string = "[UNKNOWN]")]
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn unknown_deser() {
+        assert_eq!(
+            serde_json::from_str::<AccountTier>("\"basic\"").unwrap(),
+            AccountTier::Basic
+        );
+        assert_eq!(
+            serde_json::from_str::<AccountTier>("\"\"").unwrap(),
+            AccountTier::Unknown
+        );
+        assert_eq!(
+            serde_json::from_str::<AccountTier>("\"hisshiss\"").unwrap(),
+            AccountTier::Unknown
+        );
+        assert!(serde_json::to_string(&AccountTier::Unknown).is_err());
+    }
 }

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -89,6 +89,7 @@ pub enum AccountTier {
     Admin,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]
@@ -139,6 +140,7 @@ pub enum SubscriptionType {
     Rds,
 
     /// Forward compatibility
+    #[cfg(feature = "unknown-variants")]
     #[doc(hidden)]
     #[typeshare(skip)]
     #[serde(untagged, skip_serializing)]
@@ -150,11 +152,15 @@ pub enum SubscriptionType {
 mod tests {
     use super::*;
     #[test]
-    fn unknown_deser() {
+    fn deser() {
         assert_eq!(
             serde_json::from_str::<AccountTier>("\"basic\"").unwrap(),
             AccountTier::Basic
         );
+    }
+    #[cfg(feature = "unknown-variants")]
+    #[test]
+    fn unknown_deser() {
         assert_eq!(
             serde_json::from_str::<AccountTier>("\"\"").unwrap(),
             AccountTier::Unknown("".to_string())
@@ -164,5 +170,11 @@ mod tests {
             AccountTier::Unknown("hisshiss".to_string())
         );
         assert!(serde_json::to_string(&AccountTier::Unknown("asdf".to_string())).is_err());
+    }
+    #[cfg(not(feature = "unknown-variants"))]
+    #[test]
+    fn not_unknown_deser() {
+        assert!(serde_json::from_str::<AccountTier>("\"\"").is_err());
+        assert!(serde_json::from_str::<AccountTier>("\"hisshiss\"").is_err());
     }
 }

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -57,7 +57,6 @@ impl UserResponse {
 #[derive(
     // std
     Clone,
-    Copy,
     Debug,
     Default,
     Eq,
@@ -92,9 +91,9 @@ pub enum AccountTier {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -142,9 +141,9 @@ pub enum SubscriptionType {
     /// Forward compatibility
     #[doc(hidden)]
     #[typeshare(skip)]
-    #[serde(other, skip_serializing)]
-    #[strum(to_string = "[UNKNOWN]")]
-    Unknown,
+    #[serde(untagged, skip_serializing)]
+    #[strum(default, to_string = "Unknown: {0}")]
+    Unknown(String),
 }
 
 #[cfg(test)]
@@ -158,12 +157,12 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_str::<AccountTier>("\"\"").unwrap(),
-            AccountTier::Unknown
+            AccountTier::Unknown("".to_string())
         );
         assert_eq!(
             serde_json::from_str::<AccountTier>("\"hisshiss\"").unwrap(),
-            AccountTier::Unknown
+            AccountTier::Unknown("hisshiss".to_string())
         );
-        assert!(serde_json::to_string(&AccountTier::Unknown).is_err());
+        assert!(serde_json::to_string(&AccountTier::Unknown("asdf".to_string())).is_err());
     }
 }

--- a/common/src/secrets.rs
+++ b/common/src/secrets.rs
@@ -88,7 +88,7 @@ impl IntoIterator for SecretStore {
 
 #[cfg(test)]
 #[allow(dead_code)]
-mod secrets_tests {
+mod tests {
     use super::*;
 
     #[test]

--- a/common/types.ts
+++ b/common/types.ts
@@ -104,8 +104,6 @@ export enum DeploymentState {
 	Stopped = "stopped",
 	Stopping = "stopping",
 	Failed = "failed",
-	/** Fallback */
-	Unknown = "unknown",
 }
 
 export interface DeploymentResponse {
@@ -124,8 +122,7 @@ export interface DeploymentListResponse {
 }
 
 export type BuildArgs = 
-	| { type: "Rust", content: BuildArgsRust }
-	| { type: "Unknown", content?: undefined };
+	| { type: "Rust", content: BuildArgsRust };
 
 export interface DeploymentRequestBuildArchive {
 	/** The S3 object version ID of the archive to use */

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -35,7 +35,7 @@ pub mod error;
 pub trait ResourceInputBuilder: Default {
     /// The input for requesting this resource.
     ///
-    /// If the input is a [`shuttle_common::resource::ProvisionResourceRequest`],
+    /// If the input is a [`shuttle_common::models::resource::ProvisionResourceRequest`],
     /// then the resource will be provisioned and the associated output type will
     /// be put in [`ResourceInputBuilder::Output`].
     type Input: Serialize + DeserializeOwned;


### PR DESCRIPTION
Philosophy: Add Unknown variants to enums that clients parse (responses), but not to enums that only the backend parses (requests).

- Adds the Unknown variant in a feature flag that only the api-client lib (and thus cargo-shuttle) enables, as it is only those clients that we want to parse future variants.
- Breaking: Removes unnecessary Unknown variant and Default impl on BuildArgs
- Random docs & clippy fixes, nits