### PR TITLE
feat(common): update user model fields

### DIFF
--- a/cargo-shuttle/src/util/mod.rs
+++ b/cargo-shuttle/src/util/mod.rs
@@ -130,29 +130,28 @@ pub async fn check_version(runtime_path: &Path) -> Result<()> {
         runtime_path.display()
     );
 
-    // should always be a valid semver
-    let my_version = semver::Version::from_str(crate::VERSION).unwrap();
+    let cli_version =
+        semver::Version::from_str(crate::VERSION).expect("crate version to be a valid semver");
 
     if !runtime_path.try_exists()? {
         bail!("shuttle-runtime binary not found");
     }
 
     // Get runtime version from shuttle-runtime cli
-    // It should print the version and exit immediately, so a timeout is used to not launch servers with non-Shuttle setups
+    // It should print the version and exit immediately, so a timeout is used
+    // to not get blocked by blocking programs that don't use the Shuttle runtime.
     let stdout = tokio::time::timeout(Duration::from_millis(3000), async move {
         tokio::process::Command::new(runtime_path)
             .arg("--version")
             .kill_on_drop(true) // if the binary does not halt on its own, not killing it will leak child processes
             .output()
             .await
-            .context("Failed to run the shuttle-runtime binary to check its version")
+            .context("Failed to run the binary with shuttle-runtime to check its version")
             .map(|o| o.stdout)
     })
     .await
-    .context("Checking the version of shuttle-runtime timed out. Make sure the executable is using #[shuttle-runtime::main].")??;
+    .context("Checking the version of shuttle-runtime timed out. Make sure the executable is using #[shuttle_runtime::main].")??;
 
-    // Parse the version, splitting the version from the name and
-    // and pass it to `to_semver()`.
     let runtime_version = semver::Version::from_str(
         std::str::from_utf8(&stdout)
             .context("shuttle-runtime version should be valid utf8")?
@@ -161,14 +160,14 @@ pub async fn check_version(runtime_path: &Path) -> Result<()> {
             .1
             .trim(),
     )
-    .context("failed to convert user's runtime version to semver")?;
+    .context("failed to convert runtime version to semver")?;
 
-    if semvers_are_compatible(&my_version, &runtime_version) {
+    if semvers_are_compatible(&cli_version, &runtime_version) {
         Ok(())
     } else {
         Err(VersionMismatchError {
             shuttle_runtime: runtime_version,
-            cargo_shuttle: my_version,
+            cargo_shuttle: cli_version,
         })
         .context("shuttle-runtime and Shuttle CLI have incompatible versions")
     }

--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -12,15 +12,13 @@ use strum::{EnumString, IntoStaticStr};
 #[typeshare::typeshare]
 pub struct UserResponse {
     pub id: String,
-    /// Auth0 id (deprecated)
-    pub name: Option<String>,
     /// Auth0 id
     pub auth0_id: Option<String>,
-    pub created_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
     // deprecated
     pub key: Option<String>,
     pub account_tier: AccountTier,
-    pub subscriptions: Vec<Subscription>,
+    pub subscriptions: Option<Vec<Subscription>>,
     pub flags: Option<Vec<String>>,
 }
 
@@ -36,15 +34,17 @@ impl UserResponse {
             self.account_tier.to_string_fancy()
         )
         .unwrap();
-        if !self.subscriptions.is_empty() {
-            writeln!(&mut s, "  Subscriptions:").unwrap();
-            for sub in &self.subscriptions {
-                writeln!(
-                    &mut s,
-                    "    - {}: Type: {}, Quantity: {}, Created: {}, Updated: {}",
-                    sub.id, sub.r#type, sub.quantity, sub.created_at, sub.updated_at,
-                )
-                .unwrap();
+        if let Some(subs) = self.subscriptions.as_ref() {
+            if !subs.is_empty() {
+                writeln!(&mut s, "  Subscriptions:").unwrap();
+                for sub in subs {
+                    writeln!(
+                        &mut s,
+                        "    - {}: Type: {}, Quantity: {}, Created: {}, Updated: {}",
+                        sub.id, sub.r#type, sub.quantity, sub.created_at, sub.updated_at,
+                    )
+                    .unwrap();
+                }
             }
         }
         if let Some(flags) = self.flags.as_ref() {


### PR DESCRIPTION
- `name` is no longer used, CLIs that still expect it will be discontinued with this rollout
- `created_at` will always be set
- `subscriptions` made nullable to allow moving it to other model/api, also allow representing that no subscription data was gathered

and some other random nitpicks