### PR TITLE
feat(api-client): always catch 4xx and 5xx errors regardless of body type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,6 +3789,7 @@ version = "0.55.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "headers",
  "http",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ assert_cmd = "2.0.6"
 async-trait = "0.1.58"
 axum = { version = "0.8.1", default-features = false }
 bollard = { version = "0.18.1", features = ["ssl_providerless"] }
+bytes = "1"
 cargo_metadata = "0.19.1"
 chrono = { version = "0.4.34", default-features = false }
 clap = { version = "4.2.7", features = ["derive"] }

--- a/api-client/Cargo.toml
+++ b/api-client/Cargo.toml
@@ -12,6 +12,7 @@ shuttle-common = { workspace = true, features = ["models", "unknown-variants"] }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+bytes = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }
 percent-encoding = { workspace = true }

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -18,7 +18,7 @@ fn into_api_error(body: &str, status_code: StatusCode) -> ApiError {
     #[cfg(feature = "tracing")]
     tracing::trace!("Parsing response as API error");
 
-    let res: ApiError = match serde_json::from_str(&body) {
+    let res: ApiError = match serde_json::from_str(body) {
         Ok(res) => res,
         _ => ApiError::new(
             format!("Failed to parse error response from the server:\n{}", body),

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -1,47 +1,95 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use bytes::Bytes;
 use http::StatusCode;
 use serde::de::DeserializeOwned;
 use shuttle_common::models::error::ApiError;
 
-/// A to_json wrapper for handling our error states
+/// Helpers for consuming and parsing response bodies and handling parsing of an ApiError if the response is 4xx/5xx
 #[async_trait]
-pub trait ToJson {
+pub trait ToBodyContent {
     async fn to_json<T: DeserializeOwned>(self) -> Result<T>;
+    async fn to_text(self) -> Result<String>;
+    async fn to_bytes(self) -> Result<Bytes>;
+    async fn to_empty(self) -> Result<()>;
+}
+
+fn into_api_error(body: &str, status_code: StatusCode) -> ApiError {
+    #[cfg(feature = "tracing")]
+    tracing::trace!("Parsing response as API error");
+
+    let res: ApiError = match serde_json::from_str(&body) {
+        Ok(res) => res,
+        _ => ApiError::new(
+            format!("Failed to parse error response from the server:\n{}", body),
+            status_code,
+        ),
+    };
+
+    res
+}
+
+/// Tries to convert bytes to string. If not possible, returns a string symbolizing the bytes and the length
+fn bytes_to_string_with_fallback(bytes: Bytes) -> String {
+    String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| format!("[{} bytes]", bytes.len()))
 }
 
 #[async_trait]
-impl ToJson for reqwest::Response {
+impl ToBodyContent for reqwest::Response {
     async fn to_json<T: DeserializeOwned>(self) -> Result<T> {
         let status_code = self.status();
         let bytes = self.bytes().await?;
-        let string = String::from_utf8(bytes.to_vec())
-            .unwrap_or_else(|_| format!("[{} bytes]", bytes.len()));
+        let string = bytes_to_string_with_fallback(bytes);
 
         #[cfg(feature = "tracing")]
         tracing::trace!(response = %string, "Parsing response as JSON");
 
-        if matches!(
-            status_code,
-            StatusCode::OK | StatusCode::SWITCHING_PROTOCOLS
-        ) {
-            serde_json::from_str(&string).context("failed to parse a successful response")
-        } else {
-            #[cfg(feature = "tracing")]
-            tracing::trace!("Parsing response as API error");
-
-            let res: ApiError = match serde_json::from_str(&string) {
-                Ok(res) => res,
-                _ => ApiError::new(
-                    format!(
-                        "Failed to parse error response from the server:\n{}",
-                        string
-                    ),
-                    status_code,
-                ),
-            };
-
-            Err(res.into())
+        if status_code.is_client_error() || status_code.is_server_error() {
+            return Err(into_api_error(&string, status_code).into());
         }
+
+        serde_json::from_str(&string).context("failed to parse a successful response")
+    }
+
+    async fn to_text(self) -> Result<String> {
+        let status_code = self.status();
+        let bytes = self.bytes().await?;
+        let string = bytes_to_string_with_fallback(bytes);
+
+        #[cfg(feature = "tracing")]
+        tracing::trace!(response = %string, "Parsing response as text");
+
+        if status_code.is_client_error() || status_code.is_server_error() {
+            return Err(into_api_error(&string, status_code).into());
+        }
+
+        Ok(string)
+    }
+
+    async fn to_bytes(self) -> Result<Bytes> {
+        let status_code = self.status();
+        let bytes = self.bytes().await?;
+
+        #[cfg(feature = "tracing")]
+        tracing::trace!(response_length = bytes.len(), "Got response bytes");
+
+        if status_code.is_client_error() || status_code.is_server_error() {
+            let string = bytes_to_string_with_fallback(bytes);
+            return Err(into_api_error(&string, status_code).into());
+        }
+
+        Ok(bytes)
+    }
+
+    async fn to_empty(self) -> Result<()> {
+        let status_code = self.status();
+
+        if status_code.is_client_error() || status_code.is_server_error() {
+            let bytes = self.bytes().await?;
+            let string = bytes_to_string_with_fallback(bytes);
+            return Err(into_api_error(&string, status_code).into());
+        }
+
+        Ok(())
     }
 }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -862,7 +862,8 @@ impl Shuttle {
 
     async fn logout(&mut self, logout_args: LogoutArgs) -> Result<()> {
         if logout_args.reset_api_key {
-            self.reset_api_key().await?;
+            let client = self.client.as_ref().unwrap();
+            client.reset_api_key().await.context("Resetting API key")?;
             eprintln!("Successfully reset the API key.");
         }
         self.ctx.clear_api_key()?;
@@ -870,17 +871,6 @@ impl Shuttle {
         eprintln!(" -> Use `shuttle login` to log in again.");
 
         Ok(())
-    }
-
-    async fn reset_api_key(&self) -> Result<()> {
-        let client = self.client.as_ref().unwrap();
-        client.reset_api_key().await.and_then(|res| {
-            if res.status().is_success() {
-                Ok(())
-            } else {
-                Err(anyhow!("Resetting API key failed."))
-            }
-        })
     }
 
     async fn stop(&self, tracking_args: DeploymentTrackingArgs) -> Result<()> {

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -12,10 +12,14 @@
 
 ## Usage
 
-Start by installing the Shuttle CLI by running the following in a terminal:
+Start by installing the [Shuttle CLI](https://crates.io/crates/cargo-shuttle) by running the following in a terminal ([more installation options](https://docs.shuttle.dev/getting-started/installation)):
 
 ```bash
-cargo install cargo-shuttle
+# Linux / macOS
+curl -sSfL https://www.shuttle.dev/install | bash
+
+# Windows (Powershell)
+iwr https://www.shuttle.dev/install-win | iex
 ```
 
 Now that Shuttle is installed, you can initialize a project with Axum boilerplate:


### PR DESCRIPTION
Switches the error condition (when we should read the body as ApiError) from
`not(200 or 101)` to `4xx or 5xx`.

And makes sure each call with a plain verb uses one of the `to_*` methods to parse and return an error if there is one.