### PR TITLE
Update axum examples to version 0.8

### DIFF
--- a/cargo-shuttle/tests/resources/archiving/Cargo.toml
+++ b/cargo-shuttle/tests/resources/archiving/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 # This test crate is never compiled, so bumping these is not needed
-axum = "0.6.18"
-shuttle-axum = "0.25.0"
-shuttle-runtime = "0.25.0"
+axum = "0.8.1"
+shuttle-axum = "0.56.0"
+shuttle-runtime = "0.56.0"
 tokio = "1.28.2"


### PR DESCRIPTION
## Description of change
This PR updates all Axum examples in the `shuttle-examples` submodule and `cargo-shuttle` test resources to Axum 0.8.

Key changes include:
- Upgrading `axum` dependency to `0.8.1`.
- Removing the `axum-0-7` feature flag from `shuttle-axum`.
- Updating `axum-extra` to `0.9.4` and `axum-macros` to `0.4.2` for compatibility.
- Fixing Axum path parameter syntax from `:param` to `{param}` in relevant example files.

Closes #PLA-1003

## How has this been tested? (if applicable)
- Verified that all `Cargo.toml` files now specify `axum = "0.8.1"`.
- Confirmed that the `axum-0-7` feature flag is no longer present in `shuttle-axum` dependencies.
- Successfully compiled the `examples/axum/hello-world` example.
- Verified path parameter syntax updates in affected files.

---
Linear Issue: [PLA-1003](https://linear.app/shuttle/issue/PLA-1003/examples-ensure-all-examples-are-updated-to-axum-08)

<a href="https://cursor.com/background-agent?bcId=bc-bbc233b1-fd43-4721-ae80-9d720e342be9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbc233b1-fd43-4721-ae80-9d720e342be9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

