### PR TITLE
feat: add support for additional (common) CLI env vars

### DIFF
--- a/api-client/src/lib.rs
+++ b/api-client/src/lib.rs
@@ -60,6 +60,12 @@ impl ShuttleApiClient {
             builder = builder.proxy(reqwest::Proxy::https(proxy).unwrap());
         }
 
+        if std::env::var("SHUTTLE_TLS_INSECURE_SKIP_VERIFY")
+            .is_ok_and(|value| value == "1" || value == "true")
+        {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+
         if let Some(headers) = headers {
             builder = builder.default_headers(headers);
         }


### PR DESCRIPTION
PR adds support for the common `HTTP_PROXY` and `HTTPS_PROXY` env vars to the Shuttle CLI, as well as support for explicitly disabling TLS certificate validation via a new `SHUTTLE_TLS_INSECURE_SKIP_VERIFY` env var (useful for testing against instances of the Shuttle control-plane that use self-signed certificates, e.x. locally).