### PR TITLE
chore: clean up legacy constants & related code

### DIFF
--- a/cargo-shuttle/src/builder.rs
+++ b/cargo-shuttle/src/builder.rs
@@ -4,7 +4,6 @@ use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
 use cargo_metadata::{Metadata, Package, Target};
-use shuttle_common::constants::RUNTIME_NAME;
 use tokio::io::AsyncBufReadExt;
 use tracing::{error, trace};
 
@@ -56,7 +55,7 @@ pub async fn build_workspace(
     notification.abort();
 
     let metadata = async_cargo_metadata(manifest_path.as_path()).await?;
-    let (package, target) = find_first_shuttle_package(&metadata)?;
+    let (package, target, _) = find_first_shuttle_package(&metadata)?;
 
     let service = cargo_build(
         package,
@@ -100,18 +99,24 @@ pub async fn async_cargo_metadata(manifest_path: &Path) -> Result<Metadata> {
 }
 
 /// Find crates with a runtime dependency and main macro
-fn find_shuttle_packages(metadata: &Metadata) -> Result<Vec<(Package, Target)>> {
+fn find_shuttle_packages(metadata: &Metadata) -> Result<Vec<(Package, Target, Option<String>)>> {
     let mut packages = Vec::new();
     trace!("Finding Shuttle-related packages");
     for member in metadata.workspace_packages() {
-        let has_runtime_dep = member
+        let runtime_dep = member
             .dependencies
             .iter()
-            .any(|dependency| dependency.name == RUNTIME_NAME);
-        if !has_runtime_dep {
+            .find(|dependency| dependency.name == "shuttle-runtime");
+        let Some(runtime_dep) = runtime_dep else {
             trace!("Skipping {}, no shuttle-runtime dependency", member.name);
             continue;
-        }
+        };
+        let runtime_version = runtime_dep
+            .req
+            .comparators
+            .first()
+            // is "^0.X.0" when `shuttle-runtime = "0.X.0"` is in Cargo.toml, so strip the caret
+            .and_then(|c| c.to_string().strip_prefix('^').map(ToOwned::to_owned));
 
         let mut target = None;
         for t in member.targets.iter() {
@@ -134,13 +139,16 @@ fn find_shuttle_packages(metadata: &Metadata) -> Result<Vec<(Package, Target)>> 
         };
 
         trace!("Found {}", member.name);
-        packages.push((member.to_owned(), target.to_owned()));
+        packages.push((member.to_owned(), target.to_owned(), runtime_version));
     }
 
     Ok(packages)
 }
 
-pub fn find_first_shuttle_package(metadata: &Metadata) -> Result<(Package, Target)> {
+/// Find first crate in workspace with a runtime dependency and main macro
+pub fn find_first_shuttle_package(
+    metadata: &Metadata,
+) -> Result<(Package, Target, Option<String>)> {
     find_shuttle_packages(metadata)?.into_iter().next().context(
         "Expected at least one target that Shuttle can build. \
         Make sure your crate has a binary target that uses a fully qualified `#[shuttle_runtime::main]`.",

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -1,8 +1,5 @@
 //! Shared constants used across Shuttle crates
 
-/// Used by plugins for local file storage.
-pub const STORAGE_DIRNAME: &str = ".shuttle-storage";
-
 // URLs
 pub const SHUTTLE_API_URL: &str = "https://api.shuttle.dev";
 pub const SHUTTLE_CONSOLE_URL: &str = "https://console.shuttle.dev";
@@ -20,9 +17,6 @@ pub const EXAMPLES_README: &str =
     "https://github.com/shuttle-hq/shuttle-examples#how-to-clone-run-and-deploy-an-example";
 pub const EXAMPLES_TEMPLATES_TOML: &str =
     "https://raw.githubusercontent.com/shuttle-hq/shuttle-examples/main/templates.toml";
-
-/// Crate name for checking cargo metadata
-pub const RUNTIME_NAME: &str = "shuttle-runtime";
 
 /// Current version field in `examples/templates.toml`
 pub const TEMPLATES_SCHEMA_VERSION: u32 = 1;

--- a/common/src/models/deployment.rs
+++ b/common/src/models/deployment.rs
@@ -245,7 +245,7 @@ pub struct DeploymentRequestImage {
 pub struct DeploymentMetadata {
     pub env: Environment,
     pub project_name: String,
-    /// Path to a folder that persists between deployments
+    /// Path to a recommended folder for disk storage during local runs
     pub storage_path: PathBuf,
 }
 

--- a/runtime/src/rt.rs
+++ b/runtime/src/rt.rs
@@ -104,7 +104,7 @@ pub async fn start(loader: impl Loader + Send + 'static, runner: impl Runner + S
                 };
                 let io = TokioIo::new(stream);
 
-                tokio::task::spawn(async move {
+                tokio::spawn(async move {
                     if let Err(err) = http1::Builder::new()
                         .serve_connection(
                             io,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
-use shuttle_common::constants::STORAGE_DIRNAME;
 pub use shuttle_common::{
     models::{
         deployment::{DeploymentMetadata, Environment},
@@ -80,7 +79,7 @@ impl ResourceFactory {
         DeploymentMetadata {
             env: self.env,
             project_name: self.project_name.to_string(),
-            storage_path: PathBuf::from(STORAGE_DIRNAME),
+            storage_path: PathBuf::from(".shuttle-storage"),
         }
     }
 }


### PR DESCRIPTION
Minor refactors.
Removal of `STORAGE_DIRNAME` override when archiving shouldn't break anything since `.shuttle*` is always added to users' gitignores.