### PR TITLE
chore(cargo-shuttle): remove logs --all-deployments

### DIFF
--- a/api-client/src/lib.rs
+++ b/api-client/src/lib.rs
@@ -262,11 +262,6 @@ impl ShuttleApiClient {
 
         self.get_json(path).await
     }
-    pub async fn get_project_logs(&self, project: &str) -> Result<LogsResponse> {
-        let path = format!("/projects/{project}/logs");
-
-        self.get_json(path).await
-    }
 
     pub async fn get_deployments(
         &self,

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -504,9 +504,6 @@ pub struct LogsArgs {
     /// View all log lines
     #[arg(long, group = "output_mode", hide = true)]
     pub all: bool,
-    /// Get logs from all deployments instead of one deployment
-    #[arg(long)]
-    pub all_deployments: bool,
 }
 
 /// Helper function to parse and return the absolute path


### PR DESCRIPTION
API Endpoint is deprecated.
Used by almost noone and times out due to too many/old logs to fetch in typical use case.