### PR TITLE
feat: make billing cycle optional in usage response

### DIFF
--- a/common/src/models/user.rs
+++ b/common/src/models/user.rs
@@ -224,11 +224,11 @@ pub struct UpdateAccountTierRequest {
     pub account_tier: AccountTier,
 }
 
-/// Response for the /user/me/usage backend endpoint
+/// Sub-Response for the /user/me/usage backend endpoint
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[typeshare::typeshare]
-pub struct UserUsageResponse {
+pub struct UserBillingCycle {
     /// Billing cycle start, or monthly from user creation
     /// depending on the account tier
     pub start: NaiveDate,
@@ -236,8 +236,17 @@ pub struct UserUsageResponse {
     /// Billing cycle end, or end of month from user creation
     /// depending on the account tier
     pub end: NaiveDate,
+}
 
-    /// HashMap of project related metrics for this cycle
-    /// keyed by project_id
+/// Response for the /user/me/usage backend endpoint
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[typeshare::typeshare]
+pub struct UserUsageResponse {
+    /// Billing cycle for user, will be None if no usage data exists for user.
+    pub billing_cycle: Option<UserBillingCycle>,
+
+    /// HashMap of project related metrics for this cycle keyed by project_id. Will be empty
+    /// if no project usage data exists for user.
     pub projects: HashMap<String, ProjectUsageResponse>,
 }


### PR DESCRIPTION
## Description of change
<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

Make the billing cycle optional, so we can return a 200 with an empty response if there is no data.

## How has this been tested? (if applicable)
<!-- Please describe any tests that you ran to verify your changes. -->


