### PR TITLE
feat(builder, cargo-shuttle): build and run with docker locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,6 +409,7 @@ workflows:
           matrix:
             parameters:
               crate:
+                - shuttle-builder
                 - shuttle-codegen
                 - shuttle-common
                 - shuttle-ifc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +283,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -399,6 +450,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shuttle-api-client",
+ "shuttle-builder",
  "shuttle-common",
  "shuttle-ifc",
  "shuttle-mcp",
@@ -3963,6 +4015,15 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "shuttle-builder"
+version = "0.56.0"
+dependencies = [
+ "askama",
+ "pretty_assertions",
+ "shuttle-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
   "admin",
   "api-client",
+  "builder",
   "cargo-shuttle",
   "codegen",
   "common",
@@ -21,6 +22,7 @@ repository = "https://github.com/shuttle-hq/shuttle"
 
 [workspace.dependencies]
 shuttle-api-client = { path = "api-client", version = "0.56.1", default-features = false }
+shuttle-builder = { path = "builder", version = "0.56.0" }
 shuttle-codegen = { path = "codegen", version = "0.56.0" }
 shuttle-common = { path = "common", version = "0.56.0" }
 shuttle-ifc = { path = "ifc", version = "0.56.0" }
@@ -28,6 +30,7 @@ shuttle-mcp = { path = "mcp", version = "0.56.0" }
 shuttle-service = { path = "service", version = "0.56.0" }
 
 anyhow = "1.0.66"
+askama = "0.14.0"
 assert_cmd = "2.0.6"
 async-trait = "0.1.58"
 axum = { version = "0.8.1", default-features = false }

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "shuttle-builder"
+version = "0.56.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Docker build recipes for the Shuttle platform (shuttle.dev)"
+homepage = "https://www.shuttle.dev"
+
+[dependencies]
+shuttle-common = { workspace = true, features = ["models"] }
+
+askama = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -1,0 +1,68 @@
+use askama::Template;
+use shuttle_common::models::deployment::BuildArgsRust;
+
+#[derive(Template)]
+#[template(path = "rust.Dockerfile.jinja2", escape = "none")]
+pub struct RustDockerfile<'a> {
+    /// local or remote image name for the chef image
+    pub chef_image: &'a str,
+    /// content of inlined chef dockerfile
+    pub cargo_chef_dockerfile: Option<&'a str>,
+    /// local or remote image name for the runtime image
+    pub runtime_image: &'a str,
+    /// content of inlined runtime dockerfile
+    pub runtime_base_dockerfile: Option<&'a str>,
+    pub build_args: &'a BuildArgsRust,
+}
+
+pub fn render_rust_dockerfile(build_args: &BuildArgsRust) -> String {
+    RustDockerfile {
+        chef_image: "cargo-chef",
+        cargo_chef_dockerfile: Some(include_str!("../templates/cargo-chef.Dockerfile")),
+        runtime_image: "runtime-base",
+        runtime_base_dockerfile: Some(include_str!("../templates/runtime-base.Dockerfile")),
+        build_args,
+    }
+    .render()
+    .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_str_eq;
+
+    #[test]
+    fn rust_basic() {
+        let t = RustDockerfile {
+            chef_image: "chef",
+            cargo_chef_dockerfile: Some("foo"),
+            runtime_image: "rt",
+            runtime_base_dockerfile: Some("bar"),
+            build_args: &BuildArgsRust {
+                package_name: Some("hello".into()),
+                features: Some("asdf".into()),
+                ..Default::default()
+            },
+        };
+
+        let s = t.render().unwrap();
+
+        assert!(s.contains("foo\n\n"));
+        assert!(s.contains("bar\n\n"));
+        assert!(s.contains("FROM chef AS chef"));
+        assert!(s.contains("FROM rt AS runtime"));
+        assert!(s.contains("RUN cargo chef cook --release --package hello --features asdf\n"));
+        assert!(s.contains("mv /app/target/release/hello"));
+    }
+
+    #[test]
+    fn rust_full() {
+        let s = render_rust_dockerfile(&BuildArgsRust {
+            package_name: Some("hello".into()),
+            features: Some("asdf".into()),
+            ..Default::default()
+        });
+        assert_str_eq!(s, include_str!("../tests/rust.Dockerfile"));
+    }
+}

