### PR TITLE
feat(api-client, cargo-shuttle): json output mode

### DIFF
--- a/admin/src/client.rs
+++ b/admin/src/client.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use serde_json::{json, Value};
-use shuttle_api_client::{util::ToBodyContent, ShuttleApiClient};
+use shuttle_api_client::{
+    util::{ParsedJson, ToBodyContent},
+    ShuttleApiClient,
+};
 use shuttle_common::models::{
     project::{ProjectResponse, ProjectUpdateRequest},
     team::AddTeamMemberRequest,
@@ -18,11 +21,13 @@ impl Client {
         }
     }
 
-    pub async fn get_old_certificates(&self) -> Result<Vec<(String, String, Option<String>)>> {
+    pub async fn get_old_certificates(
+        &self,
+    ) -> Result<ParsedJson<Vec<(String, String, Option<String>)>>> {
         self.inner.get_json("/admin/certificates").await
     }
 
-    pub async fn renew_certificate(&self, cert_id: &str) -> Result<String> {
+    pub async fn renew_certificate(&self, cert_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .put_json(
                 format!("/admin/certificates/renew/{cert_id}"),
@@ -35,7 +40,7 @@ impl Client {
         &self,
         project_id: &str,
         config: serde_json::Value,
-    ) -> Result<ProjectResponse> {
+    ) -> Result<ParsedJson<ProjectResponse>> {
         self.inner
             .put_json(
                 format!("/projects/{project_id}"),
@@ -47,13 +52,13 @@ impl Client {
             .await
     }
 
-    pub async fn get_project_config(&self, project_id: &str) -> Result<Value> {
+    pub async fn get_project_config(&self, project_id: &str) -> Result<ParsedJson<Value>> {
         self.inner
             .get_json(format!("/admin/projects/{project_id}/config"))
             .await
     }
 
-    pub async fn upgrade_project_to_lb(&self, project_id: &str) -> Result<Value> {
+    pub async fn upgrade_project_to_lb(&self, project_id: &str) -> Result<ParsedJson<Value>> {
         self.inner
             .put_json(
                 format!("/admin/projects/{project_id}/config"),
@@ -66,7 +71,7 @@ impl Client {
         &self,
         project_id: &str,
         update_config: &Value,
-    ) -> Result<Value> {
+    ) -> Result<ParsedJson<Value>> {
         self.inner
             .put_json(
                 format!("/admin/projects/{project_id}/scale"),
@@ -79,7 +84,7 @@ impl Client {
         &self,
         project_id: &str,
         user_id: String,
-    ) -> Result<ProjectResponse> {
+    ) -> Result<ParsedJson<ProjectResponse>> {
         self.inner
             .put_json(
                 format!("/projects/{project_id}"),
@@ -91,7 +96,11 @@ impl Client {
             .await
     }
 
-    pub async fn add_team_member(&self, team_user_id: &str, user_id: String) -> Result<String> {
+    pub async fn add_team_member(
+        &self,
+        team_user_id: &str,
+        user_id: String,
+    ) -> Result<ParsedJson<String>> {
         self.inner
             .post_json(
                 format!("/teams/{team_user_id}/members"),
@@ -126,32 +135,32 @@ impl Client {
         }
     }
 
-    pub async fn gc_free_tier(&self, days: u32) -> Result<Vec<String>> {
+    pub async fn gc_free_tier(&self, days: u32) -> Result<ParsedJson<Vec<String>>> {
         let path = format!("/admin/gc/free/{days}");
         self.inner.get_json(&path).await
     }
 
-    pub async fn gc_shuttlings(&self, minutes: u32) -> Result<Vec<String>> {
+    pub async fn gc_shuttlings(&self, minutes: u32) -> Result<ParsedJson<Vec<String>>> {
         let path = format!("/admin/gc/shuttlings/{minutes}");
         self.inner.get_json(&path).await
     }
 
-    pub async fn stop_gc_inactive_project(&self, project_id: &str) -> Result<String> {
+    pub async fn stop_gc_inactive_project(&self, project_id: &str) -> Result<ParsedJson<String>> {
         let path = format!("/admin/gc/stop-inactive-project/{project_id}");
         self.inner.put_json(&path, Option::<()>::None).await
     }
 
-    pub async fn get_user(&self, user_id: &str) -> Result<UserResponse> {
+    pub async fn get_user(&self, user_id: &str) -> Result<ParsedJson<UserResponse>> {
         self.inner.get_json(format!("/admin/users/{user_id}")).await
     }
 
-    pub async fn get_user_everything(&self, query: &str) -> Result<Value> {
+    pub async fn get_user_everything(&self, query: &str) -> Result<ParsedJson<Value>> {
         self.inner
             .get_json_with_body("/admin/users/everything", json!(query))
             .await
     }
 
-    pub async fn delete_user(&self, user_id: &str) -> Result<String> {
+    pub async fn delete_user(&self, user_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .delete_json(format!("/admin/users/{user_id}"))
             .await
@@ -168,10 +177,11 @@ impl Client {
             .await
     }
 
-    pub async fn get_expired_protrials(&self) -> Result<Vec<String>> {
+    pub async fn get_expired_protrials(&self) -> Result<ParsedJson<Vec<String>>> {
         self.inner.get_json("/admin/users/protrial-downgrade").await
     }
-    pub async fn downgrade_protrial(&self, user_id: &str) -> Result<String> {
+
+    pub async fn downgrade_protrial(&self, user_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .put_json(
                 format!("/admin/users/protrial-downgrade/{user_id}"),
@@ -180,10 +190,10 @@ impl Client {
             .await
     }
 
-    pub async fn get_projects_for_retention_policy(&self) -> Result<Vec<String>> {
+    pub async fn get_projects_for_retention_policy(&self) -> Result<ParsedJson<Vec<String>>> {
         self.inner.get_json("/admin/log-retention").await
     }
-    pub async fn fix_retention_policy(&self, project_id: &str) -> Result<String> {
+    pub async fn fix_retention_policy(&self, project_id: &str) -> Result<ParsedJson<String>> {
         self.inner
             .put_json(
                 format!("/admin/log-retention/{project_id}"),

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -8,7 +10,7 @@ use shuttle_common::models::error::ApiError;
 /// Helpers for consuming and parsing response bodies and handling parsing of an ApiError if the response is 4xx/5xx
 #[async_trait]
 pub trait ToBodyContent {
-    async fn to_json<T: DeserializeOwned>(self) -> Result<T>;
+    async fn to_json<T: DeserializeOwned>(self) -> Result<ParsedJson<T>>;
     async fn to_text(self) -> Result<String>;
     async fn to_bytes(self) -> Result<Bytes>;
     async fn to_empty(self) -> Result<()>;
@@ -34,9 +36,31 @@ fn bytes_to_string_with_fallback(bytes: Bytes) -> String {
     String::from_utf8(bytes.to_vec()).unwrap_or_else(|_| format!("[{} bytes]", bytes.len()))
 }
 
+pub struct ParsedJson<T> {
+    inner: T,
+    pub raw_json: String,
+}
+
+impl<T> ParsedJson<T> {
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<T: Debug> Debug for ParsedJson<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+impl<T: std::fmt::Display> std::fmt::Display for ParsedJson<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
 #[async_trait]
 impl ToBodyContent for reqwest::Response {
-    async fn to_json<T: DeserializeOwned>(self) -> Result<T> {
+    async fn to_json<T: DeserializeOwned>(self) -> Result<ParsedJson<T>> {
         let status_code = self.status();
         let bytes = self.bytes().await?;
         let string = bytes_to_string_with_fallback(bytes);
@@ -48,7 +72,12 @@ impl ToBodyContent for reqwest::Response {
             return Err(into_api_error(&string, status_code).into());
         }
 
-        serde_json::from_str(&string).context("failed to parse a successful response")
+        let t = serde_json::from_str(&string).context("failed to parse a successful response")?;
+
+        Ok(ParsedJson {
+            inner: t,
+            raw_json: string,
+        })
     }
 
     async fn to_text(self) -> Result<String> {

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -42,8 +42,14 @@ pub struct ParsedJson<T> {
 }
 
 impl<T> ParsedJson<T> {
+    pub fn as_ref(&self) -> &T {
+        &self.inner
+    }
     pub fn into_inner(self) -> T {
         self.inner
+    }
+    pub fn into_parts(self) -> (T, String) {
+        (self.inner, self.raw_json)
     }
 }
 

--- a/api-client/src/util.rs
+++ b/api-client/src/util.rs
@@ -42,14 +42,17 @@ pub struct ParsedJson<T> {
 }
 
 impl<T> ParsedJson<T> {
-    pub fn as_ref(&self) -> &T {
-        &self.inner
-    }
     pub fn into_inner(self) -> T {
         self.inner
     }
     pub fn into_parts(self) -> (T, String) {
         (self.inner, self.raw_json)
+    }
+}
+
+impl<T> AsRef<T> for ParsedJson<T> {
+    fn as_ref(&self) -> &T {
+        &self.inner
     }
 }
 

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -517,13 +517,13 @@ pub struct LogsArgs {
     #[arg(long)]
     pub raw: bool,
     /// View the first N log lines
-    #[arg(long, group = "output_mode", hide = true)]
+    #[arg(long, group = "pagination", hide = true)]
     pub head: Option<u32>,
     /// View the last N log lines
-    #[arg(long, group = "output_mode", hide = true)]
+    #[arg(long, group = "pagination", hide = true)]
     pub tail: Option<u32>,
     /// View all log lines
-    #[arg(long, group = "output_mode", hide = true)]
+    #[arg(long, group = "pagination", hide = true)]
     pub all: bool,
     /// Get logs from all deployments instead of one deployment
     #[arg(long, hide = true)]

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -397,7 +397,7 @@ pub struct InitArgs {
     /// Clone a starter template from Shuttle's official examples
     #[arg(long, short, value_enum, conflicts_with_all = &["from", "subfolder"])]
     pub template: Option<InitTemplateArg>,
-    /// Clone a template from a git repository or local path using cargo-generate
+    /// Clone a template from a git repository or local path
     #[arg(long)]
     pub from: Option<String>,
     /// Path to the template in the source (used with --from)

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -42,11 +42,29 @@ pub struct ShuttleArgs {
     /// Turn on tracing output for Shuttle libraries. (WARNING: can print sensitive data)
     #[arg(global = true, long, env = "SHUTTLE_DEBUG")]
     pub debug: bool,
+    /// What format to output results in (where supported).
+    #[arg(
+        global = true,
+        long = "output",
+        env = "SHUTTLE_OUTPUT_MODE",
+        default_value = "normal"
+    )]
+    pub output_mode: OutputMode,
     #[command(flatten)]
     pub project_args: ProjectArgs,
 
     #[command(subcommand)]
     pub cmd: Command,
+}
+
+#[derive(
+    ValueEnum, Clone, Debug, Default, PartialEq /* , strum::EnumMessage, strum::VariantArray */,
+)]
+pub enum OutputMode {
+    #[default]
+    Normal,
+    Json,
+    // TODO?: add table / non-table / raw table / raw logs variants?
 }
 
 /// Global args for subcommands that deal with projects
@@ -152,7 +170,7 @@ pub enum GenerateCommand {
         shell: Shell,
         /// Output to a file (stdout by default)
         #[arg(short, long)]
-        output: Option<PathBuf>,
+        output_file: Option<PathBuf>,
     },
     /// Generate man page to the standard output
     Manpage,

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -57,8 +57,8 @@ use zip::write::FileOptions;
 
 use crate::args::{
     CertificateCommand, ConfirmationArgs, DeployArgs, DeploymentCommand, GenerateCommand, InitArgs,
-    LoginArgs, LogoutArgs, LogsArgs, ProjectCommand, ProjectUpdateCommand, ResourceCommand,
-    SecretsArgs, TableArgs, TemplateLocation,
+    LoginArgs, LogoutArgs, LogsArgs, OutputMode, ProjectCommand, ProjectUpdateCommand,
+    ResourceCommand, SecretsArgs, TableArgs, TemplateLocation,
 };
 pub use crate::args::{Command, ProjectArgs, RunArgs, ShuttleArgs};
 use crate::builder::{async_cargo_metadata, build_workspace, find_shuttle_packages, BuiltService};
@@ -128,6 +128,7 @@ impl Binary {
 pub struct Shuttle {
     ctx: RequestContext,
     client: Option<ShuttleApiClient>,
+    output_mode: OutputMode,
     /// Alter behaviour based on which CLI is used
     bin: Binary,
 }
@@ -143,6 +144,7 @@ impl Shuttle {
         Ok(Self {
             ctx,
             client: None,
+            output_mode: OutputMode::Normal,
             bin,
         })
     }
@@ -151,6 +153,8 @@ impl Shuttle {
         if matches!(args.cmd, Command::Resource(ResourceCommand::Dump { .. })) {
             bail!("This command is not yet supported on the NEW platform (shuttle.dev).");
         }
+
+        self.output_mode = args.output_mode;
 
         // All commands that call the API
         if matches!(
@@ -244,8 +248,8 @@ impl Shuttle {
             }
             Command::Generate(cmd) => match cmd {
                 GenerateCommand::Manpage => generate_manpage(),
-                GenerateCommand::Shell { shell, output } => {
-                    generate_completions(self.bin, shell, output)
+                GenerateCommand::Shell { shell, output_file } => {
+                    generate_completions(self.bin, shell, output_file)
                 }
             },
             Command::Account => self.account().await,
@@ -745,8 +749,18 @@ impl Shuttle {
                         .with_prompt("Project name")
                         .interact()?;
 
-                    let proj = client.create_project(&name).await?.into_inner();
-                    eprintln!("Created project '{}' with id {}", proj.name, proj.id);
+                    let r = client.create_project(&name).await?;
+                    let proj = match self.output_mode {
+                        OutputMode::Normal => {
+                            let proj = r.into_inner();
+                            eprintln!("Created project '{}' with id {}", proj.name, proj.id);
+                            proj
+                        }
+                        OutputMode::Json => {
+                            println!("{}", r.raw_json);
+                            r.into_inner()
+                        }
+                    };
 
                     proj
                 }
@@ -762,8 +776,15 @@ impl Shuttle {
 
     async fn account(&self) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let user = client.get_current_user().await?.into_inner();
-        print!("{}", user.to_string_colored());
+        let r = client.get_current_user().await?;
+        match self.output_mode {
+            OutputMode::Normal => {
+                print!("{}", r.into_inner().to_string_colored());
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }
@@ -933,8 +954,8 @@ impl Shuttle {
         }
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
-        let logs = if args.all_deployments {
-            client.get_project_logs(pid).await?.into_inner().logs
+        let r = if args.all_deployments {
+            client.get_project_logs(pid).await?
         } else {
             let id = if args.latest {
                 // Find latest deployment (not always an active one)
@@ -959,17 +980,21 @@ impl Shuttle {
                 eprintln!("Getting logs from: {}", current.id);
                 current.id
             };
-            client
-                .get_deployment_logs(pid, &id)
-                .await?
-                .into_inner()
-                .logs
+            client.get_deployment_logs(pid, &id).await?
         };
-        for log in logs {
-            if args.raw {
-                println!("{}", log.line);
-            } else {
-                println!("{log}");
+        match self.output_mode {
+            OutputMode::Normal => {
+                let logs = r.into_inner().logs;
+                for log in logs {
+                    if args.raw {
+                        println!("{}", log.line);
+                    } else {
+                        println!("{log}");
+                    }
+                }
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
             }
         }
 
@@ -985,11 +1010,11 @@ impl Shuttle {
 
         // fetch one additional to know if there is another page available
         let limit = limit + 1;
-        let mut deployments = client
+        let (deployments, raw_json) = client
             .get_deployments(self.ctx.project_id(), page as i32, limit as i32)
             .await?
-            .into_inner()
-            .deployments;
+            .into_parts();
+        let mut deployments = deployments.deployments;
         let page_hint = if deployments.len() == limit as usize {
             // hide the extra one and show hint instead
             deployments.pop();
@@ -997,15 +1022,21 @@ impl Shuttle {
         } else {
             false
         };
-        let table = deployments_table(&deployments, table_args.raw);
-
-        println!(
-            "{}",
-            format!("Deployments in project '{}'", proj_name).bold()
-        );
-        println!("{table}");
-        if page_hint {
-            println!("View the next page using `--page {}`", page + 1);
+        match self.output_mode {
+            OutputMode::Normal => {
+                let table = deployments_table(&deployments, table_args.raw);
+                println!(
+                    "{}",
+                    format!("Deployments in project '{}'", proj_name).bold()
+                );
+                println!("{table}");
+                if page_hint {
+                    println!("View the next page using `--page {}`", page + 1);
+                }
+            }
+            OutputMode::Json => {
+                println!("{}", raw_json);
+            }
         }
 
         Ok(())
@@ -1016,10 +1047,22 @@ impl Shuttle {
         let pid = self.ctx.project_id();
 
         let deployment = match deployment_id {
-            Some(id) => client.get_deployment(pid, &id).await?.into_inner(),
+            Some(id) => {
+                let r = client.get_deployment(pid, &id).await?;
+                if self.output_mode == OutputMode::Json {
+                    println!("{}", r.raw_json);
+                    return Ok(());
+                }
+                r.into_inner()
+            }
             None => {
-                let d = client.get_current_deployment(pid).await?.into_inner();
-                let Some(d) = d else {
+                let r = client.get_current_deployment(pid).await?;
+                if self.output_mode == OutputMode::Json {
+                    println!("{}", r.raw_json);
+                    return Ok(());
+                }
+
+                let Some(d) = r.into_inner() else {
                     println!("No deployment found");
                     return Ok(());
                 };
@@ -1051,10 +1094,17 @@ impl Shuttle {
                 d.id
             }
         };
-        let deployment = client.redeploy(pid, &deployment_id).await?.into_inner();
+        let (deployment, raw_json) = client.redeploy(pid, &deployment_id).await?.into_parts();
 
         if tracking_args.no_follow {
-            println!("{}", deployment.to_string_colored());
+            match self.output_mode {
+                OutputMode::Normal => {
+                    println!("{}", deployment.to_string_colored());
+                }
+                OutputMode::Json => {
+                    println!("{}", raw_json);
+                }
+            }
             return Ok(());
         }
 
@@ -1065,14 +1115,22 @@ impl Shuttle {
     async fn resources_list(&self, table_args: TableArgs, show_secrets: bool) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
-        let resources = client
-            .get_service_resources(pid)
-            .await?
-            .into_inner()
-            .resources;
-        let table = get_resource_tables(resources.as_slice(), pid, table_args.raw, show_secrets);
+        let r = client.get_service_resources(pid).await?;
 
-        println!("{table}");
+        match self.output_mode {
+            OutputMode::Normal => {
+                let table = get_resource_tables(
+                    r.into_inner().resources.as_slice(),
+                    pid,
+                    table_args.raw,
+                    show_secrets,
+                );
+                println!("{table}");
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }
@@ -1132,25 +1190,35 @@ impl Shuttle {
 
     async fn list_certificates(&self, table_args: TableArgs) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let certs = client
-            .list_certificates(self.ctx.project_id())
-            .await?
-            .into_inner()
-            .certificates;
+        let r = client.list_certificates(self.ctx.project_id()).await?;
 
-        let table = get_certificates_table(certs.as_ref(), table_args.raw);
-        println!("{}", table);
+        match self.output_mode {
+            OutputMode::Normal => {
+                let table =
+                    get_certificates_table(r.into_inner().certificates.as_ref(), table_args.raw);
+                println!("{table}");
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }
     async fn add_certificate(&self, domain: String) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let cert = client
+        let r = client
             .add_certificate(self.ctx.project_id(), domain.clone())
-            .await?
-            .into_inner();
+            .await?;
 
-        println!("Added certificate for {}", cert.subject);
+        match self.output_mode {
+            OutputMode::Normal => {
+                println!("Added certificate for {}", r.into_inner().subject);
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }
@@ -1490,13 +1558,20 @@ impl Shuttle {
             let pid = self.ctx.project_id();
             let deployment_req_image = DeploymentRequestImage { image, secrets };
 
-            let deployment = client
+            let (deployment, raw_json) = client
                 .deploy(pid, DeploymentRequest::Image(deployment_req_image))
                 .await?
-                .into_inner();
+                .into_parts();
 
             if args.tracking_args.no_follow {
-                println!("{}", deployment.to_string_colored());
+                match self.output_mode {
+                    OutputMode::Normal => {
+                        println!("{}", deployment.to_string_colored());
+                    }
+                    OutputMode::Json => {
+                        println!("{}", raw_json);
+                    }
+                }
                 return Ok(());
             }
 
@@ -1603,13 +1678,20 @@ impl Shuttle {
         deployment_req.build_meta = Some(build_meta);
 
         eprintln!("Creating deployment...");
-        let deployment = client
+        let (deployment, raw_json) = client
             .deploy(pid, DeploymentRequest::BuildArchive(deployment_req))
             .await?
-            .into_inner();
+            .into_parts();
 
         if args.tracking_args.no_follow {
-            println!("{}", deployment.to_string_colored());
+            match self.output_mode {
+                OutputMode::Normal => {
+                    println!("{}", deployment.to_string_colored());
+                }
+                OutputMode::Json => {
+                    println!("{}", raw_json);
+                }
+            }
             return Ok(());
         }
 
@@ -1680,16 +1762,24 @@ impl Shuttle {
     async fn project_create(&self) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let name = self.ctx.project_name();
-        let project = client.create_project(name).await?.into_inner();
+        let r = client.create_project(name).await?;
 
-        println!("Created project '{}' with id {}", project.name, project.id);
+        match self.output_mode {
+            OutputMode::Normal => {
+                let project = r.into_inner();
+                println!("Created project '{}' with id {}", project.name, project.id);
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }
     async fn project_rename(&self, name: String) -> Result<()> {
         let client = self.client.as_ref().unwrap();
 
-        let project = client
+        let r = client
             .update_project(
                 self.ctx.project_id(),
                 ProjectUpdateRequest {
@@ -1697,36 +1787,52 @@ impl Shuttle {
                     ..Default::default()
                 },
             )
-            .await?
-            .into_inner();
+            .await?;
 
-        println!("Renamed project {} to '{}'", project.id, project.name);
+        match self.output_mode {
+            OutputMode::Normal => {
+                let project = r.into_inner();
+                println!("Renamed project {} to '{}'", project.id, project.name);
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }
 
     async fn projects_list(&self, table_args: TableArgs) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let all_projects = client.get_projects_list().await?.into_inner().projects;
-        // partition by team id and print separate tables
-        let mut all_projects_map = BTreeMap::new();
-        for proj in all_projects {
-            all_projects_map
-                .entry(proj.team_id.clone())
-                .or_insert_with(Vec::new)
-                .push(proj);
-        }
-        for (team_id, projects) in all_projects_map {
-            println!(
-                "{}",
-                if let Some(team_id) = team_id {
-                    format!("Team {} projects", team_id)
-                } else {
-                    "Personal Projects".to_owned()
+        let r = client.get_projects_list().await?;
+
+        match self.output_mode {
+            OutputMode::Normal => {
+                let all_projects = r.into_inner().projects;
+                // partition by team id and print separate tables
+                let mut all_projects_map = BTreeMap::new();
+                for proj in all_projects {
+                    all_projects_map
+                        .entry(proj.team_id.clone())
+                        .or_insert_with(Vec::new)
+                        .push(proj);
                 }
-                .bold()
-            );
-            println!("{}\n", get_projects_table(&projects, table_args.raw));
+                for (team_id, projects) in all_projects_map {
+                    println!(
+                        "{}",
+                        if let Some(team_id) = team_id {
+                            format!("Team {} projects", team_id)
+                        } else {
+                            "Personal Projects".to_owned()
+                        }
+                        .bold()
+                    );
+                    println!("{}\n", get_projects_table(&projects, table_args.raw));
+                }
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
         }
 
         Ok(())
@@ -1734,11 +1840,16 @@ impl Shuttle {
 
     async fn project_status(&self) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let project = client
-            .get_project(self.ctx.project_id())
-            .await?
-            .into_inner();
-        print!("{}", project.to_string_colored());
+        let r = client.get_project(self.ctx.project_id()).await?;
+
+        match self.output_mode {
+            OutputMode::Normal => {
+                print!("{}", r.into_inner().to_string_colored());
+            }
+            OutputMode::Json => {
+                println!("{}", r.raw_json);
+            }
+        }
 
         Ok(())
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -594,7 +594,11 @@ impl Shuttle {
     /// Return value: true -> success or unknown. false -> try again.
     async fn check_project_name(&self, project_args: &mut ProjectArgs, name: String) -> bool {
         let client = self.client.as_ref().unwrap();
-        match client.check_project_name(&name).await {
+        match client
+            .check_project_name(&name)
+            .await
+            .map(|r| r.into_inner())
+        {
             Ok(true) => {
                 project_args.name_or_id = Some(name);
 
@@ -659,6 +663,7 @@ impl Shuttle {
                 if let Some(proj) = client
                     .get_projects_list()
                     .await?
+                    .into_inner()
                     .projects
                     .into_iter()
                     .find(|p| p.name == *name)
@@ -669,7 +674,7 @@ impl Shuttle {
                     trace!("did not find project by name");
                     if create_missing_project {
                         trace!("creating project since it was not found");
-                        let proj = client.create_project(name).await?;
+                        let proj = client.create_project(name).await?.into_inner();
                         eprintln!("Created project '{}' with id {}", proj.name, proj.id);
                         self.ctx.set_project_id(proj.id);
                     }
@@ -692,7 +697,7 @@ impl Shuttle {
 
     async fn project_link(&mut self, id_or_name: Option<String>) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let projs = client.get_projects_list().await?.projects;
+        let projs = client.get_projects_list().await?.into_inner().projects;
 
         let theme = ColorfulTheme::default();
 
@@ -740,7 +745,7 @@ impl Shuttle {
                         .with_prompt("Project name")
                         .interact()?;
 
-                    let proj = client.create_project(&name).await?;
+                    let proj = client.create_project(&name).await?.into_inner();
                     eprintln!("Created project '{}' with id {}", proj.name, proj.id);
 
                     proj
@@ -757,7 +762,7 @@ impl Shuttle {
 
     async fn account(&self) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let user = client.get_current_user().await?;
+        let user = client.get_current_user().await?.into_inner();
         print!("{}", user.to_string_colored());
 
         Ok(())
@@ -796,7 +801,8 @@ impl Shuttle {
                 let u = client
                     .get_current_user()
                     .await
-                    .context("failed to check API key validity")?;
+                    .context("failed to check API key validity")?
+                    .into_inner();
                 println!("Logged in as {}", u.id.bold());
             }
         }
@@ -876,7 +882,7 @@ impl Shuttle {
     async fn stop(&self, tracking_args: DeploymentTrackingArgs) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
-        let res = client.stop_service(pid).await?;
+        let res = client.stop_service(pid).await?.into_inner();
         println!("{res}");
 
         if tracking_args.no_follow {
@@ -884,7 +890,7 @@ impl Shuttle {
         }
 
         wait_with_spinner(2000, |_, pb| async move {
-            let deployment = client.get_current_deployment(pid).await?;
+            let deployment = client.get_current_deployment(pid).await?.into_inner();
 
             let get_cleanup = |d: Option<DeploymentResponse>| {
                 move || {
@@ -928,11 +934,15 @@ impl Shuttle {
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
         let logs = if args.all_deployments {
-            client.get_project_logs(pid).await?.logs
+            client.get_project_logs(pid).await?.into_inner().logs
         } else {
             let id = if args.latest {
                 // Find latest deployment (not always an active one)
-                let deployments = client.get_deployments(pid, 1, 1).await?.deployments;
+                let deployments = client
+                    .get_deployments(pid, 1, 1)
+                    .await?
+                    .into_inner()
+                    .deployments;
                 let Some(most_recent) = deployments.into_iter().next() else {
                     println!("No deployments found");
                     return Ok(());
@@ -942,14 +952,18 @@ impl Shuttle {
             } else if let Some(id) = args.id {
                 id
             } else {
-                let Some(current) = client.get_current_deployment(pid).await? else {
+                let Some(current) = client.get_current_deployment(pid).await?.into_inner() else {
                     println!("No deployments found");
                     return Ok(());
                 };
                 eprintln!("Getting logs from: {}", current.id);
                 current.id
             };
-            client.get_deployment_logs(pid, &id).await?.logs
+            client
+                .get_deployment_logs(pid, &id)
+                .await?
+                .into_inner()
+                .logs
         };
         for log in logs {
             if args.raw {
@@ -974,6 +988,7 @@ impl Shuttle {
         let mut deployments = client
             .get_deployments(self.ctx.project_id(), page as i32, limit as i32)
             .await?
+            .into_inner()
             .deployments;
         let page_hint = if deployments.len() == limit as usize {
             // hide the extra one and show hint instead
@@ -1001,16 +1016,16 @@ impl Shuttle {
         let pid = self.ctx.project_id();
 
         let deployment = match deployment_id {
-            Some(id) => client.get_deployment(pid, &id).await,
+            Some(id) => client.get_deployment(pid, &id).await?.into_inner(),
             None => {
-                let d = client.get_current_deployment(pid).await?;
+                let d = client.get_current_deployment(pid).await?.into_inner();
                 let Some(d) = d else {
                     println!("No deployment found");
                     return Ok(());
                 };
-                Ok(d)
+                d
             }
-        }?;
+        };
 
         println!("{}", deployment.to_string_colored());
 
@@ -1028,7 +1043,7 @@ impl Shuttle {
         let deployment_id = match deployment_id {
             Some(id) => id,
             None => {
-                let d = client.get_current_deployment(pid).await?;
+                let d = client.get_current_deployment(pid).await?.into_inner();
                 let Some(d) = d else {
                     println!("No deployment found");
                     return Ok(());
@@ -1036,7 +1051,7 @@ impl Shuttle {
                 d.id
             }
         };
-        let deployment = client.redeploy(pid, &deployment_id).await?;
+        let deployment = client.redeploy(pid, &deployment_id).await?.into_inner();
 
         if tracking_args.no_follow {
             println!("{}", deployment.to_string_colored());
@@ -1050,7 +1065,11 @@ impl Shuttle {
     async fn resources_list(&self, table_args: TableArgs, show_secrets: bool) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
-        let resources = client.get_service_resources(pid).await?.resources;
+        let resources = client
+            .get_service_resources(pid)
+            .await?
+            .into_inner()
+            .resources;
         let table = get_resource_tables(resources.as_slice(), pid, table_args.raw, show_secrets);
 
         println!("{table}");
@@ -1086,7 +1105,8 @@ impl Shuttle {
 
         let msg = client
             .delete_service_resource(self.ctx.project_id(), resource_type)
-            .await?;
+            .await?
+            .into_inner();
         println!("{msg}");
 
         eprintln!(
@@ -1115,6 +1135,7 @@ impl Shuttle {
         let certs = client
             .list_certificates(self.ctx.project_id())
             .await?
+            .into_inner()
             .certificates;
 
         let table = get_certificates_table(certs.as_ref(), table_args.raw);
@@ -1126,7 +1147,8 @@ impl Shuttle {
         let client = self.client.as_ref().unwrap();
         let cert = client
             .add_certificate(self.ctx.project_id(), domain.clone())
-            .await?;
+            .await?
+            .into_inner();
 
         println!("Added certificate for {}", cert.subject);
 
@@ -1159,7 +1181,8 @@ impl Shuttle {
 
         let msg = client
             .delete_certificate(self.ctx.project_id(), domain.clone())
-            .await?;
+            .await?
+            .into_inner();
         println!("{msg}");
 
         Ok(())
@@ -1469,7 +1492,8 @@ impl Shuttle {
 
             let deployment = client
                 .deploy(pid, DeploymentRequest::Image(deployment_req_image))
-                .await?;
+                .await?
+                .into_inner();
 
             if args.tracking_args.no_follow {
                 println!("{}", deployment.to_string_colored());
@@ -1574,14 +1598,15 @@ impl Shuttle {
         let pid = self.ctx.project_id();
 
         eprintln!("Uploading code...");
-        let arch = client.upload_archive(pid, archive).await?;
+        let arch = client.upload_archive(pid, archive).await?.into_inner();
         deployment_req.archive_version_id = arch.archive_version_id;
         deployment_req.build_meta = Some(build_meta);
 
         eprintln!("Creating deployment...");
         let deployment = client
             .deploy(pid, DeploymentRequest::BuildArchive(deployment_req))
-            .await?;
+            .await?
+            .into_inner();
 
         if args.tracking_args.no_follow {
             println!("{}", deployment.to_string_colored());
@@ -1600,7 +1625,7 @@ impl Shuttle {
     async fn track_deployment_status(&self, pid: &str, id: &str) -> Result<bool> {
         let client = self.client.as_ref().unwrap();
         let failed = wait_with_spinner(2000, |_, pb| async move {
-            let deployment = client.get_deployment(pid, id).await?;
+            let deployment = client.get_deployment(pid, id).await?.into_inner();
 
             let state = deployment.state.clone();
             pb.set_message(deployment.to_string_summary_colored());
@@ -1634,7 +1659,12 @@ impl Shuttle {
         let client = self.client.as_ref().unwrap();
         let failed = self.track_deployment_status(proj_id, depl_id).await?;
         if failed {
-            for log in client.get_deployment_logs(proj_id, depl_id).await?.logs {
+            for log in client
+                .get_deployment_logs(proj_id, depl_id)
+                .await?
+                .into_inner()
+                .logs
+            {
                 if raw {
                     println!("{}", log.line);
                 } else {
@@ -1650,7 +1680,7 @@ impl Shuttle {
     async fn project_create(&self) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let name = self.ctx.project_name();
-        let project = client.create_project(name).await?;
+        let project = client.create_project(name).await?.into_inner();
 
         println!("Created project '{}' with id {}", project.name, project.id);
 
@@ -1667,7 +1697,8 @@ impl Shuttle {
                     ..Default::default()
                 },
             )
-            .await?;
+            .await?
+            .into_inner();
 
         println!("Renamed project {} to '{}'", project.id, project.name);
 
@@ -1676,7 +1707,7 @@ impl Shuttle {
 
     async fn projects_list(&self, table_args: TableArgs) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let all_projects = client.get_projects_list().await?.projects;
+        let all_projects = client.get_projects_list().await?.into_inner().projects;
         // partition by team id and print separate tables
         let mut all_projects_map = BTreeMap::new();
         for proj in all_projects {
@@ -1703,7 +1734,10 @@ impl Shuttle {
 
     async fn project_status(&self) -> Result<()> {
         let client = self.client.as_ref().unwrap();
-        let project = client.get_project(self.ctx.project_id()).await?;
+        let project = client
+            .get_project(self.ctx.project_id())
+            .await?
+            .into_inner();
         print!("{}", project.to_string_colored());
 
         Ok(())
@@ -1715,7 +1749,7 @@ impl Shuttle {
 
         if !no_confirm {
             // check that the project exists, and look up the name
-            let proj = client.get_project(pid).await?;
+            let proj = client.get_project(pid).await?.into_inner();
             eprintln!(
                 "{}",
                 formatdoc!(
@@ -1743,7 +1777,7 @@ impl Shuttle {
             }
         }
 
-        let res = client.delete_project(pid).await?;
+        let res = client.delete_project(pid).await?.into_inner();
 
         println!("{res}");
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -750,7 +750,8 @@ impl Shuttle {
                         .interact()?;
 
                     let r = client.create_project(&name).await?;
-                    let proj = match self.output_mode {
+
+                    match self.output_mode {
                         OutputMode::Normal => {
                             let proj = r.into_inner();
                             eprintln!("Created project '{}' with id {}", proj.name, proj.id);
@@ -760,9 +761,7 @@ impl Shuttle {
                             println!("{}", r.raw_json);
                             r.into_inner()
                         }
-                    };
-
-                    proj
+                    }
                 }
             }
         };

--- a/cargo-shuttle/tests/integration/main.rs
+++ b/cargo-shuttle/tests/integration/main.rs
@@ -22,6 +22,7 @@ async fn shuttle_command(cmd: Command, working_directory: &str) -> anyhow::Resul
                 },
                 offline: false,
                 debug: false,
+                output_mode: Default::default(),
                 cmd,
             },
             false,

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -40,6 +40,7 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                 },
                 offline: false,
                 debug: false,
+                output_mode: Default::default(),
                 cmd: Command::Run(RunArgs {
                     port,
                     external,


### PR DESCRIPTION
Supersedes #2058 

Adds `--output json` so relevant commands print the json response instead. Not 100% coverage but the important ones have it.

breaking: generate command's `--output` arg renamed to `--output-file` (somewhat matches `deploy --output-archive`)