### PR TITLE
Implement custom health check and shutdown

### DIFF
--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -107,7 +107,7 @@ impl<R: Serialize + DeserializeOwned + Send> IntoResource<R> for R {
 /// An `Into<Service>` implementor is what is returned in the `shuttle_runtime::main` macro
 /// in order to run it on the Shuttle servers.
 #[async_trait]
-pub trait Service: Send {
+pub trait Service: Send + Sync {
     /// This function is run exactly once on startup of a deployment.
     ///
     /// The passed [`SocketAddr`] receives proxied HTTP traffic from your Shuttle subdomain (or custom domain).


### PR DESCRIPTION
## Description of change
This PR implements custom health check and graceful shutdown capabilities in the Shuttle runtime.

The `Service` trait has been expanded with `health_check(&self)` and `shutdown(&self)` methods, both providing default `Ok(())` implementations for backward compatibility. The runtime now wraps the service in an `Arc` to allow shared access. It calls `service.health_check()` when the health check endpoint is hit and `service.shutdown()` during graceful termination triggered by signals. Health check failures now return a 500 status code.

This change provides a foundation for application-specific health monitoring and cleanup, while maintaining backward compatibility for existing services.

Closes PLA-1002
Closes #2004

## How has this been tested? (if applicable)
To test this functionality:
1.  Implement a custom service with `health_check` and `shutdown` methods that can fail/succeed or log their execution.
2.  Deploy the service.
3.  Send requests to the health check endpoint and verify the custom logic is executed and appropriate HTTP status codes are returned.
4.  Send a SIGTERM signal to the runtime process and verify that the `shutdown` hook is called before the process exits.

---
Linear Issue: [PLA-1002](https://linear.app/shuttle/issue/PLA-1002/implement-custom-health-check-and-graceful-shutdown-in-runtime)

<a href="https://cursor.com/background-agent?bcId=bc-94280811-b33c-49e4-92c8-5598e603234b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94280811-b33c-49e4-92c8-5598e603234b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

