### PR TITLE
feat: add support for --profile and --features flags

### DIFF
--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -382,8 +382,14 @@ pub struct RunArgs {
     #[arg(long)]
     pub external: bool,
     /// Use release mode for building the project
-    #[arg(long, short = 'r')]
+    #[arg(long, short = 'r', conflicts_with = "profile")]
     pub release: bool,
+    /// Build with the specified profile
+    #[arg(long, conflicts_with = "release")]
+    pub profile: Option<String>,
+    /// Space or comma separated list of features to activate
+    #[arg(long)]
+    pub features: Option<String>,
     /// Don't display timestamps and log origin tags
     #[arg(long)]
     pub raw: bool,

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1340,7 +1340,14 @@ impl Shuttle {
             project_directory.display()
         );
 
-        build_workspace(project_directory, run_args.release, tx).await
+        build_workspace(
+            project_directory,
+            run_args.release,
+            run_args.profile.as_deref(),
+            run_args.features.as_deref(),
+            tx,
+        )
+        .await
     }
 
     fn find_available_port(run_args: &mut RunArgs) {

--- a/cargo-shuttle/tests/integration/builder.rs
+++ b/cargo-shuttle/tests/integration/builder.rs
@@ -9,7 +9,7 @@ use cargo_shuttle::builder::{build_workspace, BuiltService};
 async fn not_shuttle() {
     let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/resources/not-shuttle");
-    build_workspace(Path::new(&project_path), false, tx)
+    build_workspace(Path::new(&project_path), false, None, None, tx)
         .await
         .unwrap();
 }
@@ -21,7 +21,7 @@ async fn not_shuttle() {
 async fn not_bin() {
     let (tx, _) = tokio::sync::mpsc::channel::<String>(256);
     let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/resources/not-bin");
-    build_workspace(Path::new(&project_path), false, tx)
+    build_workspace(Path::new(&project_path), false, None, None, tx)
         .await
         .unwrap();
 }
@@ -36,7 +36,7 @@ async fn not_full_macro() {
         env!("CARGO_MANIFEST_DIR"),
         "/tests/resources/not-full-macro"
     );
-    build_workspace(Path::new(&project_path), false, tx)
+    build_workspace(Path::new(&project_path), false, None, None, tx)
         .await
         .unwrap();
 }
@@ -47,7 +47,7 @@ async fn is_bin() {
     let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/resources/is-bin");
 
     assert_eq!(
-        build_workspace(Path::new(&project_path), false, tx)
+        build_workspace(Path::new(&project_path), false, None, None, tx)
             .await
             .unwrap(),
         BuiltService {
@@ -64,7 +64,7 @@ async fn is_bin2() {
     let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/resources/is-bin2");
 
     assert_eq!(
-        build_workspace(Path::new(&project_path), false, tx)
+        build_workspace(Path::new(&project_path), false, None, None, tx)
             .await
             .unwrap(),
         BuiltService {
@@ -83,7 +83,7 @@ async fn not_found() {
         "{}/tests/resources/non-existing",
         env!("CARGO_MANIFEST_DIR")
     );
-    build_workspace(Path::new(&project_path), false, tx)
+    build_workspace(Path::new(&project_path), false, None, None, tx)
         .await
         .unwrap();
 }
@@ -100,7 +100,7 @@ async fn workspace() {
     let project_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/resources/workspace");
 
     assert_eq!(
-        build_workspace(Path::new(&project_path), false, tx)
+        build_workspace(Path::new(&project_path), false, None, None, tx)
             .await
             .unwrap(),
         BuiltService {

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -46,6 +46,8 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                     port,
                     external,
                     release: false,
+                    profile: None,
+                    features: None,
                     raw: false,
                     bacon: false,
                     secret_args: Default::default(),


### PR DESCRIPTION
Introduces:

- `shuttle run --profile [profile]` which builds the runtime with a custom cargo profile, just like `cargo build --profile [profile]` does.
  - Supports any profile defined in `Cargo.toml` (e.g., `--profile production`, `--profile bench`)
  - Conflicts with `--release` flag to avoid confusion
  - Falls back to default debug/release behavior when not specified
- `shuttle run --features [features]` which enables specific cargo features during build.
  - Accepts space or comma-separated list of features (e.g., `--features "feature1 feature2"` or `--features feature1,feature2`)
  - Properly combines with the existing "shuttle" feature when present
  - Works exactly like `cargo build --features`

This allows users to have more control over the build process, matching the flexibility of standard cargo commands. Particularly useful for:
- Using custom optimization profiles for different environments
- Enabling optional features without modifying `Cargo.toml`
- Testing different feature combinations locally before deployment