### PR TITLE
feat(cargo-shuttle): maintain project id when deleting/creating project

### DIFF
--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -181,7 +181,7 @@ impl RequestContext {
         // TODO: assumes git is used
         create_or_update_ignore_file(
             &self
-                .project
+                .project_internal
                 .as_ref()
                 .unwrap()
                 .manager

--- a/cargo-shuttle/src/config.rs
+++ b/cargo-shuttle/src/config.rs
@@ -169,6 +169,11 @@ impl RequestContext {
             InternalProjectConfig { id: Some(id) };
     }
 
+    pub fn remove_project_id(&mut self) {
+        *self.project_internal.as_mut().unwrap().as_mut().unwrap() =
+            InternalProjectConfig { id: None };
+    }
+
     pub fn save_local_internal(&mut self) -> Result<()> {
         self.project_internal.as_ref().unwrap().save()?;
 

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -289,7 +289,7 @@ impl Shuttle {
                 } => self.delete_certificate(domain, yes).await,
             },
             Command::Project(cmd) => match cmd {
-                ProjectCommand::Create => self.project_create(args.project_args.name).await,
+                ProjectCommand::Create => self.project_create(&args.project_args).await,
                 ProjectCommand::Update(cmd) => match cmd {
                     ProjectUpdateCommand::Name { new_name } => self.project_rename(new_name).await,
                 },
@@ -1798,23 +1798,30 @@ impl Shuttle {
         Ok(())
     }
 
-    async fn project_create(&self, name: Option<String>) -> Result<()> {
-        let Some(ref name) = name else {
+    async fn project_create(&mut self, project_args: &ProjectArgs) -> Result<()> {
+        let Some(ref name) = project_args.name else {
             bail!("Provide a project name with '--name <name>'");
         };
+
+        self.ctx.load_local_internal_config(project_args)?;
 
         let client = self.client.as_ref().unwrap();
         let r = client.create_project(name).await?;
 
+        let raw_json = r.raw_json.clone();
+        let project = r.into_inner();
+
         match self.output_mode {
             OutputMode::Normal => {
-                let project = r.into_inner();
                 println!("Created project '{}' with id {}", project.name, project.id);
             }
             OutputMode::Json => {
-                println!("{}", r.raw_json);
+                println!("{}", raw_json);
             }
         }
+
+        self.ctx.set_project_id(project.id);
+        self.ctx.save_local_internal()?;
 
         Ok(())
     }

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1897,7 +1897,7 @@ impl Shuttle {
         Ok(())
     }
 
-    async fn project_delete(&self, no_confirm: bool) -> Result<()> {
+    async fn project_delete(&mut self, no_confirm: bool) -> Result<()> {
         let client = self.client.as_ref().unwrap();
         let pid = self.ctx.project_id();
 
@@ -1932,6 +1932,9 @@ impl Shuttle {
         }
 
         let res = client.delete_project(pid).await?.into_inner();
+
+        self.ctx.remove_project_id();
+        self.ctx.save_local_internal()?;
 
         println!("{res}");
 


### PR DESCRIPTION
Addresses Issue #2055 by updating `.shuttle/config.toml` as follows:

- Removes `id` when a project is deleted using `shuttle project delete`
- Inserts/updates `id` when a project is created using `shuttle project create --name ...`

This should prevent potential mismatches and provide a smoother user experience.