### PR TITLE
fix: don't care about Secrets*.toml or --secrets when building or deploying

### DIFF
--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -7,7 +7,7 @@ mod util;
 
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
-use std::fs::{read_to_string, File};
+use std::fs;
 use std::io::{Read, Write};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -1277,22 +1277,22 @@ impl Shuttle {
                 .find(|&secrets_file| secrets_file.exists() && secrets_file.is_file())
         });
 
-        Ok(if let Some(secrets_file) = secrets_file {
-            trace!("Loading secrets from {}", secrets_file.display());
-            if let Ok(secrets_str) = read_to_string(secrets_file) {
-                let secrets = toml::from_str::<HashMap<String, String>>(&secrets_str)?;
-
-                trace!(keys = ?secrets.keys(), "available secrets");
-
-                Some(secrets)
-            } else {
-                trace!("No secrets were loaded");
-                None
-            }
-        } else {
+        let Some(secrets_file) = secrets_file else {
             trace!("No secrets file was found");
-            None
-        })
+            return Ok(None);
+        };
+
+        trace!("Loading secrets from {}", secrets_file.display());
+        let Ok(secrets_str) = fs::read_to_string(secrets_file) else {
+            tracing::warn!("Failed to read secrets file, no secrets were loaded");
+            return Ok(None);
+        };
+
+        let secrets = toml::from_str::<HashMap<String, String>>(&secrets_str)
+            .context("parsing secrets file")?;
+        trace!(keys = ?secrets.keys(), "Loaded secrets");
+
+        Ok(Some(secrets))
     }
 
     async fn pre_local_run(&self, run_args: &RunArgs) -> Result<BuiltService> {
@@ -1660,7 +1660,7 @@ impl Shuttle {
         }
 
         eprintln!("Packing files...");
-        let archive = self.make_archive(args.secret_args.secrets.clone())?;
+        let archive = self.make_archive()?;
 
         if let Some(path) = args.output_archive {
             eprintln!("Writing archive to {}", path.display());
@@ -1899,7 +1899,8 @@ impl Shuttle {
         Ok(())
     }
 
-    fn make_archive(&self, secrets_file: Option<PathBuf>) -> Result<Vec<u8>> {
+    /// Find list of all files to include in a build, ready for placing in a zip archive
+    fn gather_build_files(&self) -> Result<BTreeMap<PathBuf, PathBuf>> {
         let include_patterns = self.ctx.include();
 
         let project_directory = self.ctx.project_directory();
@@ -1928,16 +1929,8 @@ impl Shuttle {
             entries.push(r.context("list dir entry")?.into_path())
         }
 
-        let mut globs = GlobSetBuilder::new();
-
-        if let Some(secrets_file) = secrets_file.clone() {
-            entries.push(secrets_file);
-        } else {
-            // Default: Include all Secrets.toml files
-            globs.add(Glob::new("**/Secrets.toml").unwrap());
-        }
-
         // User provided includes
+        let mut globs = GlobSetBuilder::new();
         if let Some(rules) = include_patterns {
             for r in rules {
                 globs.add(Glob::new(r.as_str()).context(format!("parsing glob pattern {:?}", r))?);
@@ -1970,20 +1963,19 @@ impl Shuttle {
             }
 
             // zip file puts all files in root
-            let mut name = path
+            let name = path
                 .strip_prefix(project_directory)
                 .context("strip prefix of path")?
                 .to_owned();
 
-            // if this is the custom secrets file, rename it to Secrets.toml
-            if secrets_file.as_ref().is_some_and(|sf| sf == &path) {
-                name.pop();
-                name.push("Secrets.toml");
-            }
-
             archive_files.insert(path, name);
         }
 
+        Ok(archive_files)
+    }
+
+    fn make_archive(&self) -> Result<Vec<u8>> {
+        let archive_files = self.gather_build_files()?;
         if archive_files.is_empty() {
             error!("No files included in upload. Aborting...");
             bail!("No files included in upload.");
@@ -2000,7 +1992,7 @@ impl Shuttle {
                 zip.start_file(name, FileOptions::<()>::default())?;
 
                 let mut b = Vec::new();
-                File::open(path)?.read_to_end(&mut b)?;
+                fs::File::open(path)?.read_to_end(&mut b)?;
                 zip.write_all(&b)?;
             }
             let r = zip.finish().context("finish encoding zip archive")?;
@@ -2068,7 +2060,7 @@ fn create_spinner() -> ProgressBar {
 mod tests {
     use zip::ZipArchive;
 
-    use crate::args::{DeployArgs, ProjectArgs, SecretsArgs};
+    use crate::args::ProjectArgs;
     use crate::Shuttle;
     use std::fs::{self, canonicalize};
     use std::io::Cursor;
@@ -2082,19 +2074,14 @@ mod tests {
         dunce::canonicalize(path).unwrap()
     }
 
-    async fn get_archive_entries(
-        project_args: ProjectArgs,
-        deploy_args: DeployArgs,
-    ) -> Vec<String> {
+    async fn get_archive_entries(project_args: ProjectArgs) -> Vec<String> {
         let mut shuttle = Shuttle::new(crate::Binary::Shuttle, None).unwrap();
         shuttle
             .load_project(&project_args, false, false)
             .await
             .unwrap();
 
-        let archive = shuttle
-            .make_archive(deploy_args.secret_args.secrets)
-            .unwrap();
+        let archive = shuttle.make_archive().unwrap();
 
         let mut zip = ZipArchive::new(Cursor::new(archive)).unwrap();
         (0..zip.len())
@@ -2123,14 +2110,13 @@ mod tests {
             working_directory: working_directory.clone(),
             name_or_id: Some("proj_archiving-test".to_owned()),
         };
-        let mut entries = get_archive_entries(project_args.clone(), Default::default()).await;
+        let mut entries = get_archive_entries(project_args.clone()).await;
         entries.sort();
 
         let expected = vec![
             ".gitignore",
             ".ignore",
             "Cargo.toml",
-            "Secrets.toml", // always included by default
             "Secrets.toml.example",
             "Shuttle.toml",
             "asset1", // normal file
@@ -2144,40 +2130,6 @@ mod tests {
             "src/main.rs",
         ];
         assert_eq!(entries, expected);
-
-        fs::remove_file(working_directory.join("Secrets.toml")).unwrap();
-        let mut entries = get_archive_entries(
-            project_args,
-            DeployArgs {
-                secret_args: SecretsArgs {
-                    secrets: Some(working_directory.join("Secrets.toml.example")),
-                },
-                ..Default::default()
-            },
-        )
-        .await;
-        entries.sort();
-
-        assert_eq!(
-            entries,
-            vec![
-                ".gitignore",
-                ".ignore",
-                "Cargo.toml",
-                "Secrets.toml", // got moved here
-                // Secrets.toml.example was the given secrets file, so it got moved
-                "Shuttle.toml",
-                "asset1", // normal file
-                "asset2", // .gitignore'd, but included in Shuttle.toml
-                // asset3 is .ignore'd
-                "asset4",                // .gitignore'd, but un-ignored in .ignore
-                "asset5",                // .ignore'd, but included in Shuttle.toml
-                "dist/dist1",            // .gitignore'd, but included in Shuttle.toml
-                "nested/static/nested1", // normal file
-                // nested/static/nestedignore is .gitignore'd
-                "src/main.rs",
-            ]
-        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Cleans up what was referenced in https://github.com/shuttle-hq/shuttle/issues/1933#issuecomment-2960105897