--- a/builder/templates/cargo-chef.Dockerfile
+++ b/builder/templates/cargo-chef.Dockerfile
@@ -1,0 +1,47 @@
+#syntax=docker/dockerfile:1.4
+
+FROM lukemathwalker/cargo-chef:latest AS cargo-chef
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+RUN <<EOT
+# Files and directories used by the Shuttle build process:
+mkdir /build_assets
+mkdir /app
+# Create empty files in place for optional user scripts, etc.
+# Having them empty means we can skip checking for them with [ -f ... ] etc.
+touch /app/Shuttle.toml
+touch /app/shuttle_prebuild.sh
+touch /app/shuttle_postbuild.sh
+touch /app/shuttle_setup_container.sh
+EOT
+
+# Install common build tools for external crates
+# The image should already have these: https://github.com/docker-library/buildpack-deps/blob/fdfe65ea0743aa735b4a5f27cac8e281e43508f5/debian/bookworm/Dockerfile
+RUN <<EOT
+apt-get update
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    clang \
+    cmake \
+    jq \
+    llvm-dev \
+    libclang-dev \
+    mold \
+    protobuf-compiler
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOT
+
+# Add the wasm32 target for building frontend frameworks
+RUN rustup target add wasm32-unknown-unknown
+
+# cargo binstall
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+# Utility tools for build process
+RUN cargo binstall -y --locked convert2json@1.1.5
+
+# Common cargo build tools (for the user to use)
+RUN cargo binstall -y --locked trunk@0.21.7

--- a/builder/templates/cargo-chef.Dockerfile
+++ b/builder/templates/cargo-chef.Dockerfile
@@ -1,5 +1,3 @@
-#syntax=docker/dockerfile:1.4
-
 FROM lukemathwalker/cargo-chef:latest AS cargo-chef
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/builder/templates/runtime-base.Dockerfile
+++ b/builder/templates/runtime-base.Dockerfile
@@ -1,0 +1,17 @@
+#syntax=docker/dockerfile:1.4
+
+FROM debian:bookworm-slim AS runtime-base
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+# ca-certificates for native-tls, curl for health check
+RUN <<EOT
+apt-get update
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOT

--- a/builder/templates/runtime-base.Dockerfile
+++ b/builder/templates/runtime-base.Dockerfile
@@ -1,5 +1,3 @@
-#syntax=docker/dockerfile:1.4
-
 FROM debian:bookworm-slim AS runtime-base
 
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]

--- a/builder/templates/rust.Dockerfile.jinja2
+++ b/builder/templates/rust.Dockerfile.jinja2
@@ -20,7 +20,8 @@ COPY shuttle_prebuild.sh .
 RUN bash shuttle_prebuild.sh
 
 {% if build_args.mold %}
