### PR TITLE
feat(cargo-shuttle): add `--quiet` flag for local runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5600,3 +5600,67 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "shuttle-actix-web"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-aws-rds"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-axum"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-openai"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-opendal"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-poem"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-qdrant"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-rocket"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-salvo"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-serenity"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-shared-db"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-thruster"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-tide"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-tower"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-turso"
+version = "0.56.0"
+
+[[patch.unused]]
+name = "shuttle-warp"
+version = "0.56.0"

--- a/cargo-shuttle/src/args.rs
+++ b/cargo-shuttle/src/args.rs
@@ -390,6 +390,9 @@ pub struct RunArgs {
     /// Uses bacon crate to run the project in watch mode
     #[arg(long)]
     pub bacon: bool,
+    /// Suppress non-error output
+    #[arg(long, short = 'q')]
+    pub quiet: bool,
 
     #[command(flatten)]
     pub secret_args: SecretsArgs,

--- a/cargo-shuttle/src/lib.rs
+++ b/cargo-shuttle/src/lib.rs
@@ -1334,11 +1334,13 @@ impl Shuttle {
 
         let project_directory = self.ctx.project_directory();
 
-        println!(
-            "{} {}",
-            "    Building".bold().green(),
-            project_directory.display()
-        );
+        if !run_args.quiet {
+            println!(
+                "{} {}",
+                "    Building".bold().green(),
+                project_directory.display()
+            );
+        }
 
         build_workspace(project_directory, run_args.release, tx).await
     }
@@ -1403,13 +1405,15 @@ impl Shuttle {
         });
         tokio::spawn(async move { ProvisionerServer::run(state, &api_addr).await });
 
-        println!(
-            "\n    {} {} on http://{}:{}\n",
-            "Starting".bold().green(),
-            service.target_name,
-            ip,
-            run_args.port,
-        );
+        if !run_args.quiet {
+            println!(
+                "\n    {} {} on http://{}:{}\n",
+                "Starting".bold().green(),
+                service.target_name,
+                ip,
+                run_args.port,
+            );
+        }
 
         let mut envs = vec![
             ("SHUTTLE_BETA", "true".to_owned()),
@@ -1424,6 +1428,8 @@ impl Shuttle {
         // Use a nice debugging tracing level if user does not provide their own
         if debug && std::env::var("RUST_LOG").is_err() {
             envs.push(("RUST_LOG", "info,shuttle=trace,reqwest=debug".to_owned()));
+        } else if run_args.quiet && std::env::var("RUST_LOG").is_err() {
+            envs.push(("RUST_LOG", "info,shuttle=error".to_owned()));
         }
 
         info!(

--- a/cargo-shuttle/tests/integration/run.rs
+++ b/cargo-shuttle/tests/integration/run.rs
@@ -48,6 +48,7 @@ async fn shuttle_run(working_directory: &str, external: bool) -> String {
                     release: false,
                     raw: false,
                     bacon: false,
+                    quiet: false,
                     secret_args: Default::default(),
                 }),
             },


### PR DESCRIPTION
## Description
Add `-q/--quiet` flag to `cargo shuttle run` to suppress non-error output.

Closes #1602

## How has this been tested?
- Verified flag appears in help output
- Passed clippy and fmt checks