### PR TITLE
feat(cargo-shuttle): speed up metadata call

### DIFF
--- a/cargo-shuttle/src/util/mod.rs
+++ b/cargo-shuttle/src/util/mod.rs
@@ -290,7 +290,21 @@ where
     Ok(None)
 }
 
-/// Print a verb + line similar to how cargo does
+/// Print a green verb + rest of line similar to how cargo does
 pub fn cargo_green_eprintln(verb: impl Display, line: impl Display) {
     eprintln!("{} {}", format!("{verb:>12}").bold().green(), line);
+}
+
+/// Calls cargo metadata with --no-deps to prevent from blocking for a download if crates cache is missing
+pub fn cargo_metadata(path: &Path) -> anyhow::Result<cargo_metadata::Metadata> {
+    let meta = cargo_metadata::MetadataCommand::new()
+        .current_dir(path)
+        .no_deps()
+        .exec()
+        .context(format!(
+            "Failed to find a Rust project in {}. Try again in a cargo workspace, or provide a --name or --id argument.",
+            path.display()
+        ))?;
+
+    Ok(meta)
 }


### PR DESCRIPTION
Unify all `cargo metadata` calls with `--no-deps`, which prevents fetching crates from index, which speeds up all project-related commands significantly.