-export RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=/usr/local/bin/mold"
+{# TODO: fix #}
+ENV RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=/usr/local/bin/mold"
 {% endif %}
 
 {% if build_args.cargo_chef %}

--- a/builder/templates/rust.Dockerfile.jinja2
+++ b/builder/templates/rust.Dockerfile.jinja2
@@ -1,3 +1,5 @@
+#syntax=docker/dockerfile:1.4
+
 {% if let Some(s) = cargo_chef_dockerfile %}{{s}}{% endif %}
 
 {% if let Some(s) = runtime_base_dockerfile %}{{s}}{% endif %}

--- a/builder/templates/rust.Dockerfile.jinja2
+++ b/builder/templates/rust.Dockerfile.jinja2
@@ -1,0 +1,69 @@
+{% if let Some(s) = cargo_chef_dockerfile %}{{s}}{% endif %}
+
+{% if let Some(s) = runtime_base_dockerfile %}{{s}}{% endif %}
+
+FROM {{ chef_image }} AS chef
+WORKDIR /app
+ENV SHUTTLE=true
+
+
+{% if build_args.cargo_chef %}
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare
+{% endif %}
+
+
+FROM chef AS builder
+
+COPY shuttle_prebuild.sh .
+RUN bash shuttle_prebuild.sh
+
+{% if build_args.mold %}
+export RUSTFLAGS="-C linker=clang -C link-arg=-fuse-ld=/usr/local/bin/mold"
+{% endif %}
+
+{% if build_args.cargo_chef %}
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release
+    {%- if let Some(s) = build_args.package_name %} --package {{s}}{% endif %}
+    {%- if let Some(s) = build_args.binary_name %} --bin {{s}}{% endif %}
+    {%- if let Some(s) = build_args.features %} --features {{s}}{% endif %}
+    {%- if build_args.no_default_features %} --no-default-features{% endif %}
+{% endif %}
+
+COPY . .
+
+{% if build_args.cargo_build %}
+RUN cargo build --release
+    {%- if let Some(s) = build_args.package_name %} --package {{s}}{% endif %}
+    {%- if let Some(s) = build_args.binary_name %} --bin {{s}}{% endif %}
+    {%- if let Some(s) = build_args.features %} --features {{s}}{% endif %}
+    {%- if build_args.no_default_features %} --no-default-features{% endif %}
+{% endif %}
+
+RUN bash shuttle_postbuild.sh
+
+RUN mv /app/target/release/
+    {%- if let Some(s) = build_args.binary_name -%}
+    {{s}}
+    {%- else if let Some(s) = build_args.package_name -%}
+    {{s}}
+    {%- endif %} /executable
+
+{# Create folders and copy paths of all specified build assets #}
+{# For loop is used so that no find command is run when the array is empty #}
+RUN for path in $(tq -r '.build.assets // .build_assets // [] | join(" ")' Shuttle.toml); do find "$path" -type f -exec echo Copying \{\} \; -exec install -D \{\} /build_assets/\{\} \; ; done
+
+
+FROM {{ runtime_image }} AS runtime
+WORKDIR /app
+
+COPY --from=builder /app/shuttle_setup_container.sh /tmp
+RUN bash /tmp/shuttle_setup_container.sh; rm /tmp/shuttle_setup_container.sh
+
+COPY --from=builder /build_assets /app
+COPY --from=builder /executable /usr/local/bin/runtime
+
+ENTRYPOINT ["/usr/local/bin/runtime"]
+

--- a/builder/tests/rust.Dockerfile
+++ b/builder/tests/rust.Dockerfile
@@ -1,27 +1,38 @@
+#syntax=docker/dockerfile:1.4
+
 FROM lukemathwalker/cargo-chef:latest AS cargo-chef
 
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+RUN <<EOT
 # Files and directories used by the Shuttle build process:
-RUN mkdir /build_assets
-RUN mkdir /app
+mkdir /build_assets
+mkdir /app
 # Create empty files in place for optional user scripts, etc.
 # Having them empty means we can skip checking for them with [ -f ... ] etc.
-RUN touch /app/Shuttle.toml
-RUN touch /app/shuttle_prebuild.sh
-RUN touch /app/shuttle_postbuild.sh
-RUN touch /app/shuttle_setup_container.sh
+touch /app/Shuttle.toml
+touch /app/shuttle_prebuild.sh
+touch /app/shuttle_postbuild.sh
+touch /app/shuttle_setup_container.sh
+EOT
 
 # Install common build tools for external crates
 # The image should already have these: https://github.com/docker-library/buildpack-deps/blob/fdfe65ea0743aa735b4a5f27cac8e281e43508f5/debian/bookworm/Dockerfile
-RUN apt update \
-    && apt install -y \
+RUN <<EOT
+apt-get update
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     clang \
     cmake \
     jq \
     llvm-dev \
     libclang-dev \
     mold \
-    protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
+    protobuf-compiler
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOT
 
 # Add the wasm32 target for building frontend frameworks
 RUN rustup target add wasm32-unknown-unknown
@@ -38,10 +49,19 @@ RUN cargo binstall -y --locked trunk@0.21.7
 
 FROM debian:bookworm-slim AS runtime-base
 
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
 # ca-certificates for native-tls, curl for health check
-RUN apt update \
-    && apt install -y ca-certificates curl \
-    && rm -rf /var/lib/apt/lists/*
+RUN <<EOT
+apt-get update
+
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+EOT
 
 
 FROM cargo-chef AS chef

--- a/builder/tests/rust.Dockerfile
+++ b/builder/tests/rust.Dockerfile
@@ -1,0 +1,95 @@
+FROM lukemathwalker/cargo-chef:latest AS cargo-chef
+
+# Files and directories used by the Shuttle build process:
+RUN mkdir /build_assets
+RUN mkdir /app
+# Create empty files in place for optional user scripts, etc.
+# Having them empty means we can skip checking for them with [ -f ... ] etc.
+RUN touch /app/Shuttle.toml
+RUN touch /app/shuttle_prebuild.sh
+RUN touch /app/shuttle_postbuild.sh
+RUN touch /app/shuttle_setup_container.sh
+
+# Install common build tools for external crates
+# The image should already have these: https://github.com/docker-library/buildpack-deps/blob/fdfe65ea0743aa735b4a5f27cac8e281e43508f5/debian/bookworm/Dockerfile
+RUN apt update \
+    && apt install -y \
+    clang \
+    cmake \
+    jq \
+    llvm-dev \
+    libclang-dev \
+    mold \
+    protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add the wasm32 target for building frontend frameworks
+RUN rustup target add wasm32-unknown-unknown
+
+# cargo binstall
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+# Utility tools for build process
+RUN cargo binstall -y --locked convert2json@1.1.5
+
+# Common cargo build tools (for the user to use)
+RUN cargo binstall -y --locked trunk@0.21.7
+
+
+FROM debian:bookworm-slim AS runtime-base
+
+# ca-certificates for native-tls, curl for health check
+RUN apt update \
+    && apt install -y ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+
+FROM cargo-chef AS chef
+WORKDIR /app
+ENV SHUTTLE=true
+
+
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare
+
+
+
+FROM chef AS builder
+
+COPY shuttle_prebuild.sh .
+RUN bash shuttle_prebuild.sh
+
+
+
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --package hello --features asdf
+
+
+COPY . .
+
+
+RUN cargo build --release --package hello --features asdf
+
+
+RUN bash shuttle_postbuild.sh
+
+RUN mv /app/target/release/hello /executable
+
+
+
+RUN for path in $(tq -r '.build.assets // .build_assets // [] | join(" ")' Shuttle.toml); do find "$path" -type f -exec echo Copying \{\} \; -exec install -D \{\} /build_assets/\{\} \; ; done
+
+
+FROM runtime-base AS runtime
+WORKDIR /app
+
+COPY --from=builder /app/shuttle_setup_container.sh /tmp
+RUN bash /tmp/shuttle_setup_container.sh; rm /tmp/shuttle_setup_container.sh
+
+COPY --from=builder /build_assets /app
+COPY --from=builder /executable /usr/local/bin/runtime
+
+ENTRYPOINT ["/usr/local/bin/runtime"]

--- a/cargo-shuttle/Cargo.toml
+++ b/cargo-shuttle/Cargo.toml
@@ -10,6 +10,7 @@ default-run = "shuttle"
 
 [dependencies]
 shuttle-api-client = { workspace = true, default-features = true }
+shuttle-builder = { workspace = true }
 shuttle-common = { workspace = true, features = ["models", "tables", "config"] }
 shuttle-ifc = { workspace = true }
 shuttle-mcp = { workspace = true }

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -405,6 +405,9 @@ pub struct BuildArgs {
     /// Uses bacon crate to run the project in watch mode
     #[arg(long)]
     pub bacon: bool,
+    /// Output the build archive to a file instead of building
+    #[arg(long)]
+    pub output_archive: Option<PathBuf>,
 
     // Docker-related args
     /// Build/Run with docker instead of natively

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -124,10 +124,16 @@ impl ProjectArgs {
 #[derive(Subcommand)]
 pub enum Command {
     /// Generate a Shuttle project from a template
+    #[command(visible_alias = "i")]
     Init(InitArgs),
     /// Run a project locally
+    #[command(visible_alias = "r")]
     Run(RunArgs),
+    /// Build a project
+    #[command(visible_alias = "b")]
+    Build(BuildArgs),
     /// Deploy a project
+    #[command(visible_alias = "d")]
     Deploy(DeployArgs),
     /// Manage deployments
     #[command(subcommand, visible_alias = "depl")]
@@ -381,18 +387,32 @@ pub struct RunArgs {
     /// Use 0.0.0.0 instead of localhost (for usage with local external devices)
     #[arg(long)]
     pub external: bool,
-    /// Use release mode for building the project
-    #[arg(long, short = 'r')]
-    pub release: bool,
     /// Don't display timestamps and log origin tags
     #[arg(long)]
     pub raw: bool,
+
+    #[command(flatten)]
+    pub secret_args: SecretsArgs,
+    #[command(flatten)]
+    pub build_args: BuildArgs,
+}
+
+#[derive(Args, Debug)]
+pub struct BuildArgs {
+    /// Use release mode for building the project
+    #[arg(long, short = 'r')]
+    pub release: bool,
     /// Uses bacon crate to run the project in watch mode
     #[arg(long)]
     pub bacon: bool,
 
-    #[command(flatten)]
-    pub secret_args: SecretsArgs,
+    // Docker-related args
+    /// Build/Run with docker instead of natively
+    #[arg(long, short = 'd')]
+    pub docker: bool,
+    /// Additional tag for the docker image
+    #[arg(long, short = 't')]
+    pub tag: Option<String>,
 }
 
 #[derive(Args, Debug, Default)]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -68,13 +68,12 @@ pub enum OutputMode {
 /// Global project-related options
 #[derive(Args, Clone, Debug)]
 pub struct ProjectArgs {
-    /// Specify the working directory
     #[arg(global = true, long, visible_alias = "wd", default_value = ".", value_parser = OsStringValueParser::new().try_map(parse_path))]
     pub working_directory: PathBuf,
-    /// Specify the name of the project to target or create
+    /// The name of the project to target or create
     #[arg(global = true, long)]
     pub name: Option<String>,
-    /// Specify the id of the project to target
+    /// The id of the project to target
     #[arg(global = true, long)]
     pub id: Option<String>,
 }
@@ -130,7 +129,7 @@ pub enum Command {
     #[command(visible_alias = "r")]
     Run(RunArgs),
     /// Build a project
-    #[command(visible_alias = "b")]
+    #[command(visible_alias = "b", hide = true)]
     Build(BuildArgs),
     /// Deploy a project
     #[command(visible_alias = "d")]
@@ -379,7 +378,7 @@ pub struct DeploymentTrackingArgs {
     pub raw: bool,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Default)]
 pub struct RunArgs {
     /// Port to start service on
     #[arg(long, short = 'p', env, default_value = "8000")]
@@ -394,27 +393,34 @@ pub struct RunArgs {
     #[command(flatten)]
     pub secret_args: SecretsArgs,
     #[command(flatten)]
-    pub build_args: BuildArgs,
+    pub build_args: BuildArgsShared,
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Default)]
 pub struct BuildArgs {
-    /// Use release mode for building the project
-    #[arg(long, short = 'r')]
-    pub release: bool,
-    /// Uses bacon crate to run the project in watch mode
-    #[arg(long)]
-    pub bacon: bool,
     /// Output the build archive to a file instead of building
     #[arg(long)]
     pub output_archive: Option<PathBuf>,
+    #[command(flatten)]
+    pub inner: BuildArgsShared,
+}
+
+/// Arguments shared by build and run commands
+#[derive(Args, Debug, Default)]
+pub struct BuildArgsShared {
+    /// Use release mode for building the project
+    #[arg(long, short = 'r')]
+    pub release: bool,
+    /// Uses bacon crate to build/run the project in watch mode
+    #[arg(long)]
+    pub bacon: bool,
 
     // Docker-related args
     /// Build/Run with docker instead of natively
-    #[arg(long, short = 'd')]
+    #[arg(long, hide = true)]
     pub docker: bool,
     /// Additional tag for the docker image
-    #[arg(long, short = 't')]
+    #[arg(long, short = 't', requires = "docker", hide = true)]
     pub tag: Option<String>,
 }
 

--- a/cargo-shuttle/src/builder.rs
+++ b/cargo-shuttle/src/builder.rs
@@ -1,6 +1,5 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
 use cargo_metadata::{Metadata, Package, Target};
@@ -127,7 +126,7 @@ pub async fn gather_rust_build_args(metadata: &Metadata) -> Result<BuildArgsRust
 pub async fn cargo_build(
     project_path: impl Into<PathBuf>,
     release_mode: bool,
-    silent: bool,
+    quiet: bool,
 ) -> Result<BuiltService> {
     let project_path = project_path.into();
     let manifest_path = project_path.join("Cargo.toml");
@@ -168,11 +167,10 @@ pub async fn cargo_build(
     } else {
         "debug"
     };
-
-    if silent {
-        cmd.stderr(Stdio::null());
-        cmd.stdout(Stdio::null());
+    if quiet {
+        cmd.arg("--quiet");
     }
+
     let status = cmd.spawn()?.wait().await?;
     if !status.success() {
         bail!("Build failed.");

--- a/cargo-shuttle/src/builder.rs
+++ b/cargo-shuttle/src/builder.rs
@@ -5,7 +5,7 @@ use anyhow::{bail, Context, Result};
 use cargo_metadata::{Metadata, Package, Target};
 use shuttle_common::models::deployment::BuildArgsRust;
 use shuttle_ifc::find_runtime_main_fn;
-use tracing::trace;
+use tracing::{debug, trace};
 
 /// This represents a compiled Shuttle service
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -101,7 +101,7 @@ pub fn find_first_shuttle_package(
     )
 }
 
-pub async fn gather_rust_build_args(metadata: &Metadata) -> Result<BuildArgsRust> {
+pub fn gather_rust_build_args(metadata: &Metadata) -> Result<BuildArgsRust> {
     let mut rust_build_args = BuildArgsRust::default();
 
     let (package, target, runtime_version) = find_first_shuttle_package(metadata)?;
@@ -120,6 +120,8 @@ pub async fn gather_rust_build_args(metadata: &Metadata) -> Result<BuildArgsRust
 
     // TODO: have all of the above be configurable in CLI and Shuttle.toml
 
+    debug!("Gathered build args: {:?}", rust_build_args);
+
     Ok(rust_build_args)
 }
 
@@ -131,7 +133,7 @@ pub async fn cargo_build(
     let project_path = project_path.into();
     let manifest_path = project_path.join("Cargo.toml");
     let metadata = async_cargo_metadata(manifest_path.as_path()).await?;
-    let build_args = gather_rust_build_args(&metadata).await?;
+    let build_args = gather_rust_build_args(&metadata)?;
 
     let package_name = build_args
         .package_name

--- a/cargo-shuttle/src/builder.rs
+++ b/cargo-shuttle/src/builder.rs
@@ -162,7 +162,7 @@ pub fn find_first_shuttle_package(
 pub async fn gather_rust_build_args(metadata: &Metadata) -> Result<BuildArgsRust> {
     let mut rust_build_args = BuildArgsRust::default();
 
-    let (package, target, runtime_version) = find_first_shuttle_package(&metadata)?;
+    let (package, target, runtime_version) = find_first_shuttle_package(metadata)?;
     rust_build_args.package_name = Some(package.name.to_string());
     rust_build_args.binary_name = Some(target.name.clone());
     rust_build_args.shuttle_runtime_version = runtime_version;

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{bail, Context, Result};
 use args::DeploymentTrackingArgs;
 use chrono::Utc;
 use clap::{parser::ValueSource, CommandFactory, FromArgMatches};
@@ -1923,7 +1923,7 @@ impl Shuttle {
                     println!("{}", r.raw_json);
                 }
             }
-            return Err(anyhow!("Deployment failed"));
+            bail!("Deployment failed");
         }
 
         Ok(())

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1339,9 +1339,9 @@ impl Shuttle {
             fs::write(path, archive).context("writing archive")?;
             Ok(())
         } else if build_args.docker {
-            self.local_docker_build(&build_args).await
+            self.local_docker_build(build_args).await
         } else {
-            self.local_build(&build_args).await.map(|_| ())
+            self.local_build(build_args).await.map(|_| ())
         }
     }
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1343,6 +1343,10 @@ impl Shuttle {
 
         let project_directory = self.ctx.project_directory();
 
+        // TODO: use build args in local build
+        let manifest_path = project_directory.join("Cargo.toml");
+        let _rust_build_args = Self::gather_rust_build_args(manifest_path.as_path()).await?;
+
         cargo_green_eprintln("Building", project_directory.display());
 
         build_workspace(project_directory, build_args.release, tx).await
@@ -1640,7 +1644,6 @@ impl Shuttle {
         Ok(())
     }
 
-    // TODO: use this in native local runs as well
     async fn gather_rust_build_args(manifest_path: &Path) -> Result<BuildArgsRust> {
         let mut rust_build_args = BuildArgsRust::default();
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -278,7 +278,9 @@ impl Shuttle {
                     deployment_id,
                     tracking_args,
                 } => self.deployment_redeploy(deployment_id, tracking_args).await,
-                DeploymentCommand::Stop { tracking_args } => self.stop(tracking_args).await,
+                DeploymentCommand::Stop { tracking_args } => {
+                    self.deployment_stop(tracking_args).await
+                }
             },
             Command::Resource(cmd) => match cmd {
                 ResourceCommand::List {
@@ -922,7 +924,7 @@ impl Shuttle {
         Ok(())
     }
 
-    async fn stop(&self, tracking_args: DeploymentTrackingArgs) -> Result<()> {
+    async fn deployment_stop(&self, tracking_args: DeploymentTrackingArgs) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
         let res = client.stop_service(pid).await?.into_inner();

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -2144,7 +2144,6 @@ impl Shuttle {
     fn make_archive(&self) -> Result<Vec<u8>> {
         let archive_files = self.gather_build_files()?;
         if archive_files.is_empty() {
-            error!("No files included in build. Aborting...");
             bail!("No files included in build");
         }
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1655,7 +1655,7 @@ impl Shuttle {
         let manifest_path = project_directory.join("Cargo.toml");
 
         let metadata = async_cargo_metadata(manifest_path.as_path()).await?;
-        let rust_build_args = gather_rust_build_args(&metadata).await?;
+        let rust_build_args = gather_rust_build_args(&metadata)?;
 
         cargo_green_eprintln("Building", format!("{} with docker", project_name));
 
@@ -1764,7 +1764,7 @@ impl Shuttle {
 
         let metadata = async_cargo_metadata(manifest_path.as_path()).await?;
 
-        let rust_build_args = gather_rust_build_args(&metadata).await?;
+        let rust_build_args = gather_rust_build_args(&metadata)?;
         deployment_req.build_args = Some(CommonBuildArgs::Rust(rust_build_args));
 
         let (_, target, _) = find_first_shuttle_package(&metadata)?;

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1480,7 +1480,7 @@ impl Shuttle {
                 .spawn()
                 .context("spawning 'docker run' process")?
         } else {
-            let (service, runtime_executable) = s_re.expect("skill issue");
+            let (service, runtime_executable) = s_re.context("developer skill issue")?;
             eprintln!();
             cargo_green_eprintln(
                 "Starting",

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1334,6 +1334,7 @@ impl Shuttle {
     }
 
     async fn build(&self, build_args: &BuildArgs) -> Result<()> {
+        eprintln!("WARN: The build command is EXPERIMENTAL. Please submit feedback on GitHub or Discord if you encounter issues.");
         if let Some(path) = build_args.output_archive.as_ref() {
             let archive = self.make_archive()?;
             eprintln!("Writing archive to {}", path.display());

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1341,9 +1341,9 @@ impl Shuttle {
 
         cargo_green_eprintln("Building", project_directory.display());
 
-        // TODO: hook up --quiet flag to silent param
-        let silent = false;
-        cargo_build(project_directory.to_owned(), build_args.release, silent).await
+        // TODO: hook up -q/--quiet flag
+        let quiet = false;
+        cargo_build(project_directory.to_owned(), build_args.release, quiet).await
     }
 
     fn find_available_port(run_args: &mut RunArgs) {

--- a/cargo-shuttle/src/util/mod.rs
+++ b/cargo-shuttle/src/util/mod.rs
@@ -1,7 +1,7 @@
 pub mod bacon;
 
 use std::{
-    fmt::Write,
+    fmt::{Display, Write},
     fs::File,
     io::stdout,
     path::{Path, PathBuf},
@@ -13,6 +13,7 @@ use anyhow::{bail, Context, Result};
 use clap::CommandFactory;
 use clap_complete::{generate, Shell};
 use clap_mangen::Man;
+use crossterm::style::Stylize;
 use futures::StreamExt;
 use git2::{Repository, StatusOptions};
 use indoc::writedoc;
@@ -287,4 +288,9 @@ where
     }
 
     Ok(None)
+}
+
+/// Print a verb + line similar to how cargo does
+pub fn cargo_green_eprintln(verb: impl Display, line: impl Display) {
+    eprintln!("{} {}", format!("{verb:>12}").bold().green(), line);
 }

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -50,6 +50,7 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                     build_args: BuildArgs {
                         release: false,
                         bacon: false,
+                        output_archive: None,
                         docker: false,
                         tag: None,
                     },

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -1,6 +1,6 @@
 use std::{fs::canonicalize, process::exit, time::Duration};
 
-use cargo_shuttle::{BuildArgs, Command, ProjectArgs, RunArgs, Shuttle, ShuttleArgs};
+use cargo_shuttle::{Command, ProjectArgs, RunArgs, Shuttle, ShuttleArgs};
 use portpicker::pick_unused_port;
 use tokio::time::sleep;
 
@@ -45,15 +45,7 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                 cmd: Command::Run(RunArgs {
                     port,
                     external,
-                    raw: false,
-                    secret_args: Default::default(),
-                    build_args: BuildArgs {
-                        release: false,
-                        bacon: false,
-                        output_archive: None,
-                        docker: false,
-                        tag: None,
-                    },
+                    ..Default::default()
                 }),
             },
             false,

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -1,6 +1,6 @@
 use std::{fs::canonicalize, process::exit, time::Duration};
 
-use cargo_shuttle::{Command, ProjectArgs, RunArgs, Shuttle, ShuttleArgs};
+use cargo_shuttle::{BuildArgs, Command, ProjectArgs, RunArgs, Shuttle, ShuttleArgs};
 use portpicker::pick_unused_port;
 use tokio::time::sleep;
 
@@ -45,10 +45,14 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                 cmd: Command::Run(RunArgs {
                     port,
                     external,
-                    release: false,
                     raw: false,
-                    bacon: false,
                     secret_args: Default::default(),
+                    build_args: BuildArgs {
+                        release: false,
+                        bacon: false,
+                        docker: false,
+                        tag: None,
+                    },
                 }),
             },
             false,

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -163,7 +163,7 @@ pub enum BuildArgs {
     // No Unknown variant: is a Request type and should only be deserialized on backend
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[typeshare::typeshare]
 pub struct BuildArgsRust {


### PR DESCRIPTION
Introduces (hidden commands + prints a warnings about being experimental):
- `shuttle build` which builds the runtime natively with `cargo build`, just like `shuttle run` does.
  - Supports `--release/-r` and `--bacon` args from `run`
  - Supports `--output-archive`
- `shuttle build --docker` which uses the same archiving logic as deploy, and the same dockerfile pipeline as the platform.
  - Great for debugging the platform's build system.
  - `--tag/-t [tag]` can be used to tag the image (in addition to the default image tag `shuttle-build-[project_name]`) so that it can later be used to `docker push` somewhere. *Enables adding a `--push` arg in the future.*
  - Does not support `--bacon`.
  - Always builds in release mode (like platform) (can be changed).
- (experimental) `shuttle run --docker` does a local run with the docker build followed by a `docker run`.
  - Great for debugging the platform's runtime environment. 
  - Does not support same things as `build --docker`, and potentially more. (alpha state, highly untested)

Adds aliases:
- `shuttle i` for init
- `shuttle b` for build (parity with cargo)
- `shuttle r` for run (parity with cargo)
- `shuttle d` for deploy (note: `shuttle depl` is current alias for deployment subcommands)

Also:
- Fancier "Packing", "Uploading", "Building" printouts that match the ones from cargo
- Let cargo build process print all its output to stdout/stderr, no tx/rx channels
- Unify how args for local build and docker (remote) builds are gathered.

TODO (followups):
- Increase parity in `run --docker`
- CI for build & run with `--docker`