### PR TITLE
feat(cargo-shuttle): SHUTTLE_API_ENV for separate global configs and automatic api urls

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -32,6 +32,10 @@ pub struct ShuttleArgs {
     /// Modify Shuttle API URL to use admin endpoints
     #[arg(global = true, long, env = "SHUTTLE_ADMIN", hide = true)]
     pub admin: bool,
+    /// Target a different Shuttle API env (use a separate global config) (default: None (production))
+    // (SHUTTLE_ENV is used for user-facing environments (agnostic of Shuttle API env))
+    #[arg(global = true, long, env = "SHUTTLE_API_ENV", hide = true)]
+    pub shuttle_api_env: Option<String>,
     /// Disable network requests that are not strictly necessary. Limits some features.
     #[arg(global = true, long, env = "SHUTTLE_OFFLINE")]
     pub offline: bool,

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -26,16 +26,16 @@ use shuttle_common::{constants::EXAMPLES_REPO, models::resource::ResourceType};
         .hide(true))
 )]
 pub struct ShuttleArgs {
-    /// URL for the Shuttle API to target (mainly for development)
+    /// Target a different Shuttle API env (use a separate global config) (default: None (= prod = production))
+    // ("SHUTTLE_ENV" is used for user-facing environments (agnostic of Shuttle API env))
+    #[arg(global = true, long, env = "SHUTTLE_API_ENV", hide = true)]
+    pub api_env: Option<String>,
+    /// URL for the Shuttle API to target (overrides inferred URL from api_env)
     #[arg(global = true, long, env = "SHUTTLE_API", hide = true)]
     pub api_url: Option<String>,
     /// Modify Shuttle API URL to use admin endpoints
     #[arg(global = true, long, env = "SHUTTLE_ADMIN", hide = true)]
     pub admin: bool,
-    /// Target a different Shuttle API env (use a separate global config) (default: None (= prod = production))
-    // (SHUTTLE_ENV is used for user-facing environments (agnostic of Shuttle API env))
-    #[arg(global = true, long, env = "SHUTTLE_API_ENV", hide = true)]
-    pub shuttle_api_env: Option<String>,
     /// Disable network requests that are not strictly necessary. Limits some features.
     #[arg(global = true, long, env = "SHUTTLE_OFFLINE")]
     pub offline: bool,

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -32,7 +32,7 @@ pub struct ShuttleArgs {
     /// Modify Shuttle API URL to use admin endpoints
     #[arg(global = true, long, env = "SHUTTLE_ADMIN", hide = true)]
     pub admin: bool,
-    /// Target a different Shuttle API env (use a separate global config) (default: None (production))
+    /// Target a different Shuttle API env (use a separate global config) (default: None (= prod = production))
     // (SHUTTLE_ENV is used for user-facing environments (agnostic of Shuttle API env))
     #[arg(global = true, long, env = "SHUTTLE_API_ENV", hide = true)]
     pub shuttle_api_env: Option<String>,

--- a/cargo-shuttle/src/bin/cargo-shuttle.rs
+++ b/cargo-shuttle/src/bin/cargo-shuttle.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
 
     setup_tracing(args.debug);
 
-    Shuttle::new(Binary::CargoShuttle, args.shuttle_api_env.clone())?
+    Shuttle::new(Binary::CargoShuttle, args.api_env.clone())?
         .run(args, provided_path_to_init)
         .await
 }

--- a/cargo-shuttle/src/bin/cargo-shuttle.rs
+++ b/cargo-shuttle/src/bin/cargo-shuttle.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
 
     setup_tracing(args.debug);
 
-    Shuttle::new(Binary::CargoShuttle)?
+    Shuttle::new(Binary::CargoShuttle, args.shuttle_api_env.clone())?
         .run(args, provided_path_to_init)
         .await
 }

--- a/cargo-shuttle/src/bin/shuttle.rs
+++ b/cargo-shuttle/src/bin/shuttle.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
 
     setup_tracing(args.debug);
 
-    Shuttle::new(Binary::Shuttle)?
+    Shuttle::new(Binary::Shuttle, args.shuttle_api_env.clone())?
         .run(args, provided_path_to_init)
         .await
 }

--- a/cargo-shuttle/src/bin/shuttle.rs
+++ b/cargo-shuttle/src/bin/shuttle.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<()> {
 
     setup_tracing(args.debug);
 
-    Shuttle::new(Binary::Shuttle, args.shuttle_api_env.clone())?
+    Shuttle::new(Binary::Shuttle, args.api_env.clone())?
         .run(args, provided_path_to_init)
         .await
 }

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
+use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use shuttle_common::constants::SHUTTLE_API_URL;
 use tracing::trace;
