### PR TITLE
feat(api-client, cargo-shuttle): json output mode

### DIFF
--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use serde_json::{json, Value};
-use shuttle_api_client::{util::ToBodyContent, ShuttleApiClient};
+use shuttle_api_client::{
+    util::{ParsedJson, ToBodyContent},
+    ShuttleApiClient,
+};
 use shuttle_common::models::{
     project::{ProjectResponse, ProjectUpdateRequest},
     team::AddTeamMemberRequest,
@@ -18,11 +21,13 @@ impl Client {
         }
     }
 
-    pub async fn get_old_certificates(&self) -> Result<Vec<(String, String, Option<String>)>> {
+    pub async fn get_old_certificates(
+        &self,
+    ) -> Result<ParsedJson<Vec<(String, String, Option<String>)>>> {
         self.inner.get_json("/admin/certificates").await
     }
 
-    pub async fn renew_certificate(&self, cert_id: &str) -> Result<String> {
+    pub async fn renew_certificate(&self, cert_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .put_json(
                 format!("/admin/certificates/renew/{cert_id}"),
@@ -35,7 +40,7 @@ impl Client {
         &self,
         project_id: &str,
         config: serde_json::Value,
-    ) -> Result<ProjectResponse> {
+    ) -> Result<ParsedJson<ProjectResponse>> {
         self.inner
             .put_json(
                 format!("/projects/{project_id}"),
@@ -47,13 +52,13 @@ impl Client {
             .await
     }
 
-    pub async fn get_project_config(&self, project_id: &str) -> Result<Value> {
+    pub async fn get_project_config(&self, project_id: &str) -> Result<ParsedJson<Value>> {
         self.inner
             .get_json(format!("/admin/projects/{project_id}/config"))
             .await
     }
 
-    pub async fn upgrade_project_to_lb(&self, project_id: &str) -> Result<Value> {
+    pub async fn upgrade_project_to_lb(&self, project_id: &str) -> Result<ParsedJson<Value>> {
         self.inner
             .put_json(
                 format!("/admin/projects/{project_id}/config"),
@@ -66,7 +71,7 @@ impl Client {
         &self,
         project_id: &str,
         update_config: &Value,
-    ) -> Result<Value> {
+    ) -> Result<ParsedJson<Value>> {
         self.inner
             .put_json(
                 format!("/admin/projects/{project_id}/scale"),
@@ -79,7 +84,7 @@ impl Client {
         &self,
         project_id: &str,
         user_id: String,
-    ) -> Result<ProjectResponse> {
+    ) -> Result<ParsedJson<ProjectResponse>> {
         self.inner
             .put_json(
                 format!("/projects/{project_id}"),
@@ -91,7 +96,11 @@ impl Client {
             .await
     }
 
-    pub async fn add_team_member(&self, team_user_id: &str, user_id: String) -> Result<String> {
+    pub async fn add_team_member(
+        &self,
+        team_user_id: &str,
+        user_id: String,
+    ) -> Result<ParsedJson<String>> {
         self.inner
             .post_json(
                 format!("/teams/{team_user_id}/members"),
@@ -126,27 +135,27 @@ impl Client {
         }
     }
 
-    pub async fn gc_free_tier(&self, days: u32) -> Result<Vec<String>> {
+    pub async fn gc_free_tier(&self, days: u32) -> Result<ParsedJson<Vec<String>>> {
         let path = format!("/admin/gc/free/{days}");
         self.inner.get_json(&path).await
     }
 
-    pub async fn gc_shuttlings(&self, minutes: u32) -> Result<Vec<String>> {
+    pub async fn gc_shuttlings(&self, minutes: u32) -> Result<ParsedJson<Vec<String>>> {
         let path = format!("/admin/gc/shuttlings/{minutes}");
         self.inner.get_json(&path).await
     }
 
-    pub async fn get_user(&self, user_id: &str) -> Result<UserResponse> {
+    pub async fn get_user(&self, user_id: &str) -> Result<ParsedJson<UserResponse>> {
         self.inner.get_json(format!("/admin/users/{user_id}")).await
     }
 
-    pub async fn get_user_everything(&self, query: &str) -> Result<Value> {
+    pub async fn get_user_everything(&self, query: &str) -> Result<ParsedJson<Value>> {
         self.inner
             .get_json_with_body("/admin/users/everything", json!(query))
             .await
     }
 
-    pub async fn delete_user(&self, user_id: &str) -> Result<String> {
+    pub async fn delete_user(&self, user_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .delete_json(format!("/admin/users/{user_id}"))
             .await
@@ -163,11 +172,11 @@ impl Client {
             .await
     }
 
-    pub async fn get_expired_protrials(&self) -> Result<Vec<String>> {
+    pub async fn get_expired_protrials(&self) -> Result<ParsedJson<Vec<String>>> {
         self.inner.get_json("/admin/users/protrial-downgrade").await
     }
 
-    pub async fn downgrade_protrial(&self, user_id: &str) -> Result<String> {
+    pub async fn downgrade_protrial(&self, user_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .put_json(
                 format!("/admin/users/protrial-downgrade/{user_id}"),

--- a/admin/src/lib.rs
+++ b/admin/src/lib.rs
@@ -57,21 +57,23 @@ pub async fn run(args: Args) {
             let res = client
                 .update_project_owner(&project_id, new_user_id)
                 .await
-                .unwrap();
+                .unwrap()
+                .into_inner();
             println!("{res:?}");
         }
         Command::AddUserToTeam {
             team_user_id,
             user_id,
         } => {
-            client
+            let res = client
                 .add_team_member(&team_user_id, user_id)
                 .await
-                .unwrap();
-            println!("added");
+                .unwrap()
+                .into_inner();
+            println!("{res:?}");
         }
         Command::RenewCerts => {
-            let certs = client.get_old_certificates().await.unwrap();
+            let certs = client.get_old_certificates().await.unwrap().into_inner();
             eprintln!("Starting renewals of {} certs in 5 seconds...", certs.len());
             tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
             for (cert_id, subject, acm) in certs {
@@ -125,7 +127,7 @@ pub async fn run(args: Args) {
             stop_deployments,
             limit,
         } => {
-            let project_ids = client.gc_free_tier(days).await.unwrap();
+            let project_ids = client.gc_free_tier(days).await.unwrap().into_inner();
             gc(client, project_ids, stop_deployments, limit).await;
         }
         Command::GcShuttlings {
@@ -133,7 +135,7 @@ pub async fn run(args: Args) {
             stop_deployments,
             limit,
         } => {
-            let project_ids = client.gc_shuttlings(minutes).await.unwrap();
+            let project_ids = client.gc_shuttlings(minutes).await.unwrap().into_inner();
             gc(client, project_ids, stop_deployments, limit).await;
         }
         Command::DeleteUser { user_id } => {
@@ -147,11 +149,15 @@ pub async fn run(args: Args) {
             println!("Set {user_id} to {tier}");
         }
         Command::Everything { query } => {
-            let v = client.get_user_everything(&query).await.unwrap();
+            let v = client
+                .get_user_everything(&query)
+                .await
+                .unwrap()
+                .into_inner();
             println!("{}", serde_json::to_string_pretty(&v).unwrap());
         }
         Command::DowngradeProTrials => {
-            let users = client.get_expired_protrials().await.unwrap();
+            let users = client.get_expired_protrials().await.unwrap().into_inner();
             eprintln!(
                 "Starting downgrade of {} users in 5 seconds...",
                 users.len()
@@ -183,7 +189,10 @@ async fn gc(client: Client, mut project_ids: Vec<String>, stop_deployments: bool
     );
     tokio::time::sleep(tokio::time::Duration::from_millis(5000)).await;
     for pid in project_ids {
-        println!("{}", client.inner.stop_service(&pid).await.unwrap());
+        println!(
+            "{}",
+            client.inner.stop_service(&pid).await.unwrap().into_inner()
+        );
         // prevent api rate limiting
         tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
     }

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -8,7 +10,7 @@ use shuttle_common::models::error::ApiError;
 /// Helpers for consuming and parsing response bodies and handling parsing of an ApiError if the response is 4xx/5xx
 #[async_trait]
 pub trait ToBodyContent {
-    async fn to_json<T: DeserializeOwned>(self) -> Result<T>;
+    async fn to_json<T: DeserializeOwned>(self) -> Result<ParsedJson<T>>;
     async fn to_text(self) -> Result<String>;
     async fn to_bytes(self) -> Result<Bytes>;
     async fn to_empty(self) -> Result<()>;
@@ -34,9 +36,31 @@ fn bytes_to_string_with_fallback(bytes: Bytes) -> String {
     String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| format!("[{} bytes]", bytes.len()))
 }
 
+pub struct ParsedJson<T> {
+    inner: T,
+    pub raw_json: String,
+}
+
+impl<T> ParsedJson<T> {
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: Debug> Debug for ParsedJson<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+impl<T: std::fmt::Display> std::fmt::Display for ParsedJson<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
 #[async_trait]
 impl ToBodyContent for reqwest::Response {
-    async fn to_json<T: DeserializeOwned>(self) -> Result<T> {
+    async fn to_json<T: DeserializeOwned>(self) -> Result<ParsedJson<T>> {
         let status_code = self.status();
         let bytes = self.bytes().await?;
         let string = bytes_to_string_with_fallback(bytes);
@@ -48,7 +72,12 @@ impl ToBodyContent for reqwest::Response {
             return Err(into_api_error(&string, status_code).into());
         }
 
-        serde_json::from_str(&string).context("failed to parse a successful response")
+        let t = serde_json::from_str(&string).context("failed to parse a successful response")?;
+
+        Ok(ParsedJson {
+            inner: t,
+            raw_json: string,
+        })
     }
 
     async fn to_text(self) -> Result<String> {

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -42,8 +42,14 @@ pub struct ParsedJson<T> {
 }
 
 impl<T> ParsedJson<T> {
+    pub fn as_ref(&self) -> &T {
+        &self.inner
+    }
     pub fn into_inner(self) -> T {
         self.inner
+    }
+    pub fn into_parts(self) -> (T, String) {
+        (self.inner, self.raw_json)
     }
 }
 

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -42,14 +42,17 @@ pub struct ParsedJson<T> {
 }
 
 impl<T> ParsedJson<T> {
-    pub fn as_ref(&self) -> &T {
-        &self.inner
-    }
     pub fn into_inner(self) -> T {
         self.inner
     }
     pub fn into_parts(self) -> (T, String) {
         (self.inner, self.raw_json)
+    }
+}
+
+impl<T> AsRef<T> for ParsedJson<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
     }
 }
 

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -42,11 +42,29 @@ pub struct ShuttleArgs {
     /// Turn on tracing output for Shuttle libraries. (WARNING: can print sensitive data)
     #[arg(global = true, long, env = "SHUTTLE_DEBUG")]
     pub debug: bool,
+    /// What format to output results in (where supported).
+    #[arg(
+        global = true,
+        long = "output",
+        env = "SHUTTLE_OUTPUT_MODE",
+        default_value = "normal"
+    )]
+    pub output_mode: OutputMode,
     #[command(flatten)]
     pub project_args: ProjectArgs,
 
     #[command(subcommand)]
     pub cmd: Command,
+}
+
+#[derive(
+    ValueEnum, Clone, Debug, Default, PartialEq /* , strum::EnumMessage, strum::VariantArray */,
+)]
+pub enum OutputMode {
+    #[default]
+    Normal,
+    Json,
+    // TODO?: add table / non-table / raw table / raw logs variants?
 }
 
 /// Global args for subcommands that deal with projects
@@ -158,7 +176,7 @@ pub enum GenerateCommand {
         shell: Shell,
         /// Output to a file (stdout by default)
         #[arg(short, long)]
-        output: Option<PathBuf>,
+        output_file: Option<PathBuf>,
     },
     /// Generate man page to the standard output
     Manpage,

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -537,13 +537,13 @@ pub struct LogsArgs {
     #[arg(long)]
     pub raw: bool,
     /// View the first N log lines
-    #[arg(long, group = "output_mode", hide = true)]
+    #[arg(long, group = "pagination", hide = true)]
     pub head: Option<u32>,
     /// View the last N log lines
-    #[arg(long, group = "output_mode", hide = true)]
+    #[arg(long, group = "pagination", hide = true)]
     pub tail: Option<u32>,
     /// View all log lines
-    #[arg(long, group = "output_mode", hide = true)]
+    #[arg(long, group = "pagination", hide = true)]
     pub all: bool,
     /// Get logs from all deployments instead of one deployment
     #[arg(long, hide = true)]

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -761,7 +761,8 @@ impl Shuttle {
                         .interact()?;
 
                     let r = client.create_project(&name).await?;
-                    let proj = match self.output_mode {
+
+                    match self.output_mode {
                         OutputMode::Normal => {
                             let proj = r.into_inner();
                             eprintln!("Created project '{}' with id {}", proj.name, proj.id);
@@ -771,9 +772,7 @@ impl Shuttle {
                             println!("{}", r.raw_json);
                             r.into_inner()
                         }
-                    };
-
-                    proj
+                    }
                 }
             }
         };

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -22,6 +22,7 @@ async fn shuttle_command(cmd: Command, working_directory: &str) -> anyhow::Resul
                 },
                 offline: false,
                 debug: false,
+                output_mode: Default::default(),
                 cmd,
             },
             false,

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -40,6 +40,7 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                 },
                 offline: false,
                 debug: false,
+                output_mode: Default::default(),
                 cmd: Command::Run(RunArgs {
                     port,
                     external,


### PR DESCRIPTION
Adds `--output json` so relevant commands print the json response instead. Not 100% coverage but the important ones have it.

breaking: generate command's `--output` arg renamed to `--output-file` (somewhat matches `deploy --output-archive`)