### PR TITLE
fix(runtime): drop service before sys exit

### DIFF
--- a/runtime/src/start.rs
+++ b/runtime/src/start.rs
@@ -72,5 +72,9 @@ pub async fn start(
         guard
     };
 
-    rt::start(loader, runner).await
+    let exit_code = rt::start(loader, runner).await;
+
+    // TODO: drop/shutdown logger guards
+
+    std::process::exit(exit_code)
 }


### PR DESCRIPTION
Allows services and other internals to `Drop` before the runtime calls `exit()`