@@ -284,6 +285,12 @@ pub struct RequestContext {
 impl RequestContext {
     /// Create a [`RequestContext`], only loading in the global configuration details.
     pub fn load_global(env_override: Option<String>) -> Result<Self> {
+        if let Some(ref e) = env_override {
+            eprintln!(
+                "{}",
+                format!("INFO: Using non-default global config file: {e}").yellow(),
+            );
+        }
         let mut global = Config::new(GlobalConfigManager::new(env_override)?);
         if !global.exists() {
             global.create()?;

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -3,7 +3,6 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
-use crossterm::style::Stylize;
 use serde::{Deserialize, Serialize};
 use shuttle_common::constants::SHUTTLE_API_URL;
 use tracing::trace;
@@ -285,12 +284,6 @@ pub struct RequestContext {
 impl RequestContext {
     /// Create a [`RequestContext`], only loading in the global configuration details.
     pub fn load_global(env_override: Option<String>) -> Result<Self> {
-        if let Some(ref e) = env_override {
-            eprintln!(
-                "{}",
-                format!("INFO: Using non-default global config file: {e}").yellow(),
-            );
-        }
         let mut global = Config::new(GlobalConfigManager::new(env_override)?);
         if !global.exists() {
             global.create()?;

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -84,11 +84,11 @@ pub fn parse_args() -> (ShuttleArgs, bool) {
 
     // don't use an override if production is targetted
     if args
-        .shuttle_api_env
+        .api_env
         .as_ref()
         .is_some_and(|e| e == "prod" || e == "production")
     {
-        args.shuttle_api_env = None;
+        args.api_env = None;
     }
 
     (args, provided_path_to_init)
@@ -173,11 +173,7 @@ impl Shuttle {
             let api_url = args
                 .api_url
                 // calculate env-specific url if no explicit url given but an env was given
-                .or_else(|| {
-                    args.shuttle_api_env
-                        .as_ref()
-                        .map(|env| other_env_api_url(env))
-                })
+                .or_else(|| args.api_env.as_ref().map(|env| other_env_api_url(env)))
                 // add /admin prefix if in admin mode
                 .map(|u| if args.admin { format!("{u}/admin") } else { u });
             if let Some(ref url) = api_url {

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -162,7 +162,7 @@ impl Shuttle {
                 .or_else(|| {
                     args.shuttle_api_env
                         .as_ref()
-                        .map(|env| other_env_api_url(&env))
+                        .map(|env| other_env_api_url(env))
                 })
                 // add /admin prefix if in admin mode
                 .map(|u| if args.admin { format!("{u}/admin") } else { u });

--- a/cargo-shuttle/tests/integration/init.rs
+++ b/cargo-shuttle/tests/integration/init.rs
@@ -30,7 +30,7 @@ async fn non_interactive_basic_init() {
         "none",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await
@@ -63,7 +63,7 @@ async fn non_interactive_rocket_init() {
         "rocket",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await
@@ -96,7 +96,7 @@ async fn non_interactive_init_with_from_url() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await
@@ -131,7 +131,7 @@ async fn non_interactive_init_with_from_gh() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await
@@ -166,7 +166,7 @@ async fn non_interactive_init_with_from_repo_name() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await
@@ -201,7 +201,7 @@ async fn non_interactive_init_with_from_local_path() {
         "tower/hello-world",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await
@@ -236,7 +236,7 @@ async fn non_interactive_init_from_local_path_with_workspace() {
         "rocket/workspace",
         temp_dir_path.to_str().unwrap(),
     ]);
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(args, true)
         .await

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -9,12 +9,13 @@ use std::path::Path;
 async fn shuttle_command(cmd: Command, working_directory: &str) -> anyhow::Result<()> {
     let working_directory = Path::new(working_directory).to_path_buf();
 
-    Shuttle::new(cargo_shuttle::Binary::Shuttle)
+    Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
         .unwrap()
         .run(
             ShuttleArgs {
                 api_url: Some("http://shuttle.invalid:80".to_string()),
                 admin: false,
+                shuttle_api_env: None,
                 project_args: ProjectArgs {
                     working_directory,
                     name_or_id: None,

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -15,7 +15,7 @@ async fn shuttle_command(cmd: Command, working_directory: &str) -> anyhow::Resul
             ShuttleArgs {
                 api_url: Some("http://shuttle.invalid:80".to_string()),
                 admin: false,
-                shuttle_api_env: None,
+                api_env: None,
                 project_args: ProjectArgs {
                     working_directory,
                     name_or_id: None,

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -33,7 +33,7 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
             ShuttleArgs {
                 api_url: Some("http://shuttle.invalid:80".to_string()),
                 admin: false,
-                shuttle_api_env: None,
+                api_env: None,
                 project_args: ProjectArgs {
                     working_directory: working_directory.clone(),
                     name_or_id: None,

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -27,27 +27,30 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
         format!("http://0.0.0.0:{port}")
     };
 
-    let runner = Shuttle::new(cargo_shuttle::Binary::Shuttle).unwrap().run(
-        ShuttleArgs {
-            api_url: Some("http://shuttle.invalid:80".to_string()),
-            admin: false,
-            project_args: ProjectArgs {
-                working_directory: working_directory.clone(),
-                name_or_id: None,
+    let runner = Shuttle::new(cargo_shuttle::Binary::Shuttle, None)
+        .unwrap()
+        .run(
+            ShuttleArgs {
+                api_url: Some("http://shuttle.invalid:80".to_string()),
+                admin: false,
+                shuttle_api_env: None,
+                project_args: ProjectArgs {
+                    working_directory: working_directory.clone(),
+                    name_or_id: None,
+                },
+                offline: false,
+                debug: false,
+                cmd: Command::Run(RunArgs {
+                    port,
+                    external,
+                    release: false,
+                    raw: false,
+                    bacon: false,
+                    secret_args: Default::default(),
+                }),
             },
-            offline: false,
-            debug: false,
-            cmd: Command::Run(RunArgs {
-                port,
-                external,
-                release: false,
-                raw: false,
-                bacon: false,
-                secret_args: Default::default(),
-            }),
-        },
-        false,
-    );
+            false,
+        );
 
     tokio::spawn({
         let working_directory = working_directory.clone();

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -7,6 +7,10 @@ pub const STORAGE_DIRNAME: &str = ".shuttle-storage";
 pub const SHUTTLE_API_URL: &str = "https://api.shuttle.dev";
 pub const SHUTTLE_CONSOLE_URL: &str = "https://console.shuttle.dev";
 
+pub fn other_env_api_url(env: &str) -> String {
+    format!("https://api.{env}.shuttle.dev")
+}
+
 pub const SHUTTLE_INSTALL_DOCS_URL: &str = "https://docs.shuttle.dev/getting-started/installation";
 
 pub const SHUTTLE_GH_REPO_URL: &str = "https://github.com/shuttle-hq/shuttle";

--- a/scripts/env-dev.sh
+++ b/scripts/env-dev.sh
@@ -1,3 +1,0 @@
-export SHUTTLE_API="https://api.dev.shuttle.dev"
-unset SHUTTLE_API_KEY
-export PS1="(shuttle: Dev) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"

--- a/scripts/env-dev2.sh
+++ b/scripts/env-dev2.sh
@@ -1,3 +1,0 @@
-export SHUTTLE_API="https://api.dev2.shuttle.dev"
-unset SHUTTLE_API_KEY
-export PS1="(shuttle: Dev2) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"

--- a/scripts/env-prod.sh
+++ b/scripts/env-prod.sh
@@ -1,3 +1,0 @@
-export SHUTTLE_API="https://api.shuttle.dev"
-unset SHUTTLE_API_KEY
-export PS1="(shuttle: Production) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"

--- a/scripts/env-staging.sh
+++ b/scripts/env-staging.sh
@@ -1,3 +1,0 @@
-export SHUTTLE_API="https://api.staging.shuttle.dev"
-unset SHUTTLE_API_KEY
-export PS1="(shuttle: Staging) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"

--- a/scripts/set-env.sh
+++ b/scripts/set-env.sh
@@ -1,0 +1,10 @@
+# Usage: source scripts/set-env.sh [env]
+
+if [ -z "$1" ]; then
+    echo "provide an env name";
+else
+    export SHUTTLE_API_ENV="$1"
+    unset SHUTTLE_API
+    unset SHUTTLE_API_KEY
+    export PS1="(shuttle: $SHUTTLE_API_ENV) $(echo $PS1 | sed -e "s/(shuttle: .*) //")"
+fi


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Adds `--shuttle-api-env` / `SHUTTLE_API_ENV` which
- uses a separate config file for that env
- sets the url (SHUTTLE_API) for you (but you can still override it)

This allows you to be logged into multiple envs, and switch between them with this var.

The env scripts were also combined for easy switching.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->

Tested by logging in to dev2, and the key was placed in `~/.config/shuttle/config.dev2.toml`

```
cargo r --bin shuttle -- --shuttle-api-env dev2 account
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/shuttle --shuttle-api-env dev2 account`
INFO: Using non-default global config file: dev2
INFO: Targeting non-default API: https://api.dev2.shuttle.dev
Account info:
  User ID: user_01J...
  Account tier: basic

cargo r --bin shuttle -- --shuttle-api-env prod account
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running `target/debug/shuttle --shuttle-api-env prod account`
Account info:
  User ID: user_01H...
  Account tier: admin
```

Script:

```
source ~/shuttle/scripts/set-env.sh
provide an env name

source ~/shuttle/scripts/set-env.sh dev
(shuttle: dev) 
cargo r --bin shuttle -- account
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/shuttle account`
INFO: Using non-default global config file: dev
INFO: Targeting non-default API: https://api.dev.shuttle.dev
Error: 401 Unauthorized
Message: No authorization credential found in request. Use `shuttle login` to log in.
```